### PR TITLE
feat(tracer): add new field instrumentation

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -49,7 +49,6 @@ def test_agent():
     assert agent.long_term_memory.backend == "local"
     assert load_memory in agent.tools
 
-    assert tracer.llm_metrics_hook in agent.before_model_callback
-    assert tracer.token_metrics_hook in agent.after_model_callback
-    assert tracer.token_metrics_hook in agent.after_model_callback
-    assert tracer.token_metrics_hook in agent.after_model_callback
+    assert tracer.tracer_hook_before_model in agent.before_model_callback
+    assert tracer.tracer_hook_after_model in agent.after_model_callback
+    assert tracer.tracer_hook_after_tool in agent.after_tool_callback

--- a/veadk/agent.py
+++ b/veadk/agent.py
@@ -118,9 +118,11 @@ class Agent(LlmAgent):
         if self.tracers:
             self.before_model_callback = []
             self.after_model_callback = []
+            self.after_tool_callback = []
             for tracer in self.tracers:
-                self.before_model_callback.append(tracer.llm_metrics_hook)
-                self.after_model_callback.append(tracer.token_metrics_hook)
+                self.before_model_callback.append(tracer.tracer_hook_before_model)
+                self.after_model_callback.append(tracer.tracer_hook_after_model)
+                self.after_tool_callback.append(tracer.tracer_hook_after_tool)
 
         logger.info(f"Agent `{self.name}` init done.")
         logger.debug(
@@ -221,6 +223,9 @@ class Agent(LlmAgent):
             session_service=session_service,
             memory_service=self.long_term_memory,
         )
+        if getattr(self, "tracers", None):
+            for tracer in self.tracers:
+                tracer.set_app_name(app_name)
 
         logger.info(f"Begin to process prompt {prompt}")
         # run

--- a/veadk/cli/services/vefaas/template/src/app.py
+++ b/veadk/cli/services/vefaas/template/src/app.py
@@ -49,11 +49,15 @@ if not getattr(agent, "before_model_callback", None):
     agent.before_model_callback = []
 if not getattr(agent, "after_model_callback", None):
     agent.after_model_callback = []
+if not getattr(agent, "after_tool_callback", None):
+    agent.after_tool_callback = []
 for tracer in TRACERS:
-    if tracer.llm_metrics_hook not in agent.before_model_callback:
-        agent.before_model_callback.append(tracer.llm_metrics_hook)
-    if tracer.token_metrics_hook not in agent.after_model_callback:
-        agent.after_model_callback.append(tracer.token_metrics_hook)
+    if tracer.tracer_hook_before_model not in agent.before_model_callback:
+        agent.before_model_callback.append(tracer.tracer_hook_before_model)
+    if tracer.tracer_hook_after_model not in agent.after_model_callback:
+        agent.after_model_callback.append(tracer.tracer_hook_after_model)
+    if tracer.tracer_hook_after_tool not in agent.after_tool_callback:
+        agent.after_tool_callback.append(tracer.tracer_hook_after_tool)
 
 # Tracer Config ================================================================
 # ==============================================================================

--- a/veadk/runner.py
+++ b/veadk/runner.py
@@ -70,6 +70,10 @@ class Runner:
             memory_service=self.long_term_memory,
         )
 
+        if getattr(self.agent, "tracers", None):
+            for tracers in self.agent.tracers:
+                tracers.set_app_name(self.app_name)
+
     def _convert_messages(self, messages) -> list:
         if isinstance(messages, str):
             messages = [types.Content(role="user", parts=[types.Part(text=messages)])]

--- a/veadk/tracing/telemetry/opentelemetry_tracer.py
+++ b/veadk/tracing/telemetry/opentelemetry_tracer.py
@@ -51,6 +51,11 @@ class OpentelemetryTracer(BaseModel, BaseTracer):
         DEFAULT_VEADK_TRACER_NAME, description="The identifier of tracer."
     )
 
+    app_name: str = Field(
+        "veadk_app",
+        description="The identifier of app.",
+    )
+
     def model_post_init(self, context: Any, /) -> None:
         self._processors = []
         self._inmemory_exporter: InMemoryExporter = None


### PR DESCRIPTION
### Add fields to the tracer attrabute

- app.name: Add the `app.name` field in the agent_run, call_llm, and execute_tool stages respectively.
- agent.name: Add the `agent.name` field in the agent_run, call_llm, and execute_tool stages respectively.
- tool.name: Add the `tool.name` field in the execute_tool stage.

### Special Instructions

- Since `app.name` is a field at the runner level, in `runner.py`, the injection of `app_name` is achieved by adding the following code:
```python
        if getattr(self.agent, "tracers", None):
            for tracers in self.agent.tracers:
                tracers.set_app_name(self.app_name)
```

- Add `after_tool_callback` to implement field tracing of `agent.name` and `app.name` during the tool call stage