### PR TITLE
fix(vikingdb): add host configuration for non-byteplus cloud providers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "veadk-python"
-version = "0.5.19"
+version = "0.5.20"
 description = "Volcengine agent development kit, integrations with Volcengine cloud services."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/veadk/memory/long_term_memory_backends/vikingdb_memory_backend.py
+++ b/veadk/memory/long_term_memory_backends/vikingdb_memory_backend.py
@@ -152,7 +152,8 @@ class VikingDBLTMBackend(BaseLongTermMemoryBackend):
         ak, sk, sts_token = self._get_ak_sk_sts()
         if self.cloud_provider.lower() == "byteplus":
             host = f"api-knowledgebase.mlp.{self.region}.bytepluses.com"
-
+        else:
+            host = f"api-knowledgebase.mlp.{self.region}.volces.com"
         logger.info(f"Cloud provider: {self.cloud_provider.lower()}")
         logger.info(f"VikingDBLTMBackend: region={self.region}, host={host}")
 
@@ -168,7 +169,8 @@ class VikingDBLTMBackend(BaseLongTermMemoryBackend):
         ak, sk, sts_token = self._get_ak_sk_sts()
         if self.cloud_provider.lower() == "byteplus":
             host = f"api-knowledgebase.mlp.{self.region}.bytepluses.com"
-
+        else:
+            host = f"api-knowledgebase.mlp.{self.region}.volces.com"
         logger.info(f"Cloud provider: {self.cloud_provider.lower()}")
         logger.info(f"VikingDBLTMBackend: region={self.region}, host={host}")
 

--- a/veadk/version.py
+++ b/veadk/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "0.5.19"
+VERSION = "0.5.20"


### PR DESCRIPTION
Add default host configuration for non-byteplus cloud providers in VikingDBLTMBackend. This ensures the backend works correctly with other cloud providers like Volcengine.