### PR TITLE
fix: Avoid modifying original config in AgentBuilder._build()

### DIFF
--- a/veadk/agent_builder.py
+++ b/veadk/agent_builder.py
@@ -47,7 +47,6 @@ class AgentBuilder:
             for sub_agent_config in agent_config["sub_agents"]:
                 agent = self._build(sub_agent_config)
                 sub_agents.append(agent)
-            agent_config.pop("sub_agents")
 
         tools = []
         if agent_config.get("tools", []):
@@ -58,10 +57,16 @@ class AgentBuilder:
                 func = getattr(module, func_name)
 
                 tools.append(func)
-            agent_config.pop("tools")
+
+        # Filter out special fields that will be passed explicitly
+        # to avoid modifying the original config and parameter conflicts
+        config_for_init = {
+            k: v for k, v in agent_config.items()
+            if k not in ["sub_agents", "tools"]
+        }
 
         agent_cls = AGENT_TYPES[agent_config["type"]]
-        agent = agent_cls(**agent_config, sub_agents=sub_agents, tools=tools)
+        agent = agent_cls(**config_for_init, sub_agents=sub_agents, tools=tools)
 
         logger.debug("Build agent done.")
 


### PR DESCRIPTION
## Related issue
Fixes #508

## Problem
Currently, the `AgentBuilder._build()` method uses `pop()` operations which modify the original config dict, potentially causing:

1. **Side effects**: If the caller retains a reference to the config, they'll find it unexpectedly modified
2. **Reusability issues**: The same config object cannot be used multiple times
3. **Unclear intent**: The purpose of `pop()` is not clear enough

Use dictionary comprehension to create a new dict, filtering out fields that need to be passed explicitly:

```python
# Filter out special fields that will be passed explicitly
# to avoid modifying the original config and parameter conflicts
config_for_init = {
    k: v for k, v in agent_config.items()
    if k not in ["sub_agents", "tools"]
}

agent = agent_cls(**config_for_init, sub_agents=sub_agents, tools=tools)
```
## Changes:

Remove agent_config.pop("sub_agents")
Remove agent_config.pop("tools")
Add dictionary filtering to create config_for_init
Add comments explaining the change

## Benefits
No side effects: doesn't modify original config
Reusable: config can be used multiple times
Clear intent: code purpose is explicit
Best practice: follows immutability principle