### PR TITLE
Remove the trailing '/' to avoid the 404 in docs example

### DIFF
--- a/docs/docs/agent/agent-to-agent.md
+++ b/docs/docs/agent/agent-to-agent.md
@@ -108,7 +108,7 @@ async def main(prompt: str) -> str:
     """
     weather_agent = RemoteVeAgent(
         name="weather_agent",
-        url="http://localhost:8000/",  # <--- url of A2A server
+        url="http://localhost:8000",  # <--- url of A2A server
     )
     print(f"Remote agent name is {weather_agent.name}.")
     print(f"Remote agent description is {weather_agent.description}.")


### PR DESCRIPTION
`GET /.well-known/agent-card.json` returns 200 OK, while `GET //.well-known/agent-card.json` returns 404.

When `RemoteVeAgent` is constructed with the `url` parameter, the trailing `/` is not removed. However, when it is constructed with the `httpx_client` parameter, the trailing `/` is stripped.

These behaviors are inconsistent and should probably be aligned.