### PR TITLE
fix: add required option to vefaas deploy cli

### DIFF
--- a/veadk/cli/cli_deploy.py
+++ b/veadk/cli/cli_deploy.py
@@ -29,7 +29,9 @@ TEMP_PATH = "/tmp"
     default=None,
     help="Volcengine secret key",
 )
-@click.option("--vefaas-app-name", help="Expected Volcengine FaaS application name")
+@click.option(
+    "--vefaas-app-name", required=True, help="Expected Volcengine FaaS application name"
+)
 @click.option(
     "--veapig-instance-name", default="", help="Expected Volcengine APIG instance name"
 )


### PR DESCRIPTION
When user not specify `--vefaas-app-name`, a `None` value is incorrect. Use must give vefaas app name.