### PR TITLE
feat: forward model config env vars to sandbox in  execute_skillsvars to sandbox in execute_skills

### DIFF
--- a/veadk/tools/builtin_tools/execute_skills.py
+++ b/veadk/tools/builtin_tools/execute_skills.py
@@ -173,6 +173,17 @@ def execute_skills(
         "PYTHONPATH": "$SRV_PYTHONPATH:$PYTHONPATH",
     }
 
+	# 注入模型配置，让沙箱使用与本地 Agent 相同的模型。
+    for model_key in [
+       "MODEL_AGENT_NAME",
+       "MODEL_AGENT_PROVIDER",
+       "MODEL_AGENT_API_BASE",
+       "MODEL_AGENT_API_KEY",
+    ]:
+        model_val = os.getenv(model_key, "")
+        if model_val:
+            env_vars[model_key] = model_val
+
     code = f"""
 import subprocess
 import os


### PR DESCRIPTION
# PR: feat: forward model config env vars to sandbox in execute_skills

## Problem

When `execute_skills` invokes the remote AIO sandbox, it only passes these environment variables:

```python
env_vars = {
    "TOS_SKILLS_DIR": ...,
    "SKILL_SPACE_ID": ...,
    "TOOL_USER_SESSION_ID": ...,
    "PYTHONPATH": ...,
}
```

The sandbox then falls back to the **default model baked into its Docker image** (e.g., `doubao-seed-2-0-lite`), completely ignoring any model configuration set in the local `.env` or `agentkit.yaml`.

This means users who configure a custom model (e.g., OpenAI, Anthropic, or a third-party proxy) via `MODEL_AGENT_NAME` / `MODEL_AGENT_PROVIDER` / `MODEL_AGENT_API_BASE` / `MODEL_AGENT_API_KEY` **cannot use that model inside the sandbox**.

### Scenario

User configures `.env`:
```
MODEL_AGENT_NAME=gpt-4o-mini
MODEL_AGENT_PROVIDER=openai
MODEL_AGENT_API_BASE=https://proxy.example.com/v1
MODEL_AGENT_API_KEY=sk-xxxxx
```

Local Agent works fine with gpt-4o-mini. But when `execute_skills` invokes the sandbox, the sandbox's internal agent still uses `doubao-seed-2-0-lite` because these env vars are not forwarded.

## Solution

Forward model-related environment variables to the sandbox via `env_vars`, so the sandbox's internal agent respects the same model configuration as the local agent.

The sandbox's `VeADKConfig` (in `config.py`) already reads these env vars at startup — we just need to pass them through.

## Changes

In `veadk/tools/builtin_tools/execute_skills.py`, after the `env_vars` dict construction, inject model configuration:

```python
# 注入模型配置，让沙箱使用与本地 Agent 相同的模型。
# VeADK 的 VeADKConfig 在沙箱启动时会读取这些环境变量。
for model_key in [
    "MODEL_AGENT_NAME",
    "MODEL_AGENT_PROVIDER",
    "MODEL_AGENT_API_BASE",
    "MODEL_AGENT_API_KEY",
]:
    model_val = os.getenv(model_key, "")
    if model_val:
        env_vars[model_key] = model_val
```

## Backward Compatibility

- If the env vars are not set locally, nothing changes (empty strings are skipped).
- The sandbox's default model config still applies as a fallback.
- The `if key not in env` check in the sandbox wrapper code ensures existing env vars in the sandbox image are not overwritten.
