### PR TITLE
fix(tracing): handle null function_response_event in tool telemetry

### DIFF
--- a/veadk/tracing/telemetry/attributes/extractors/tool_attributes_extractors.py
+++ b/veadk/tracing/telemetry/attributes/extractors/tool_attributes_extractors.py
@@ -126,6 +126,8 @@ def tool_gen_ai_tool_output(params: ToolAttributesParams) -> ExtractorResponse:
     Returns:
         ExtractorResponse: Response containing JSON serialized tool output data
     """
+    if params.function_response_event is None:
+        return ExtractorResponse(content="<unknown_tool_output>")
     function_response = params.function_response_event.get_function_responses()[
         0
     ].model_dump()

--- a/veadk/tracing/telemetry/attributes/extractors/types.py
+++ b/veadk/tracing/telemetry/attributes/extractors/types.py
@@ -156,9 +156,10 @@ class ToolAttributesParams:
         args: Dictionary of arguments that were passed to the tool function
             during execution, including parameter names and values
         function_response_event: Event object containing the tool's execution
-            results, return values, timing information, and any error details
+            results, return values, timing information, and any error details.
+            May be None if tool execution raised an exception.
     """
 
     tool: BaseTool
     args: dict[str, Any]
-    function_response_event: Event
+    function_response_event: Event | None

--- a/veadk/tracing/telemetry/telemetry.py
+++ b/veadk/tracing/telemetry/telemetry.py
@@ -71,7 +71,7 @@ def _upload_call_llm_metrics(
 def _upload_tool_call_metrics(
     tool: BaseTool,
     args: dict[str, Any],
-    function_response_event: Event,
+    function_response_event: Event | None,
 ):
     """Upload tool call metrics to the global meter uploader.
 
@@ -304,7 +304,7 @@ def set_common_attributes_on_tool_span(current_span: _Span) -> None:
 def trace_tool_call(
     tool: BaseTool,
     args: dict[str, Any],
-    function_response_event: Event,
+    function_response_event: Event | None,
     **kwargs,
 ) -> None:
     """Trace a tool function call with comprehensive telemetry data.


### PR DESCRIPTION
Fixes: #535 

Add null check for function_response_event in tool attributes extraction. Update type hints and documentation to reflect that function_response_event can be None when tool execution raises an exception.