### PR TITLE
fix: adapt to the Windows platform

### DIFF
--- a/veadk/evaluation/base_evaluator.py
+++ b/veadk/evaluation/base_evaluator.py
@@ -199,7 +199,7 @@ class BaseEvaluator:
         eval_case_data_list: list[EvalTestCase] = []
 
         try:
-            with open(file_path, "r") as f:
+            with open(file_path, "r", encoding="utf-8") as f:
                 file_content = json.load(f)
         except json.JSONDecodeError as e:
             raise ValueError(f"Invalid JSON format in file {file_path}: {e}")

--- a/veadk/evaluation/eval_set_recorder.py
+++ b/veadk/evaluation/eval_set_recorder.py
@@ -21,7 +21,7 @@ from google.adk.evaluation.local_eval_sets_manager import LocalEvalSetsManager
 from google.adk.sessions import BaseSessionService
 
 from veadk.utils.logger import get_logger
-from veadk.utils.misc import formatted_timestamp
+from veadk.utils.misc import formatted_timestamp, get_temp_dir
 
 logger = get_logger(__name__)
 
@@ -30,7 +30,7 @@ class EvalSetRecorder(LocalEvalSetsManager):
     def __init__(
         self, session_service: BaseSessionService, eval_set_id: str = "default"
     ):
-        super().__init__(agents_dir="/tmp/")
+        super().__init__(agents_dir=get_temp_dir())
         self.eval_set_id = eval_set_id if eval_set_id != "" else "default"
         self.session_service: BaseSessionService = session_service
 

--- a/veadk/tracing/telemetry/opentelemetry_tracer.py
+++ b/veadk/tracing/telemetry/opentelemetry_tracer.py
@@ -36,6 +36,7 @@ from veadk.tracing.telemetry.exporters.inmemory_exporter import (
 )
 from veadk.utils.logger import get_logger
 from veadk.utils.patches import patch_google_adk_telemetry
+from veadk.utils.misc import get_temp_dir
 
 logger = get_logger(__name__)
 
@@ -159,7 +160,7 @@ class OpentelemetryTracer(BaseModel, BaseTracer):
         self,
         user_id: str = "unknown_user_id",
         session_id: str = "unknown_session_id",
-        path: str = "/tmp",
+        path: str = get_temp_dir(),
     ) -> str:
         def _build_trace_file_path(path: str, user_id: str, session_id: str) -> str:
             return f"{path}/{self.name}_{user_id}_{session_id}_{self.trace_id}.json"

--- a/veadk/utils/misc.py
+++ b/veadk/utils/misc.py
@@ -148,3 +148,18 @@ def set_envs(config_yaml_path: str) -> tuple[dict, dict]:
         os.environ[k] = str(v)
 
     return config_dict, veadk_environments
+
+
+def get_temp_dir():
+    """
+    Return the corresponding temporary directory based on the operating system
+    - For Windows systems, return the system's default temporary directory
+    - For other systems (macOS, Linux, etc.), return the /tmp directory
+    """
+    # First determine if it is a Windows system
+    if sys.platform.startswith("win"):
+        # Windows systems use the temporary directory from environment variables
+        return os.environ.get("TEMP", os.environ.get("TMP", "/tmp"))
+    else:
+        # Non-Windows systems (macOS, Linux, etc.) uniformly return /tmp
+        return "/tmp"

--- a/veadk/utils/misc.py
+++ b/veadk/utils/misc.py
@@ -159,7 +159,7 @@ def get_temp_dir():
     # First determine if it is a Windows system
     if sys.platform.startswith("win"):
         # Windows systems use the temporary directory from environment variables
-        return os.environ.get("TEMP", os.environ.get("TMP", "C:\WINDOWS\TEMP"))
+        return os.environ.get("TEMP", os.environ.get("TMP", r"C:\WINDOWS\TEMP"))
     else:
         # Non-Windows systems (macOS, Linux, etc.) uniformly return /tmp
         return "/tmp"

--- a/veadk/utils/misc.py
+++ b/veadk/utils/misc.py
@@ -159,7 +159,7 @@ def get_temp_dir():
     # First determine if it is a Windows system
     if sys.platform.startswith("win"):
         # Windows systems use the temporary directory from environment variables
-        return os.environ.get("TEMP", os.environ.get("TMP", "/tmp"))
+        return os.environ.get("TEMP", os.environ.get("TMP", "C:\WINDOWS\TEMP"))
     else:
         # Non-Windows systems (macOS, Linux, etc.) uniformly return /tmp
         return "/tmp"


### PR DESCRIPTION
In some parts of `Tracing` and `Evaluation` where temporary directories need to be obtained, `/tmp` was used directly. However, this would cause errors on the Windows platform, so adaptation modifications have been made in this regard.