### PR TITLE
feat: support initial state when creating session in short term memory

### DIFF
--- a/veadk/memory/short_term_memory.py
+++ b/veadk/memory/short_term_memory.py
@@ -152,7 +152,10 @@ class ShortTermMemory(BaseModel):
             app_name (str): The name of the application associated with the session.
             user_id (str): The unique identifier of the user.
             session_id (str): The unique identifier of the session to be created or retrieved.
-            state (dict | None): The initial state of the session.
+            state (dict | None):
+                The initial state of the session.
+                If a session with the given `session_id` already exists,
+                this argument is ignored and the existing session state is preserved.
 
         Returns:
             Session | None: The retrieved or newly created `Session` object, or `None` if the session creation failed.

--- a/veadk/memory/short_term_memory.py
+++ b/veadk/memory/short_term_memory.py
@@ -138,6 +138,7 @@ class ShortTermMemory(BaseModel):
         app_name: str,
         user_id: str,
         session_id: str,
+        state: dict | None = None,
     ) -> Session | None:
         """Create or retrieve a user session.
 
@@ -151,6 +152,7 @@ class ShortTermMemory(BaseModel):
             app_name (str): The name of the application associated with the session.
             user_id (str): The unique identifier of the user.
             session_id (str): The unique identifier of the session to be created or retrieved.
+            state (dict | None): The initial state of the session.
 
         Returns:
             Session | None: The retrieved or newly created `Session` object, or `None` if the session creation failed.
@@ -175,7 +177,7 @@ class ShortTermMemory(BaseModel):
             return session
         else:
             return await self._session_service.create_session(
-                app_name=app_name, user_id=user_id, session_id=session_id
+                app_name=app_name, user_id=user_id, session_id=session_id, state=state
             )
 
     async def generate_profile(


### PR DESCRIPTION
`ShortTermMemory` 的 `create_session` 接口支持传入可选的 `state` 参数，直接透传给底层的 `session_service`。

该参数可以用于在创建会话时，就注入会话状态。例如，在创建会话之前，创建一个沙箱，并将其元数据绑定到会话状态中。