### PR TITLE
Add retry_on_errors decorator for MCP session retries

### DIFF
--- a/veadk/integrations/ve_identity/mcp_tool.py
+++ b/veadk/integrations/ve_identity/mcp_tool.py
@@ -24,14 +24,13 @@ from google.adk.tools.base_tool import BaseTool
 from google.adk.tools.tool_context import ToolContext
 from google.adk.tools._gemini_schema_util import _to_gemini_schema
 from google.adk.tools.mcp_tool.mcp_session_manager import MCPSessionManager
-from google.adk.tools.mcp_tool.mcp_session_manager import retry_on_closed_resource
 
 from veadk.integrations.ve_identity.auth_config import VeIdentityAuthConfig
 from veadk.integrations.ve_identity.auth_mixins import (
     VeIdentityAuthMixin,
     AuthRequiredException,
 )
-from veadk.integrations.ve_identity.utils import generate_headers
+from veadk.integrations.ve_identity.utils import generate_headers, retry_on_errors
 from veadk.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -157,7 +156,7 @@ class VeIdentityMcpTool(VeIdentityAuthMixin, BaseTool):
             args=args, tool_context=tool_context, credential=credential
         )
 
-    @retry_on_closed_resource
+    @retry_on_errors
     async def _run_async_impl(
         self, *, args, tool_context: ToolContext, credential: AuthCredential
     ):

--- a/veadk/integrations/ve_identity/mcp_toolset.py
+++ b/veadk/integrations/ve_identity/mcp_toolset.py
@@ -29,7 +29,6 @@ from mcp import StdioServerParameters, ClientSession
 from mcp.types import ListToolsResult
 
 from google.adk.tools.mcp_tool.mcp_session_manager import (
-    retry_on_closed_resource,
     SseConnectionParams,
     StdioConnectionParams,
     StreamableHTTPConnectionParams,
@@ -43,7 +42,7 @@ from google.adk.agents.readonly_context import ReadonlyContext
 from veadk.integrations.ve_identity.auth_config import VeIdentityAuthConfig
 from veadk.integrations.ve_identity.auth_mixins import VeIdentityAuthMixin
 from veadk.integrations.ve_identity.mcp_tool import VeIdentityMcpTool
-from veadk.integrations.ve_identity.utils import generate_headers
+from veadk.integrations.ve_identity.utils import generate_headers, retry_on_errors
 
 logger = logging.getLogger(__name__)
 
@@ -158,7 +157,7 @@ class VeIdentityMcpToolset(VeIdentityAuthMixin, BaseToolset):
             errlog=errlog,
         )
 
-    @retry_on_closed_resource
+    @retry_on_errors
     @override
     async def get_tools(
         self,


### PR DESCRIPTION
Introduced a new retry_on_errors decorator in utils.py to handle automatic retries on MCP session errors. Updated mcp_tool.py and mcp_toolset.py to use this decorator instead of retry_on_closed_resource, improving error handling and session recovery.