### PR TITLE
feat: add db_kwargs for sql connection config

### DIFF
--- a/veadk/memory/short_term_memory.py
+++ b/veadk/memory/short_term_memory.py
@@ -126,6 +126,8 @@ class ShortTermMemory(BaseModel):
 
     backend_configs: dict = Field(default_factory=dict)
 
+    db_kwargs: dict = Field(default_factory=dict)
+
     db_url: str = ""
 
     local_database_path: str = "/tmp/veadk_local_database.db"
@@ -143,7 +145,9 @@ class ShortTermMemory(BaseModel):
                     "Please encode `username` or `password` with `urllib.parse.quote_plus`. "
                     "Examples: p@ssword→p%40ssword."
                 )
-            self._session_service = DatabaseSessionService(db_url=self.db_url)
+            self._session_service = DatabaseSessionService(
+                db_url=self.db_url, **self.db_kwargs
+            )
         else:
             if self.backend == "database":
                 logger.warning(
@@ -155,7 +159,7 @@ class ShortTermMemory(BaseModel):
                     self._session_service = InMemorySessionService()
                 case "mysql":
                     self._session_service = MysqlSTMBackend(
-                        **self.backend_configs
+                        db_kwargs=self.db_kwargs, **self.backend_configs
                     ).session_service
                 case "sqlite":
                     self._session_service = SQLiteSTMBackend(
@@ -163,7 +167,7 @@ class ShortTermMemory(BaseModel):
                     ).session_service
                 case "postgresql":
                     self._session_service = PostgreSqlSTMBackend(
-                        **self.backend_configs
+                        db_kwargs=self.db_kwargs, **self.backend_configs
                     ).session_service
 
         if self.after_load_memory_callback:

--- a/veadk/memory/short_term_memory_backends/mysql_backend.py
+++ b/veadk/memory/short_term_memory_backends/mysql_backend.py
@@ -34,6 +34,7 @@ from veadk.memory.short_term_memory_backends.base_backend import (
 
 class MysqlSTMBackend(BaseShortTermMemoryBackend):
     mysql_config: MysqlConfig = Field(default_factory=MysqlConfig)
+    db_kwargs: dict = Field(default_factory=dict)
 
     def model_post_init(self, context: Any) -> None:
         encoded_username = quote_plus(self.mysql_config.user)
@@ -46,4 +47,4 @@ class MysqlSTMBackend(BaseShortTermMemoryBackend):
     @cached_property
     @override
     def session_service(self) -> BaseSessionService:
-        return DatabaseSessionService(db_url=self._db_url)
+        return DatabaseSessionService(db_url=self._db_url, **self.db_kwargs)

--- a/veadk/memory/short_term_memory_backends/postgresql_backend.py
+++ b/veadk/memory/short_term_memory_backends/postgresql_backend.py
@@ -34,6 +34,7 @@ from veadk.memory.short_term_memory_backends.base_backend import (
 
 class PostgreSqlSTMBackend(BaseShortTermMemoryBackend):
     postgresql_config: PostgreSqlConfig = Field(default_factory=PostgreSqlConfig)
+    db_kwargs: dict = Field(default_factory=dict)
 
     def model_post_init(self, context: Any) -> None:
         encoded_username = quote_plus(self.postgresql_config.user)
@@ -46,4 +47,4 @@ class PostgreSqlSTMBackend(BaseShortTermMemoryBackend):
     @cached_property
     @override
     def session_service(self) -> BaseSessionService:
-        return DatabaseSessionService(db_url=self._db_url)
+        return DatabaseSessionService(db_url=self._db_url, **self.db_kwargs)


### PR DESCRIPTION
The DataBaseSessionService of adk-python supports adding connection pool configurations when connecting to a MySQL database. For example:

```python
from google.adk.sessions import DatabaseSessionService  

session_service = DatabaseSessionService(  
    db_url="mysql+aiomysql://user:pass@host/db",  
    pool_recycle=3600,      # Recycle connections after 1 hour (to prevent timeouts)  
    pool_pre_ping=True,     # Check connection validity before use  
    pool_size=10,           # Connection pool size  
    max_overflow=20         # Maximum number of additional connections  
)
```

Previously, veadk did not support customizing these fields. This PR implements support for parameters such as connection pool configurations.

Users can pass relevant parameters through the `db_kwargs` field:

```python
short_term_memory = ShortTermMemory(
        backend="mysql", 
        db_kwargs={
            "pool_size": 10,
            "max_overflow": 20,
            "echo": True,
            "pool_recycle": 3600,
            "pool_pre_ping": True,
        }
    )
```