### PR TITLE
Update processor argument and auth header format

### DIFF
--- a/docs/content/91.auth/4.oauth2-user-federation-outbound.md
+++ b/docs/content/91.auth/4.oauth2-user-federation-outbound.md
@@ -146,7 +146,7 @@ cloud_assistant_tools = VeIdentityMcpToolset(
 agent = Agent(
     tools=[ecs_tools, cloud_assistant_tools],
     system_prompt="你是火山引擎ECS助手，可以查询ECS实例信息并执行服务器命令。",
-    auth_request_processor=AuthRequestProcessor(),
+    run_processor=AuthRequestProcessor(),
 )
 
 asyncio.run(

--- a/veadk/integrations/ve_identity/utils.py
+++ b/veadk/integrations/ve_identity/utils.py
@@ -144,7 +144,7 @@ def generate_headers(credential: AuthCredential) -> Optional[dict[str, str]]:
                     )
                 }
         elif credential.api_key:
-            headers = {"Authorization": f"Bearer {credential.api_key}"}
+            headers = {"Authorization": credential.api_key}
         elif credential.service_account:
             pass
 


### PR DESCRIPTION
Replaces 'auth_request_processor' with 'run_processor' in agent initialization for consistency. Removes 'Bearer' prefix from Authorization header when using API key in generate_headers.