### PR TITLE
fix(web_search): improve credential retrieval logic in web_search fun…

### DIFF
--- a/veadk/tools/builtin_tools/web_search.py
+++ b/veadk/tools/builtin_tools/web_search.py
@@ -168,13 +168,13 @@ def web_search(query: str, tool_context: ToolContext) -> list[str]:
         "NeedSummary": True,
     }
 
-    ak = tool_context.state.get(
-        "VOLCENGINE_ACCESS_KEY", getenv("VOLCENGINE_ACCESS_KEY")
-    )
+    ak = tool_context.state.get("VOLCENGINE_ACCESS_KEY")
+    if not ak:
+        ak = getenv("VOLCENGINE_ACCESS_KEY")
 
-    sk = tool_context.state.get(
-        "VOLCENGINE_SECRET_KEY", getenv("VOLCENGINE_SECRET_KEY")
-    )
+    sk = tool_context.state.get("VOLCENGINE_SECRET_KEY")
+    if not sk:
+        sk = getenv("VOLCENGINE_SECRET_KEY")
 
     now = datetime.datetime.utcnow()
     response_body = request(


### PR DESCRIPTION
This pull request refactors how API credentials are retrieved in the `web_search` tool. The main improvement is to ensure that the code first checks for credentials in the `tool_context.state`, and only falls back to environment variables if they are not set in the state. This makes credential handling more robust and predictable.

Credential retrieval logic update:

* Updated `web_search` in `veadk/tools/builtin_tools/web_search.py` to first check for `VOLCENGINE_ACCESS_KEY` and `VOLCENGINE_SECRET_KEY` in `tool_context.state`, and only use environment variables as a fallback.…ction