### PR TITLE
docs(examples): add graded VeADK usage examples + deployable basic-app

### DIFF
--- a/examples/01_quickstart/.env.example
+++ b/examples/01_quickstart/.env.example
@@ -1,0 +1,9 @@
+# Copy this file to `.env` (in this directory) and fill in your key.
+# VeADK automatically loads `.env` from the current working directory.
+
+# --- Agent reasoning model (Volcengine Ark) ---
+# Get an API key at https://console.volcengine.com/ark
+MODEL_AGENT_PROVIDER=openai
+MODEL_AGENT_NAME=doubao-seed-1-6-250615
+MODEL_AGENT_API_BASE=https://ark.cn-beijing.volces.com/api/v3/
+MODEL_AGENT_API_KEY=your-ark-api-key-here

--- a/examples/01_quickstart/README.md
+++ b/examples/01_quickstart/README.md
@@ -1,0 +1,46 @@
+# 01 · Quickstart
+
+The smallest possible VeADK program. An `Agent` carries the model and
+instruction; a `Runner` drives a conversation and returns the final answer.
+
+> 中文版见 [README.zh.md](./README.zh.md)
+
+## Core idea
+
+```python
+agent = Agent(name="quickstart_agent", instruction="You are a helpful assistant.")
+runner = Runner(agent=agent, app_name="quickstart")
+answer = await runner.run(messages="Hello!", session_id="demo-session")
+```
+
+- `Agent(...)` reads its model config from the environment (`MODEL_AGENT_*`).
+- `runner.run(...)` is **async** and returns the final text reply as a string.
+
+## Run it
+
+1. Install VeADK:
+
+   ```bash
+   pip install veadk-python
+   ```
+
+2. Configure your key:
+
+   ```bash
+   cp .env.example .env
+   # then edit .env and set MODEL_AGENT_API_KEY
+   ```
+
+3. Run:
+
+   ```bash
+   python main.py
+   ```
+
+You should see a one-sentence answer printed to the terminal.
+
+## What to try next
+
+- Change `instruction` to give the agent a different persona.
+- Move on to [02 · Custom tools](../02_custom_tools/) to let the agent call
+  your own Python functions.

--- a/examples/01_quickstart/README.zh.md
+++ b/examples/01_quickstart/README.zh.md
@@ -1,0 +1,44 @@
+# 01 · 快速开始
+
+最小可运行的 VeADK 程序。`Agent` 承载模型与指令，`Runner` 负责驱动一次对话并返回最终回答。
+
+> English version: [README.md](./README.md)
+
+## 核心思想
+
+```python
+agent = Agent(name="quickstart_agent", instruction="你是一个乐于助人的助手。")
+runner = Runner(agent=agent, app_name="quickstart")
+answer = await runner.run(messages="你好！", session_id="demo-session")
+```
+
+- `Agent(...)` 会自动从环境变量（`MODEL_AGENT_*`）读取模型配置。
+- `runner.run(...)` 是**异步**方法，返回最终回答文本（字符串）。
+
+## 运行步骤
+
+1. 安装 VeADK：
+
+   ```bash
+   pip install veadk-python
+   ```
+
+2. 配置密钥：
+
+   ```bash
+   cp .env.example .env
+   # 然后编辑 .env，填入 MODEL_AGENT_API_KEY
+   ```
+
+3. 运行：
+
+   ```bash
+   python main.py
+   ```
+
+终端会打印出一句话的回答。
+
+## 下一步
+
+- 修改 `instruction`，给智能体一个不同的人设。
+- 继续阅读 [02 · 自定义工具](../02_custom_tools/)，让智能体调用你自己的 Python 函数。

--- a/examples/01_quickstart/main.py
+++ b/examples/01_quickstart/main.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The smallest possible VeADK program: one agent, one question, one answer.
+
+An `Agent` holds the model + instruction; a `Runner` drives a conversation
+with it. `runner.run(...)` is async and returns the final text answer.
+"""
+
+import asyncio
+
+from veadk import Agent, Runner
+
+
+async def main() -> None:
+    agent = Agent(
+        name="quickstart_agent",
+        description="A friendly assistant that answers in one short paragraph.",
+        instruction="You are a helpful assistant. Answer concisely in the user's language.",
+    )
+
+    runner = Runner(agent=agent, app_name="quickstart")
+
+    answer = await runner.run(
+        messages="用一句话介绍火山引擎（Volcengine）。",
+        session_id="demo-session",
+    )
+    print(answer)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/02_custom_tools/.env.example
+++ b/examples/02_custom_tools/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to `.env` and fill in your key.
+
+# --- Agent reasoning model (Volcengine Ark) ---
+# Get an API key at https://console.volcengine.com/ark
+MODEL_AGENT_PROVIDER=openai
+MODEL_AGENT_NAME=doubao-seed-1-6-250615
+MODEL_AGENT_API_BASE=https://ark.cn-beijing.volces.com/api/v3/
+MODEL_AGENT_API_KEY=your-ark-api-key-here

--- a/examples/02_custom_tools/README.md
+++ b/examples/02_custom_tools/README.md
@@ -1,0 +1,40 @@
+# 02 · Custom tools
+
+Teach the agent to call your own Python functions. A tool is just a function
+with **type hints** and a **docstring** — pass it in `tools=[...]` and the model
+decides when to call it.
+
+> 中文版见 [README.zh.md](./README.zh.md)
+
+## Core idea
+
+```python
+def get_city_weather(city: str) -> dict[str, str]:
+    """Get the current weather for a city.
+
+    Args:
+        city: The English name of the city, e.g. "Beijing".
+    """
+    ...
+
+agent = Agent(tools=[get_city_weather, recommend_clothing])
+```
+
+The docstring is the tool's "API spec" that the model reads. Describe each
+argument clearly; the model uses it to decide *when* and *how* to call the tool.
+
+This example chains two tools: the agent looks up the weather, reads the
+temperature, then asks the clothing tool for advice — all in a single turn.
+
+## Run it
+
+```bash
+pip install veadk-python
+cp .env.example .env   # then set MODEL_AGENT_API_KEY
+python main.py
+```
+
+## What to try next
+
+- Add a `get_air_quality(city)` tool and update the instruction to use it.
+- Move on to [03 · Short-term memory](../03_short_term_memory/) for multi-turn conversations.

--- a/examples/02_custom_tools/README.zh.md
+++ b/examples/02_custom_tools/README.zh.md
@@ -1,0 +1,38 @@
+# 02 · 自定义工具
+
+让智能体调用你自己的 Python 函数。工具本质上就是一个带**类型注解**和**文档字符串（docstring）**
+的函数 —— 通过 `tools=[...]` 传入，模型会自行决定何时调用。
+
+> English version: [README.md](./README.md)
+
+## 核心思想
+
+```python
+def get_city_weather(city: str) -> dict[str, str]:
+    """获取某个城市的当前天气。
+
+    Args:
+        city: 城市的英文名称，例如 "Beijing"。
+    """
+    ...
+
+agent = Agent(tools=[get_city_weather, recommend_clothing])
+```
+
+docstring 就是工具的“接口说明”，模型会据此理解工具用途。请清晰描述每个参数，
+模型会用这些信息判断*何时*以及*如何*调用工具。
+
+本示例串联了两个工具：智能体先查询天气，读取温度，再调用穿衣建议工具 —— 在一轮对话内完成。
+
+## 运行步骤
+
+```bash
+pip install veadk-python
+cp .env.example .env   # 然后填入 MODEL_AGENT_API_KEY
+python main.py
+```
+
+## 下一步
+
+- 新增一个 `get_air_quality(city)` 工具，并更新 instruction 来使用它。
+- 继续阅读 [03 · 短期记忆](../03_short_term_memory/)，实现多轮对话。

--- a/examples/02_custom_tools/main.py
+++ b/examples/02_custom_tools/main.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Give the agent tools: plain Python functions it can decide to call.
+
+A "tool" in VeADK is just a function with type hints and a docstring. The
+docstring is what the model reads to decide *when* and *how* to call it, so
+write it for the model, not only for humans.
+"""
+
+import asyncio
+
+from veadk import Agent, Runner
+
+
+def get_city_weather(city: str) -> dict[str, str]:
+    """Get the current weather for a city.
+
+    Args:
+        city: The English name of the city, e.g. "Beijing".
+
+    Returns:
+        A dict with a human-readable weather "result".
+    """
+    fixed_weather = {
+        "beijing": "Sunny, 25°C",
+        "shanghai": "Cloudy, 22°C",
+        "shenzhen": "Partly cloudy, 29°C",
+    }
+    return {"result": fixed_weather.get(city.lower().strip(), f"No data for {city}")}
+
+
+def recommend_clothing(temperature_celsius: int) -> dict[str, str]:
+    """Recommend what to wear for a given temperature.
+
+    Args:
+        temperature_celsius: The temperature in degrees Celsius.
+
+    Returns:
+        A dict with a clothing "result" suggestion.
+    """
+    if temperature_celsius < 10:
+        advice = "Wear a thick coat."
+    elif temperature_celsius < 23:
+        advice = "A light jacket is enough."
+    else:
+        advice = "T-shirt weather."
+    return {"result": advice}
+
+
+async def main() -> None:
+    agent = Agent(
+        name="weather_agent",
+        description="An assistant that checks weather and suggests clothing.",
+        instruction=(
+            "You help users with weather. Use `get_city_weather` to look up "
+            "conditions, then `recommend_clothing` based on the temperature. "
+            "Always state the temperature you used."
+        ),
+        tools=[get_city_weather, recommend_clothing],
+    )
+
+    runner = Runner(agent=agent, app_name="custom_tools")
+
+    answer = await runner.run(
+        messages="北京今天天气怎么样？我该穿什么？",
+        session_id="demo-session",
+    )
+    print(answer)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/03_short_term_memory/.env.example
+++ b/examples/03_short_term_memory/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to `.env` and fill in your key.
+
+# --- Agent reasoning model (Volcengine Ark) ---
+# Get an API key at https://console.volcengine.com/ark
+MODEL_AGENT_PROVIDER=openai
+MODEL_AGENT_NAME=doubao-seed-1-6-250615
+MODEL_AGENT_API_BASE=https://ark.cn-beijing.volces.com/api/v3/
+MODEL_AGENT_API_KEY=your-ark-api-key-here

--- a/examples/03_short_term_memory/README.md
+++ b/examples/03_short_term_memory/README.md
@@ -1,0 +1,41 @@
+# 03 · Short-term memory (multi-turn)
+
+Make the agent remember earlier turns within a conversation. **Short-term
+memory** is the conversation context; VeADK keys it by `session_id`.
+
+> 中文版见 [README.zh.md](./README.zh.md)
+
+## Core idea
+
+```python
+short_term_memory = ShortTermMemory(backend="sqlite", local_database_path="./short_term_memory.db")
+agent = Agent(short_term_memory=short_term_memory)
+runner = Runner(agent=agent, short_term_memory=short_term_memory, app_name="memory_demo")
+
+await runner.run(messages="My name is Xiao Ming.", session_id="user-42-chat")
+await runner.run(messages="What is my name?", session_id="user-42-chat")  # remembers
+```
+
+- Same `session_id` → the agent sees the previous turns.
+- `backend="sqlite"` persists the session to a local `.db` file, so it survives
+  restarts. Use `backend="local"` for an ephemeral in-memory session.
+- Other backends: `mysql`, `postgresql` (configured via env / `config.yaml`).
+
+## Run it
+
+```bash
+pip install veadk-python
+cp .env.example .env   # then set MODEL_AGENT_API_KEY
+python main.py
+```
+
+Turn 2 should correctly recall the name and color from turn 1. Run it again and
+the agent still remembers (the session is on disk in `short_term_memory.db`).
+
+## What to try next
+
+- Change `SESSION_ID` and run again — it's a fresh conversation with no memory.
+- Short-term memory is *within* a conversation. For knowledge that persists
+  *across* conversations and users, see long-term memory in the
+  [VeADK docs](https://volcengine.github.io/veadk-python/).
+- Move on to [04 · Web search](../04_web_search/) for built-in Volcengine tools.

--- a/examples/03_short_term_memory/README.zh.md
+++ b/examples/03_short_term_memory/README.zh.md
@@ -1,0 +1,39 @@
+# 03 · 短期记忆（多轮对话）
+
+让智能体记住同一轮对话中之前说过的话。**短期记忆**即对话上下文，VeADK 通过 `session_id` 来区分。
+
+> English version: [README.md](./README.md)
+
+## 核心思想
+
+```python
+short_term_memory = ShortTermMemory(backend="sqlite", local_database_path="./short_term_memory.db")
+agent = Agent(short_term_memory=short_term_memory)
+runner = Runner(agent=agent, short_term_memory=short_term_memory, app_name="memory_demo")
+
+await runner.run(messages="我叫小明。", session_id="user-42-chat")
+await runner.run(messages="我叫什么名字？", session_id="user-42-chat")  # 能记住
+```
+
+- 相同的 `session_id` → 智能体能看到之前的对话轮次。
+- `backend="sqlite"` 会把会话持久化到本地 `.db` 文件，进程重启后依然存在。
+  若想要进程退出即消失的内存会话，使用 `backend="local"`。
+- 其他后端：`mysql`、`postgresql`（通过环境变量 / `config.yaml` 配置）。
+
+## 运行步骤
+
+```bash
+pip install veadk-python
+cp .env.example .env   # 然后填入 MODEL_AGENT_API_KEY
+python main.py
+```
+
+第二轮应能正确回忆出第一轮提到的名字和颜色。再次运行，智能体仍然记得
+（会话保存在 `short_term_memory.db` 文件中）。
+
+## 下一步
+
+- 修改 `SESSION_ID` 再运行一次 —— 这是一段全新的、没有记忆的对话。
+- 短期记忆作用于*同一段*对话内。若需要*跨对话、跨用户*持久化的知识，
+  请参阅 [VeADK 文档](https://volcengine.github.io/veadk-python/) 中的长期记忆（long-term memory）。
+- 继续阅读 [04 · 联网搜索](../04_web_search/)，体验内置的火山引擎工具。

--- a/examples/03_short_term_memory/main.py
+++ b/examples/03_short_term_memory/main.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Multi-turn conversation backed by short-term memory.
+
+Short-term memory = the conversation context (everything sent to the model:
+system prompt + history). VeADK keys it by `session_id`: reuse the same id and
+the agent remembers earlier turns. Here we use the `sqlite` backend so the
+session also survives across process restarts (stored on disk).
+"""
+
+import asyncio
+
+from veadk import Agent, Runner
+from veadk.memory.short_term_memory import ShortTermMemory
+
+APP_NAME = "memory_demo"
+SESSION_ID = "user-42-chat"
+
+
+async def main() -> None:
+    # `sqlite` persists the session to a local file. Use "local" for a purely
+    # in-memory session that disappears when the process exits.
+    short_term_memory = ShortTermMemory(
+        backend="sqlite",
+        local_database_path="./short_term_memory.db",
+    )
+
+    agent = Agent(
+        name="memory_agent",
+        instruction="You are a concise assistant. Remember what the user tells you.",
+        short_term_memory=short_term_memory,
+    )
+
+    runner = Runner(
+        agent=agent,
+        short_term_memory=short_term_memory,
+        app_name=APP_NAME,
+    )
+
+    # Turn 1: tell the agent something.
+    print(
+        "Turn 1 ->",
+        await runner.run(
+            messages="我叫小明，最喜欢的颜色是蓝色。",
+            session_id=SESSION_ID,
+        ),
+    )
+
+    # Turn 2: same session_id, so the agent recalls turn 1.
+    print(
+        "Turn 2 ->",
+        await runner.run(
+            messages="我叫什么名字？我喜欢什么颜色？",
+            session_id=SESSION_ID,
+        ),
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/04_web_search/.env.example
+++ b/examples/04_web_search/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to `.env` and fill in your keys.
+
+# --- Agent reasoning model (Volcengine Ark) ---
+# Get an API key at https://console.volcengine.com/ark
+MODEL_AGENT_PROVIDER=openai
+MODEL_AGENT_NAME=doubao-seed-1-6-250615
+MODEL_AGENT_API_BASE=https://ark.cn-beijing.volces.com/api/v3/
+MODEL_AGENT_API_KEY=your-ark-api-key-here
+
+# --- Volcengine AK/SK for the web_search tool ---
+# Create access keys at https://console.volcengine.com/iam/keymanage
+VOLCENGINE_ACCESS_KEY=your-volcengine-access-key
+VOLCENGINE_SECRET_KEY=your-volcengine-secret-key

--- a/examples/04_web_search/README.md
+++ b/examples/04_web_search/README.md
@@ -1,0 +1,45 @@
+# 04 · Built-in tool: web search
+
+Use one of VeADK's ready-made tools. `web_search` queries Volcengine's search
+API so the agent can answer with fresh, real-world information.
+
+> 中文版见 [README.zh.md](./README.zh.md)
+
+## Core idea
+
+```python
+from veadk.tools.builtin_tools.web_search import web_search
+
+agent = Agent(tools=[web_search])
+```
+
+Built-in tools live under `veadk.tools.builtin_tools` (web search, image
+generation, TTS, code sandbox, and more). They're added exactly like custom
+functions — just put them in `tools=[...]`.
+
+## Credentials
+
+`web_search` calls the Volcengine search API, so besides the model key it needs
+a Volcengine **AK/SK** pair:
+
+- `VOLCENGINE_ACCESS_KEY`
+- `VOLCENGINE_SECRET_KEY`
+
+Create them in the [Volcengine IAM console](https://console.volcengine.com/iam/keymanage).
+
+## Run it
+
+```bash
+pip install veadk-python
+cp .env.example .env   # set MODEL_AGENT_API_KEY + VOLCENGINE_ACCESS_KEY/SECRET_KEY
+python main.py
+```
+
+The agent decides to call `web_search`, then answers using the results.
+
+## What to try next
+
+- Browse other tools in `veadk/tools/builtin_tools/` (e.g. `image_generate`,
+  `tts`, `link_reader`).
+- Move on to [05 · Knowledgebase RAG](../05_knowledgebase_rag/) to ground
+  answers in your own documents.

--- a/examples/04_web_search/README.zh.md
+++ b/examples/04_web_search/README.zh.md
@@ -1,0 +1,41 @@
+# 04 · 内置工具：联网搜索
+
+使用 VeADK 提供的开箱即用工具。`web_search` 会调用火山引擎的搜索 API，
+让智能体能基于最新的真实信息作答。
+
+> English version: [README.md](./README.md)
+
+## 核心思想
+
+```python
+from veadk.tools.builtin_tools.web_search import web_search
+
+agent = Agent(tools=[web_search])
+```
+
+内置工具位于 `veadk.tools.builtin_tools`（联网搜索、图像生成、语音合成、代码沙箱等）。
+它们的用法与自定义函数完全一样 —— 放进 `tools=[...]` 即可。
+
+## 凭证
+
+`web_search` 调用火山引擎搜索 API，因此除模型密钥外还需要一对火山引擎 **AK/SK**：
+
+- `VOLCENGINE_ACCESS_KEY`
+- `VOLCENGINE_SECRET_KEY`
+
+可在[火山引擎 IAM 控制台](https://console.volcengine.com/iam/keymanage)创建。
+
+## 运行步骤
+
+```bash
+pip install veadk-python
+cp .env.example .env   # 填入 MODEL_AGENT_API_KEY 以及 VOLCENGINE_ACCESS_KEY/SECRET_KEY
+python main.py
+```
+
+智能体会自行决定调用 `web_search`，并基于搜索结果作答。
+
+## 下一步
+
+- 浏览 `veadk/tools/builtin_tools/` 下的其他工具（如 `image_generate`、`tts`、`link_reader`）。
+- 继续阅读 [05 · 知识库 RAG](../05_knowledgebase_rag/)，让回答基于你自己的文档。

--- a/examples/04_web_search/main.py
+++ b/examples/04_web_search/main.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Use a built-in tool: live web search powered by Volcengine.
+
+VeADK ships ready-made tools under `veadk.tools.builtin_tools`. The `web_search`
+tool calls Volcengine's search API, so it needs a Volcengine AK/SK pair
+(`VOLCENGINE_ACCESS_KEY` / `VOLCENGINE_SECRET_KEY`) in addition to the model key.
+Adding it is the same as any tool: drop it into `tools=[...]`.
+"""
+
+import asyncio
+
+from veadk import Agent, Runner
+from veadk.tools.builtin_tools.web_search import web_search
+
+
+async def main() -> None:
+    agent = Agent(
+        name="search_agent",
+        description="An assistant that can search the web for fresh information.",
+        instruction=(
+            "When a question needs current or factual information you are unsure "
+            "about, call `web_search` first, then answer based on the results. "
+            "Cite the key facts you found."
+        ),
+        tools=[web_search],
+    )
+
+    runner = Runner(agent=agent, app_name="web_search_demo")
+
+    answer = await runner.run(
+        messages="火山引擎最近发布了哪些大模型相关的产品？请联网查一下。",
+        session_id="demo-session",
+    )
+    print(answer)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/05_knowledgebase_rag/.env.example
+++ b/examples/05_knowledgebase_rag/.env.example
@@ -1,0 +1,15 @@
+# Copy this file to `.env` and fill in your keys.
+
+# --- Agent reasoning model (Volcengine Ark) ---
+# Get an API key at https://console.volcengine.com/ark
+MODEL_AGENT_PROVIDER=openai
+MODEL_AGENT_NAME=doubao-seed-1-6-250615
+MODEL_AGENT_API_BASE=https://ark.cn-beijing.volces.com/api/v3/
+MODEL_AGENT_API_KEY=your-ark-api-key-here
+
+# --- Embedding model (used to vectorize the knowledge base) ---
+# If omitted, VeADK falls back to MODEL_AGENT_API_KEY for the embedding key.
+MODEL_EMBEDDING_NAME=doubao-embedding-vision-250615
+MODEL_EMBEDDING_DIM=2048
+MODEL_EMBEDDING_API_BASE=https://ark.cn-beijing.volces.com/api/v3/
+MODEL_EMBEDDING_API_KEY=your-ark-api-key-here

--- a/examples/05_knowledgebase_rag/README.md
+++ b/examples/05_knowledgebase_rag/README.md
@@ -1,0 +1,51 @@
+# 05 · Knowledgebase RAG
+
+Ground the agent's answers in *your own* documents using Retrieval-Augmented
+Generation (RAG). A `KnowledgeBase` embeds your docs into a vector store; when
+attached to an `Agent`, VeADK gives it a retrieval tool automatically.
+
+> 中文版见 [README.zh.md](./README.zh.md)
+
+## Core idea
+
+```python
+knowledgebase = KnowledgeBase(backend="local", index="company_faq")
+knowledgebase.add_from_directory("./docs")
+
+agent = Agent(knowledgebase=knowledgebase)   # retrieval tool added automatically
+```
+
+At query time the agent retrieves the most relevant passages from your docs and
+answers based on them — so it can correctly answer questions the base model has
+never seen (here: Acme Inc.'s internal leave / remote-work policy in `docs/`).
+
+## Requirements
+
+The `local` backend embeds documents, so it needs:
+
+1. The optional extensions dependency:
+
+   ```bash
+   pip install "veadk-python[extensions]"
+   ```
+
+2. An **embedding model** config (`MODEL_EMBEDDING_*`). If you omit the embedding
+   key, VeADK reuses `MODEL_AGENT_API_KEY`.
+
+## Run it
+
+```bash
+cp .env.example .env   # set MODEL_AGENT_API_KEY (and embedding config)
+python main.py
+```
+
+The answer about annual leave / remote work comes straight from
+`docs/company_faq.md`, not the model's prior knowledge.
+
+## What to try next
+
+- Drop your own `.md` / `.txt` / `.pdf` files into `docs/` and ask about them.
+- Swap `backend="local"` for a persistent store like `viking`, `opensearch`, or
+  `redis` (configured in `config.yaml`) for production use.
+- Move on to [06 · Multi-agent workflow](../06_multi_agent/) to compose several
+  agents.

--- a/examples/05_knowledgebase_rag/README.zh.md
+++ b/examples/05_knowledgebase_rag/README.zh.md
@@ -1,0 +1,47 @@
+# 05 · 知识库 RAG
+
+通过检索增强生成（RAG），让智能体基于*你自己的*文档作答。`KnowledgeBase` 会把文档
+向量化并存入向量库；当它被挂载到 `Agent` 上时，VeADK 会自动为其添加检索工具。
+
+> English version: [README.md](./README.md)
+
+## 核心思想
+
+```python
+knowledgebase = KnowledgeBase(backend="local", index="company_faq")
+knowledgebase.add_from_directory("./docs")
+
+agent = Agent(knowledgebase=knowledgebase)   # 自动添加检索工具
+```
+
+提问时，智能体会从你的文档中检索最相关的片段并据此作答 —— 因此它能正确回答
+基座模型从未见过的问题（本例中是 `docs/` 里 Acme 公司的内部年假 / 远程办公政策）。
+
+## 前置依赖
+
+`local` 后端需要对文档做 embedding，因此需要：
+
+1. 安装可选扩展依赖：
+
+   ```bash
+   pip install "veadk-python[extensions]"
+   ```
+
+2. 配置 **embedding 模型**（`MODEL_EMBEDDING_*`）。若不单独配置 embedding 密钥，
+   VeADK 会复用 `MODEL_AGENT_API_KEY`。
+
+## 运行步骤
+
+```bash
+cp .env.example .env   # 填入 MODEL_AGENT_API_KEY（以及 embedding 配置）
+python main.py
+```
+
+关于年假 / 远程办公的回答直接来自 `docs/company_faq.md`，而非模型的固有知识。
+
+## 下一步
+
+- 把你自己的 `.md` / `.txt` / `.pdf` 文件放进 `docs/` 并就其内容提问。
+- 将 `backend="local"` 替换为持久化存储（如 `viking`、`opensearch`、`redis`，
+  在 `config.yaml` 中配置），用于生产环境。
+- 继续阅读 [06 · 多智能体工作流](../06_multi_agent/)，组合多个智能体。

--- a/examples/05_knowledgebase_rag/docs/company_faq.md
+++ b/examples/05_knowledgebase_rag/docs/company_faq.md
@@ -1,0 +1,27 @@
+# Acme Inc. — Employee FAQ
+
+## Annual leave
+
+Full-time employees get 15 days of paid annual leave per year. Leave accrues
+monthly and unused days can be carried over to the next year, up to a maximum of
+5 days. Requests should be submitted at least 3 working days in advance.
+
+## Remote work
+
+Employees may work remotely up to 3 days per week. Fully remote arrangements
+require manager approval and are reviewed every 6 months.
+
+## Working hours
+
+Standard working hours are 10:00–19:00 with a flexible start between 09:00 and
+10:30. Core collaboration hours are 14:00–17:00.
+
+## Equipment
+
+Each new employee receives a laptop and a one-time 1,000 RMB budget for home
+office equipment. Reimbursement requires a receipt submitted within 30 days.
+
+## Reimbursement
+
+Travel and meal expenses are reimbursed monthly. Submit receipts through the
+internal portal before the 5th of the following month.

--- a/examples/05_knowledgebase_rag/main.py
+++ b/examples/05_knowledgebase_rag/main.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Retrieval-Augmented Generation (RAG) with a KnowledgeBase.
+
+A `KnowledgeBase` embeds your documents and stores them in a vector backend.
+When you attach it to an `Agent`, VeADK automatically gives the agent a
+retrieval tool, so it can look up relevant passages before answering — grounding
+its responses in *your* content instead of the model's general knowledge.
+
+This uses the `local` (in-memory) backend, which requires the embedding model
+config and the optional `extensions` dependency:
+
+    pip install "veadk-python[extensions]"
+"""
+
+import asyncio
+from pathlib import Path
+
+from veadk import Agent, Runner
+from veadk.knowledgebase import KnowledgeBase
+
+DOCS_DIR = Path(__file__).parent / "docs"
+
+
+async def main() -> None:
+    # 1. Build a knowledge base and ingest the local docs (embedded on add).
+    knowledgebase = KnowledgeBase(backend="local", index="company_faq")
+    knowledgebase.add_from_directory(str(DOCS_DIR))
+
+    # 2. Attach it to the agent. VeADK adds a retrieval tool automatically.
+    agent = Agent(
+        name="rag_agent",
+        description="Answers questions using the company knowledge base.",
+        instruction=(
+            "Answer questions about the company. Always consult the knowledge "
+            "base first and base your answer on what you retrieve. If the answer "
+            "is not in the knowledge base, say so."
+        ),
+        knowledgebase=knowledgebase,
+    )
+
+    runner = Runner(agent=agent, app_name="rag_demo")
+
+    answer = await runner.run(
+        messages="公司的年假政策是怎样的？远程办公可以吗？",
+        session_id="demo-session",
+    )
+    print(answer)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/06_multi_agent/.env.example
+++ b/examples/06_multi_agent/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to `.env` and fill in your key.
+
+# --- Agent reasoning model (Volcengine Ark) ---
+# Get an API key at https://console.volcengine.com/ark
+MODEL_AGENT_PROVIDER=openai
+MODEL_AGENT_NAME=doubao-seed-1-6-250615
+MODEL_AGENT_API_BASE=https://ark.cn-beijing.volces.com/api/v3/
+MODEL_AGENT_API_KEY=your-ark-api-key-here

--- a/examples/06_multi_agent/README.md
+++ b/examples/06_multi_agent/README.md
@@ -1,0 +1,49 @@
+# 06 · Multi-agent workflow
+
+Split a job across specialist agents that run in a fixed order. A
+`SequentialAgent` runs its sub-agents top to bottom, passing data through
+shared session state.
+
+> 中文版见 [README.zh.md](./README.zh.md)
+
+## Core idea
+
+```text
+outliner  ->  writer  ->  editor
+```
+
+```python
+outliner = Agent(name="outliner", instruction="...", output_key="outline")
+writer = Agent(name="writer", instruction="...expand:\n{outline}", output_key="draft")
+editor = Agent(name="editor", instruction="...polish:\n{draft}", output_key="final")
+
+pipeline = SequentialAgent(
+    name="content_pipeline", sub_agents=[outliner, writer, editor]
+)
+runner = Runner(agent=pipeline, app_name="multi_agent_demo")
+```
+
+Two mechanisms make this work:
+
+- **`output_key`** — an agent stores its reply into session state under that key.
+- **`{key}` templating** — the next agent's instruction pulls that value back in.
+
+So `outliner` writes `outline`, `writer` reads `{outline}` and writes `draft`,
+`editor` reads `{draft}` and produces the `final` text the runner returns.
+
+## Run it
+
+```bash
+pip install veadk-python
+cp .env.example .env   # then set MODEL_AGENT_API_KEY
+python main.py
+```
+
+You'll get a polished paragraph that passed through all three stages.
+
+## What to try next
+
+- VeADK also ships `ParallelAgent` (run sub-agents concurrently) and `LoopAgent`
+  (repeat until a condition). Same `sub_agents=[...]` pattern.
+- For *dynamic* delegation (a coordinator that chooses which specialist to call),
+  pass `sub_agents=[...]` to a regular `Agent` and let the LLM route.

--- a/examples/06_multi_agent/README.zh.md
+++ b/examples/06_multi_agent/README.zh.md
@@ -1,0 +1,48 @@
+# 06 · 多智能体工作流
+
+把一个任务拆分给多个各司其职的智能体，并按固定顺序执行。`SequentialAgent` 会
+自上而下依次运行子智能体，通过共享的会话状态在它们之间传递数据。
+
+> English version: [README.md](./README.md)
+
+## 核心思想
+
+```text
+拟提纲 -> 撰写 -> 润色
+```
+
+```python
+outliner = Agent(name="outliner", instruction="...", output_key="outline")
+writer = Agent(name="writer", instruction="...扩写：\n{outline}", output_key="draft")
+editor = Agent(name="editor", instruction="...润色：\n{draft}", output_key="final")
+
+pipeline = SequentialAgent(
+    name="content_pipeline", sub_agents=[outliner, writer, editor]
+)
+runner = Runner(agent=pipeline, app_name="multi_agent_demo")
+```
+
+让它跑通的两个机制：
+
+- **`output_key`** —— 智能体把自己的回复写入会话状态的该键下。
+- **`{key}` 模板注入** —— 下一个智能体在 instruction 中引用该键即可取回其值。
+
+于是 `outliner` 写入 `outline`，`writer` 读取 `{outline}` 并写入 `draft`，
+`editor` 读取 `{draft}` 并产出最终文本 `final`，由 runner 返回。
+
+## 运行步骤
+
+```bash
+pip install veadk-python
+cp .env.example .env   # 然后填入 MODEL_AGENT_API_KEY
+python main.py
+```
+
+你会得到一段经过三个阶段处理、润色后的文字。
+
+## 下一步
+
+- VeADK 还提供 `ParallelAgent`（并发运行子智能体）与 `LoopAgent`（循环直到满足条件），
+  用法都是同样的 `sub_agents=[...]`。
+- 若需要*动态*委派（由一个协调者智能体自行决定调用哪个专家），
+  可直接给普通 `Agent` 传入 `sub_agents=[...]`，让大模型来路由。

--- a/examples/06_multi_agent/main.py
+++ b/examples/06_multi_agent/main.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compose several agents into a workflow with `SequentialAgent`.
+
+Instead of one agent doing everything, we split the job into specialists that
+run in a fixed order:
+
+    outliner  ->  writer  ->  editor
+
+State is shared between them. Each sub-agent writes its result to the session
+state via `output_key`, and the next agent reads it by referencing `{that_key}`
+in its instruction. The `SequentialAgent` just runs them top to bottom.
+"""
+
+import asyncio
+
+from veadk import Agent, Runner
+from veadk.agents.sequential_agent import SequentialAgent
+from veadk.memory.short_term_memory import ShortTermMemory
+
+
+def build_pipeline() -> SequentialAgent:
+    outliner = Agent(
+        name="outliner",
+        instruction=(
+            "You are an outliner. Given the user's topic, produce a tight "
+            "3-point outline (just the bullet points, no prose)."
+        ),
+        output_key="outline",
+    )
+
+    writer = Agent(
+        name="writer",
+        instruction=(
+            "You are a writer. Expand the following outline into a short, "
+            "engaging paragraph (~120 words):\n\n{outline}"
+        ),
+        output_key="draft",
+    )
+
+    editor = Agent(
+        name="editor",
+        instruction=(
+            "You are an editor. Polish the draft below for clarity and flow, "
+            "then return ONLY the final text:\n\n{draft}"
+        ),
+        output_key="final",
+    )
+
+    return SequentialAgent(
+        name="content_pipeline",
+        description="Turns a topic into a polished short paragraph.",
+        sub_agents=[outliner, writer, editor],
+    )
+
+
+async def main() -> None:
+    pipeline = build_pipeline()
+    # Workflow agents (Sequential/Parallel/Loop) don't carry their own memory, so
+    # give the Runner a session store explicitly.
+    runner = Runner(
+        agent=pipeline,
+        short_term_memory=ShortTermMemory(),
+        app_name="multi_agent_demo",
+    )
+
+    final_text = await runner.run(
+        messages="主题：为什么团队应该写好的提交信息（commit message）。",
+        session_id="demo-session",
+    )
+    print(final_text)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/07_structured_output/.env.example
+++ b/examples/07_structured_output/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to `.env` and fill in your key.
+
+# --- Agent reasoning model (Volcengine Ark) ---
+# Get an API key at https://console.volcengine.com/ark
+MODEL_AGENT_PROVIDER=openai
+MODEL_AGENT_NAME=doubao-seed-1-6-250615
+MODEL_AGENT_API_BASE=https://ark.cn-beijing.volces.com/api/v3/
+MODEL_AGENT_API_KEY=your-ark-api-key-here

--- a/examples/07_structured_output/README.md
+++ b/examples/07_structured_output/README.md
@@ -1,0 +1,44 @@
+# 07 · Structured output
+
+Make the agent return JSON that matches a schema you define, instead of free
+text. Pass a Pydantic model as `output_schema`.
+
+> 中文版见 [README.zh.md](./README.zh.md)
+
+## Core idea
+
+```python
+class Ticket(BaseModel):
+    summary: str
+    category: str
+    priority: str
+    sentiment: str
+
+agent = Agent(output_schema=Ticket, instruction="Extract a support ticket.")
+
+raw = await runner.run(messages="The app keeps crashing on billing!", ...)
+ticket = Ticket.model_validate_json(raw)   # guaranteed to parse
+```
+
+The reply is guaranteed to conform to `Ticket`, so you can `model_validate_json`
+(or `json.loads`) it directly — great for extraction, classification, and
+feeding the result into downstream code.
+
+> ⚠️ When `output_schema` is set, the agent returns **only** the structured
+> answer — it cannot call tools or transfer to sub-agents.
+
+## Run it
+
+```bash
+pip install veadk-python
+cp .env.example .env   # then set MODEL_AGENT_API_KEY
+python main.py
+```
+
+You'll get a parsed `Ticket` printed as pretty JSON.
+
+## What to try next
+
+- Add fields (e.g. `affected_feature: str`) and rerun.
+- Combine structured extraction with a workflow ([06](../06_multi_agent/)): one
+  agent extracts, the next acts on the structured result.

--- a/examples/07_structured_output/README.zh.md
+++ b/examples/07_structured_output/README.zh.md
@@ -1,0 +1,42 @@
+# 07 · 结构化输出
+
+让智能体返回符合你定义 schema 的 JSON，而不是自由文本。把一个 Pydantic 模型
+传给 `output_schema` 即可。
+
+> English version: [README.md](./README.md)
+
+## 核心思想
+
+```python
+class Ticket(BaseModel):
+    summary: str
+    category: str
+    priority: str
+    sentiment: str
+
+agent = Agent(output_schema=Ticket, instruction="抽取一张工单。")
+
+raw = await runner.run(messages="你们的 App 一打开账单页就崩溃！", ...)
+ticket = Ticket.model_validate_json(raw)   # 保证能解析
+```
+
+回复保证符合 `Ticket` 结构，因此可以直接 `model_validate_json`（或 `json.loads`）—
+非常适合信息抽取、分类，以及把结果交给下游代码处理。
+
+> ⚠️ 设置 `output_schema` 后，智能体**只会**返回结构化结果，无法调用工具或转交子智能体。
+
+## 运行步骤
+
+```bash
+pip install veadk-python
+cp .env.example .env   # 然后填入 MODEL_AGENT_API_KEY
+python main.py
+```
+
+你会看到解析后的 `Ticket` 以美化 JSON 打印出来。
+
+## 下一步
+
+- 增加字段（如 `affected_feature: str`）后重新运行。
+- 把结构化抽取与工作流（[06](../06_multi_agent/)）结合：一个智能体负责抽取，
+  下一个智能体基于结构化结果继续处理。

--- a/examples/07_structured_output/main.py
+++ b/examples/07_structured_output/main.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Force the agent to return structured JSON with `output_schema`.
+
+Pass a Pydantic model as `output_schema` and the agent's reply is guaranteed to
+match that schema — ideal for extraction / classification where you want to
+`json.loads(...)` the result instead of parsing free text.
+
+Note: when `output_schema` is set, the agent returns *only* the structured
+answer and cannot call tools or transfer to sub-agents.
+"""
+
+import asyncio
+import json
+
+from pydantic import BaseModel, Field
+
+from veadk import Agent, Runner
+
+
+class Ticket(BaseModel):
+    """A structured support ticket extracted from a user's message."""
+
+    summary: str = Field(description="One-line summary of the issue.")
+    category: str = Field(description="One of: billing, bug, feature_request, other.")
+    priority: str = Field(description="One of: low, medium, high.")
+    sentiment: str = Field(description="One of: positive, neutral, negative.")
+
+
+async def main() -> None:
+    agent = Agent(
+        name="ticket_extractor",
+        description="Turns a free-text complaint into a structured ticket.",
+        instruction="Extract a support ticket from the user's message.",
+        output_schema=Ticket,
+    )
+
+    runner = Runner(agent=agent, app_name="structured_output")
+
+    raw = await runner.run(
+        messages=(
+            "你们的 App 又崩溃了！我每次点开账单页面就闪退，已经第三次了，"
+            "非常影响我交月费，请尽快处理！"
+        ),
+        session_id="demo-session",
+    )
+
+    # `raw` is a JSON string that matches the Ticket schema.
+    ticket = Ticket.model_validate_json(raw)
+    print(json.dumps(ticket.model_dump(), ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/08_model_config/.env.example
+++ b/examples/08_model_config/.env.example
@@ -1,0 +1,9 @@
+# Copy this file to `.env` and fill in your key.
+# This example sets model_name on the Agent itself, so MODEL_AGENT_NAME here is
+# only a fallback default. The API key is still read from the environment.
+
+# --- Agent reasoning model (Volcengine Ark) ---
+# Get an API key at https://console.volcengine.com/ark
+MODEL_AGENT_PROVIDER=openai
+MODEL_AGENT_API_BASE=https://ark.cn-beijing.volces.com/api/v3/
+MODEL_AGENT_API_KEY=your-ark-api-key-here

--- a/examples/08_model_config/README.md
+++ b/examples/08_model_config/README.md
@@ -1,0 +1,40 @@
+# 08 · Model config: fallbacks & extra options
+
+Configure the model directly on the `Agent` — pick the model per agent, add
+fallbacks for resilience, and pass extra request options.
+
+> 中文版见 [README.zh.md](./README.zh.md)
+
+## Core idea
+
+```python
+agent = Agent(
+    # primary + fallbacks, tried in order
+    model_name=["doubao-seed-1-6-250615", "deepseek-v3-2-251201"],
+    model_extra_config={"extra_body": {"thinking": {"type": "disabled"}}},
+)
+```
+
+- **`model_name` as a list** — the first model is primary; the rest are tried in
+  order if a request fails. A single string also works for one fixed model.
+- **`model_provider` / `model_api_base` / `model_api_key`** — override the model
+  for *this* agent (e.g. a cheaper model for a sub-agent) without touching the
+  global environment config.
+- **`model_extra_config`** — merged into every request. The `thinking: disabled`
+  body turns off the model's chain-of-thought output for faster, cheaper replies.
+
+## Run it
+
+```bash
+pip install veadk-python
+cp .env.example .env   # then set MODEL_AGENT_API_KEY
+python main.py
+```
+
+Notice the reply comes back quickly — there's no long "thinking" stream because
+we disabled it.
+
+## What to try next
+
+- Give different sub-agents in [06](../06_multi_agent/) different
+  `model_name`s — a strong model to write, a cheap one to format.

--- a/examples/08_model_config/README.zh.md
+++ b/examples/08_model_config/README.zh.md
@@ -1,0 +1,37 @@
+# 08 · 模型配置：降级回退与额外选项
+
+直接在 `Agent` 上配置模型 —— 为每个智能体单独选模型、添加回退（fallback）以提升健壮性、
+并传入额外的请求选项。
+
+> English version: [README.md](./README.md)
+
+## 核心思想
+
+```python
+agent = Agent(
+    model_name=["doubao-seed-1-6-250615", "deepseek-v3-2-251201"],  # 主模型 + 回退
+    model_extra_config={"extra_body": {"thinking": {"type": "disabled"}}},
+)
+```
+
+- **`model_name` 传列表** —— 第一个为主模型，请求失败时按顺序尝试后续模型。
+  传单个字符串则固定使用一个模型。
+- **`model_provider` / `model_api_base` / `model_api_key`** —— 为*当前*智能体单独覆盖模型
+  （例如给某个子智能体用更便宜的模型），无需改动全局环境配置。
+- **`model_extra_config`** —— 合并进每次请求。`thinking: disabled` 关闭模型的思维链输出，
+  让回复更快、更省。
+
+## 运行步骤
+
+```bash
+pip install veadk-python
+cp .env.example .env   # 然后填入 MODEL_AGENT_API_KEY
+python main.py
+```
+
+你会发现回复很快返回 —— 因为我们关闭了 thinking，没有冗长的思考输出。
+
+## 下一步
+
+- 在 [06](../06_multi_agent/) 中给不同子智能体配置不同的 `model_name`：
+  用强模型负责写作，用便宜模型负责排版。

--- a/examples/08_model_config/main.py
+++ b/examples/08_model_config/main.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configure the model: per-agent override, fallbacks, and extra request body.
+
+Three knobs, all set right on the `Agent` (no global config needed):
+
+- `model_name=[primary, backup, ...]` — try the primary model first; if it
+  fails, automatically fall back to the next one(s).
+- `model_provider` / `model_api_base` / `model_api_key` — override the model for
+  *this* agent instead of using the environment defaults.
+- `model_extra_config` — extra fields merged into every request. Here we disable
+  the model's "thinking" output to get faster, cheaper replies.
+"""
+
+import asyncio
+
+from veadk import Agent, Runner
+
+
+async def main() -> None:
+    agent = Agent(
+        name="resilient_agent",
+        instruction="You are a concise assistant. Answer in one short sentence.",
+        # Primary model first; the rest are fallbacks tried in order on failure.
+        model_name=["doubao-seed-1-6-250615", "deepseek-v3-2-251201"],
+        # Merged into every model request. Disabling "thinking" speeds things up.
+        model_extra_config={"extra_body": {"thinking": {"type": "disabled"}}},
+    )
+
+    runner = Runner(agent=agent, app_name="model_config")
+
+    answer = await runner.run(
+        messages="用一句话解释什么是负载均衡。",
+        session_id="demo-session",
+    )
+    print(answer)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/09_long_term_memory/.env.example
+++ b/examples/09_long_term_memory/.env.example
@@ -1,0 +1,15 @@
+# Copy this file to `.env` and fill in your keys.
+
+# --- Agent reasoning model (Volcengine Ark) ---
+# Get an API key at https://console.volcengine.com/ark
+MODEL_AGENT_PROVIDER=openai
+MODEL_AGENT_NAME=doubao-seed-1-6-250615
+MODEL_AGENT_API_BASE=https://ark.cn-beijing.volces.com/api/v3/
+MODEL_AGENT_API_KEY=your-ark-api-key-here
+
+# --- Embedding model (used to vectorize long-term memories) ---
+# If omitted, VeADK falls back to MODEL_AGENT_API_KEY for the embedding key.
+MODEL_EMBEDDING_NAME=doubao-embedding-vision-250615
+MODEL_EMBEDDING_DIM=2048
+MODEL_EMBEDDING_API_BASE=https://ark.cn-beijing.volces.com/api/v3/
+MODEL_EMBEDDING_API_KEY=your-ark-api-key-here

--- a/examples/09_long_term_memory/README.md
+++ b/examples/09_long_term_memory/README.md
@@ -1,0 +1,53 @@
+# 09 · Long-term memory
+
+Remember facts *across* conversations. Where short-term memory ([03](../03_short_term_memory/))
+lives inside one session, long-term memory persists across different sessions
+(and users) and is searched on demand.
+
+> 中文版见 [README.zh.md](./README.zh.md)
+
+## Core idea
+
+```python
+long_term_memory = LongTermMemory(backend="local", app_name="ltm_demo")
+agent = Agent(
+    long_term_memory=long_term_memory,   # adds a `load_memory` tool
+    auto_save_session=True,              # save each session to memory automatically
+)
+```
+
+- `long_term_memory=...` gives the agent a **`load_memory`** tool to search past
+  sessions.
+- `auto_save_session=True` writes each finished session into long-term memory.
+
+In this example, session #1 tells the agent about dietary restrictions;
+session #2 is a *brand-new* conversation, yet the agent recalls them by
+searching memory (not from its context window).
+
+## Requirements
+
+The `local` backend embeds memories, so it needs:
+
+```bash
+pip install "veadk-python[extensions]"
+```
+
+and an embedding model config (`MODEL_EMBEDDING_*`, falls back to
+`MODEL_AGENT_API_KEY`).
+
+## Run it
+
+```bash
+cp .env.example .env   # set MODEL_AGENT_API_KEY (+ embedding config)
+python main.py
+```
+
+Session #2's recommendation should respect the peanut allergy and vegetarian
+preference from session #1.
+
+## What to try next
+
+- Short-term vs long-term: see [03](../03_short_term_memory/) for the
+  in-session kind.
+- Swap `backend="local"` for a persistent store (`viking`, `redis`, `opensearch`,
+  `mem0`) so memories survive process restarts.

--- a/examples/09_long_term_memory/README.zh.md
+++ b/examples/09_long_term_memory/README.zh.md
@@ -1,0 +1,47 @@
+# 09 · 长期记忆
+
+*跨对话*记住事实。短期记忆（[03](../03_short_term_memory/)）作用于单段会话内，
+而长期记忆能跨越不同会话（乃至不同用户）持久保存，并在需要时被检索。
+
+> English version: [README.md](./README.md)
+
+## 核心思想
+
+```python
+long_term_memory = LongTermMemory(backend="local", app_name="ltm_demo")
+agent = Agent(
+    long_term_memory=long_term_memory,   # 添加 `load_memory` 工具
+    auto_save_session=True,              # 自动把每段会话存入记忆
+)
+```
+
+- `long_term_memory=...` 为智能体添加 **`load_memory`** 工具，用于检索过往会话。
+- `auto_save_session=True` 会在每段会话结束后自动写入长期记忆。
+
+本示例中，会话 #1 告诉智能体饮食限制；会话 #2 是一段*全新*对话，但智能体仍能
+通过检索记忆（而非上下文窗口）回忆起来。
+
+## 前置依赖
+
+`local` 后端需要对记忆做 embedding，因此需要：
+
+```bash
+pip install "veadk-python[extensions]"
+```
+
+以及 embedding 模型配置（`MODEL_EMBEDDING_*`，可回退到 `MODEL_AGENT_API_KEY`）。
+
+## 运行步骤
+
+```bash
+cp .env.example .env   # 填入 MODEL_AGENT_API_KEY（以及 embedding 配置）
+python main.py
+```
+
+会话 #2 的推荐应当尊重会话 #1 中提到的花生过敏与素食偏好。
+
+## 下一步
+
+- 短期 vs 长期：会话内的记忆见 [03](../03_short_term_memory/)。
+- 把 `backend="local"` 换成持久化存储（`viking`、`redis`、`opensearch`、`mem0`），
+  让记忆在进程重启后依然存在。

--- a/examples/09_long_term_memory/main.py
+++ b/examples/09_long_term_memory/main.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Remember things *across* conversations with long-term memory.
+
+Short-term memory (example 03) lives inside one conversation. Long-term memory
+persists facts across *different* sessions and users:
+
+- `long_term_memory=...` gives the agent a `load_memory` tool to search past
+  sessions.
+- `auto_save_session=True` writes each finished session into long-term memory
+  automatically.
+
+So we talk in session #1, then start a brand-new session #2 and the agent can
+still recall what was said — by searching its memory, not its context window.
+
+Uses the `local` backend, which embeds memories and needs:
+
+    pip install "veadk-python[extensions]"
+"""
+
+import asyncio
+
+from veadk import Agent, Runner
+from veadk.memory.long_term_memory import LongTermMemory
+
+APP_NAME = "ltm_demo"
+USER_ID = "user-42"
+
+
+def build_runner() -> Runner:
+    long_term_memory = LongTermMemory(backend="local", app_name=APP_NAME)
+    agent = Agent(
+        name="ltm_agent",
+        instruction=(
+            "You are a personal assistant. When the user asks about something "
+            "they told you before, use the `load_memory` tool to recall it."
+        ),
+        long_term_memory=long_term_memory,
+        auto_save_session=True,  # persist each session to long-term memory
+    )
+    return Runner(agent=agent, app_name=APP_NAME, user_id=USER_ID)
+
+
+async def main() -> None:
+    runner = build_runner()
+
+    # Session #1: share a fact. auto_save_session stores it afterwards.
+    print(
+        "Session 1 ->",
+        await runner.run(
+            messages="记一下：我对花生过敏，而且我是素食者。",
+            session_id="session-1",
+        ),
+    )
+
+    # Session #2: a *different* session. The agent must recall via memory search.
+    print(
+        "Session 2 ->",
+        await runner.run(
+            messages="帮我推荐一道适合我的菜，要考虑我的饮食限制。",
+            session_id="session-2",
+        ),
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/10_agent_routing/.env.example
+++ b/examples/10_agent_routing/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to `.env` and fill in your key.
+
+# --- Agent reasoning model (Volcengine Ark) ---
+# Get an API key at https://console.volcengine.com/ark
+MODEL_AGENT_PROVIDER=openai
+MODEL_AGENT_NAME=doubao-seed-1-6-250615
+MODEL_AGENT_API_BASE=https://ark.cn-beijing.volces.com/api/v3/
+MODEL_AGENT_API_KEY=your-ark-api-key-here

--- a/examples/10_agent_routing/README.md
+++ b/examples/10_agent_routing/README.md
@@ -1,0 +1,48 @@
+# 10 · Agent routing (dynamic delegation)
+
+A coordinator agent that **decides at runtime** which specialist to hand each
+request to. This is the counterpart to the fixed pipeline in
+[06](../06_multi_agent/): there the order is hard-coded, here the LLM routes.
+
+> 中文版见 [README.zh.md](./README.zh.md)
+
+## Core idea
+
+```python
+coordinator = Agent(
+    instruction="You are a router. Transfer to the right specialist.",
+    sub_agents=[finance_agent, translator_agent],
+)
+```
+
+Give a regular `Agent` a list of `sub_agents` and it can **transfer** the
+conversation to whichever one fits. The coordinator chooses based on each
+sub-agent's **`description`** — so those descriptions are effectively the routing
+table. Write them for the router.
+
+In this example:
+
+- "100 USD to CNY?" → routed to `finance_agent` (which calls
+  `get_exchange_rate`).
+- "Translate ..." → routed to `translator_agent`.
+
+## Run it
+
+```bash
+pip install veadk-python
+cp .env.example .env   # then set MODEL_AGENT_API_KEY
+python main.py
+```
+
+## SequentialAgent vs routing
+
+| | Order | Decided by |
+| --- | --- | --- |
+| [06 SequentialAgent](../06_multi_agent/) | Fixed (A→B→C) | You |
+| 10 Routing (this) | Dynamic | The LLM coordinator |
+
+## What to try next
+
+- Add a third specialist (e.g. a `weather_agent`) and watch the coordinator
+  pick it.
+- Combine: a routed specialist can itself be a `SequentialAgent`.

--- a/examples/10_agent_routing/README.zh.md
+++ b/examples/10_agent_routing/README.zh.md
@@ -1,0 +1,44 @@
+# 10 · 智能体路由（动态委派）
+
+一个协调者智能体，在**运行时决定**把每个请求交给哪个专家。这与
+[06](../06_multi_agent/) 的固定流水线相对：那里顺序写死，这里由大模型来路由。
+
+> English version: [README.md](./README.md)
+
+## 核心思想
+
+```python
+coordinator = Agent(
+    instruction="你是一个路由器，把请求转交给合适的专家。",
+    sub_agents=[finance_agent, translator_agent],
+)
+```
+
+给普通 `Agent` 一个 `sub_agents` 列表，它就能把对话**转交（transfer）**给最合适的那个。
+协调者依据每个子智能体的 **`description`** 来选择 —— 因此这些描述实际上就是路由表。
+请为路由器而写好这些描述。
+
+本示例中：
+
+- “100 美元换多少人民币？” → 路由到 `finance_agent`（调用 `get_exchange_rate`）。
+- “翻译……” → 路由到 `translator_agent`。
+
+## 运行步骤
+
+```bash
+pip install veadk-python
+cp .env.example .env   # 然后填入 MODEL_AGENT_API_KEY
+python main.py
+```
+
+## SequentialAgent 与路由的区别
+
+| | 顺序 | 由谁决定 |
+| --- | --- | --- |
+| [06 SequentialAgent](../06_multi_agent/) | 固定（A→B→C） | 你 |
+| 10 路由（本例） | 动态 | 大模型协调者 |
+
+## 下一步
+
+- 增加第三个专家（如 `weather_agent`），观察协调者如何选择。
+- 组合使用：被路由到的专家本身也可以是一个 `SequentialAgent`。

--- a/examples/10_agent_routing/main.py
+++ b/examples/10_agent_routing/main.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dynamic routing: a coordinator that delegates to specialist sub-agents.
+
+Unlike the fixed pipeline in example 06 (`SequentialAgent`), here a regular
+`Agent` is given `sub_agents=[...]` and the LLM itself decides which specialist
+to hand the request to (this is the ADK "transfer" / agent-as-router pattern).
+
+The key is each sub-agent's `description`: that's what the coordinator reads to
+choose where to route. Write descriptions for the router, not just for humans.
+"""
+
+import asyncio
+
+from veadk import Agent, Runner
+
+
+def get_exchange_rate(base: str, quote: str) -> dict[str, float]:
+    """Get a (mock) currency exchange rate.
+
+    Args:
+        base: ISO code of the base currency, e.g. "USD".
+        quote: ISO code of the quote currency, e.g. "CNY".
+    """
+    rates = {("USD", "CNY"): 7.18, ("EUR", "CNY"): 7.80, ("USD", "EUR"): 0.92}
+    return {"rate": rates.get((base.upper(), quote.upper()), 1.0)}
+
+
+def build_coordinator() -> Agent:
+    finance_agent = Agent(
+        name="finance_agent",
+        description="Handles money, currencies, and exchange-rate questions.",
+        instruction="Answer finance questions. Use get_exchange_rate for conversions.",
+        tools=[get_exchange_rate],
+    )
+
+    translator_agent = Agent(
+        name="translator_agent",
+        description="Translates text between languages.",
+        instruction="Translate exactly what the user asks, and nothing else.",
+    )
+
+    return Agent(
+        name="coordinator",
+        description="Front desk that routes requests to the right specialist.",
+        instruction=(
+            "You are a router. Decide which specialist should handle the user's "
+            "request and transfer to it. Do not answer specialist questions "
+            "yourself."
+        ),
+        sub_agents=[finance_agent, translator_agent],
+    )
+
+
+async def main() -> None:
+    runner = Runner(agent=build_coordinator(), app_name="agent_routing")
+
+    print(
+        "Q1 ->",
+        await runner.run(
+            messages="100 美元能换多少人民币？",
+            session_id="demo-1",
+        ),
+    )
+
+    print(
+        "Q2 ->",
+        await runner.run(
+            messages="把“今天天气真好”翻译成英文。",
+            session_id="demo-2",
+        ),
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/11_tracing/.env.example
+++ b/examples/11_tracing/.env.example
@@ -1,0 +1,18 @@
+# Copy this file to `.env` and fill in your key.
+
+# --- Agent reasoning model (Volcengine Ark) ---
+# Get an API key at https://console.volcengine.com/ark
+MODEL_AGENT_PROVIDER=openai
+MODEL_AGENT_NAME=doubao-seed-1-6-250615
+MODEL_AGENT_API_BASE=https://ark.cn-beijing.volces.com/api/v3/
+MODEL_AGENT_API_KEY=your-ark-api-key-here
+
+# --- Optional: ship traces to a Volcengine observability platform ---
+# Uncomment + configure to export instead of (or in addition to) the local dump.
+# ENABLE_COZELOOP=true
+# OBSERVABILITY_OPENTELEMETRY_COZELOOP_API_KEY=your-cozeloop-api-key
+# OBSERVABILITY_OPENTELEMETRY_COZELOOP_SERVICE_NAME=your-cozeloop-space-id
+#
+# ENABLE_APMPLUS=true
+# OBSERVABILITY_OPENTELEMETRY_APMPLUS_API_KEY=your-apmplus-api-key
+# OBSERVABILITY_OPENTELEMETRY_APMPLUS_SERVICE_NAME=your-service-name

--- a/examples/11_tracing/README.md
+++ b/examples/11_tracing/README.md
@@ -1,0 +1,53 @@
+# 11 · Tracing & observability
+
+See exactly what the agent did — every LLM call and tool call — by attaching a
+tracer. Each run gets a `trace_id` you can search in an observability platform.
+
+> 中文版见 [README.zh.md](./README.zh.md)
+
+## Core idea
+
+```python
+from veadk.tracing.telemetry.opentelemetry_tracer import OpentelemetryTracer
+
+tracer = OpentelemetryTracer()
+agent = Agent(tracers=[tracer], tools=[...])
+
+answer = await runner.run(messages="...", session_id="demo-session")
+runner.get_trace_id()    # the trace id to correlate in your backend
+```
+
+- **`tracers=[...]`** — attach one or more tracers to the agent.
+- Each LLM call and tool call becomes a span with timing, inputs, and outputs.
+- **`runner.get_trace_id()`** — the id that ties those spans together; search it
+  in your observability platform's UI.
+
+## Run it
+
+```bash
+pip install veadk-python
+cp .env.example .env   # then set MODEL_AGENT_API_KEY
+python main.py
+```
+
+The script prints the answer and the trace id.
+
+> ℹ️ The local `runner.save_tracing_file(...)` dump is intentionally omitted
+> here: on the current VeADK + Google ADK 2.0 combination its session→trace
+> filter can return an empty file. The platform exporters below are the reliable
+> way to inspect traces.
+
+## Exporting to a platform
+
+To ship traces to **CozeLoop**, **APMPlus**, or **TLS** instead of (or in
+addition to) the local dump, set the corresponding env vars — VeADK wires up the
+exporters automatically:
+
+```bash
+ENABLE_COZELOOP=true
+OBSERVABILITY_OPENTELEMETRY_COZELOOP_API_KEY=...
+OBSERVABILITY_OPENTELEMETRY_COZELOOP_SERVICE_NAME=...   # space id
+```
+
+See `.env.example` for the APMPlus equivalents and the
+[configuration docs](https://volcengine.github.io/veadk-python/) for the rest.

--- a/examples/11_tracing/README.zh.md
+++ b/examples/11_tracing/README.zh.md
@@ -1,0 +1,50 @@
+# 11 · 链路追踪与可观测性
+
+通过挂载 tracer，清楚地看到智能体做了什么 —— 每一次大模型调用、每一次工具调用。
+每次运行都会得到一个 `trace_id`，可在可观测平台中检索。
+
+> English version: [README.md](./README.md)
+
+## 核心思想
+
+```python
+from veadk.tracing.telemetry.opentelemetry_tracer import OpentelemetryTracer
+
+tracer = OpentelemetryTracer()
+agent = Agent(tracers=[tracer], tools=[...])
+
+answer = await runner.run(messages="...", session_id="demo-session")
+runner.get_trace_id()    # 用于在后端平台关联检索的 trace id
+```
+
+- **`tracers=[...]`** —— 为智能体挂载一个或多个 tracer。
+- 每一次大模型调用与工具调用都会成为一个 span，包含耗时、输入与输出。
+- **`runner.get_trace_id()`** —— 串联这些 span 的 id；在可观测平台 UI 中检索它。
+
+## 运行步骤
+
+```bash
+pip install veadk-python
+cp .env.example .env   # 然后填入 MODEL_AGENT_API_KEY
+python main.py
+```
+
+脚本会打印回答与 trace id。
+
+> ℹ️ 这里有意没有演示本地的 `runner.save_tracing_file(...)` 导出：在当前
+> VeADK + Google ADK 2.0 的组合下，其“会话→trace”过滤可能返回空文件。
+> 下方的平台 exporter 才是查看 trace 的可靠方式。
+
+## 导出到平台
+
+若想把 trace 上报到 **CozeLoop**、**APMPlus** 或 **TLS**（替代或叠加本地导出），
+只需设置对应的环境变量，VeADK 会自动接好 exporter：
+
+```bash
+ENABLE_COZELOOP=true
+OBSERVABILITY_OPENTELEMETRY_COZELOOP_API_KEY=...
+OBSERVABILITY_OPENTELEMETRY_COZELOOP_SERVICE_NAME=...   # space id
+```
+
+APMPlus 的等价配置见 `.env.example`，其余配置见
+[配置文档](https://volcengine.github.io/veadk-python/)。

--- a/examples/11_tracing/main.py
+++ b/examples/11_tracing/main.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Observe what the agent did with tracing.
+
+Attach a tracer via `tracers=[...]`. Every LLM call and tool call becomes a span,
+and the run gets a `trace_id` you can correlate in an observability backend.
+
+To ship traces to a platform, set the matching env vars
+(`ENABLE_COZELOOP=true`, `ENABLE_APMPLUS=true`, `ENABLE_TLS=true`) and configure
+their endpoints/keys; VeADK wires up the exporters automatically and you can then
+search for the printed `trace_id` in that platform's UI.
+"""
+
+import asyncio
+
+from veadk import Agent, Runner
+from veadk.tracing.telemetry.opentelemetry_tracer import OpentelemetryTracer
+
+SESSION_ID = "demo-session"
+
+
+def get_city_weather(city: str) -> dict[str, str]:
+    """Get the current weather for a city.
+
+    Args:
+        city: The English name of the city, e.g. "Beijing".
+    """
+    return {"result": {"beijing": "Sunny, 25°C"}.get(city.lower(), "Unknown")}
+
+
+async def main() -> None:
+    tracer = OpentelemetryTracer()
+
+    agent = Agent(
+        name="traced_agent",
+        instruction="Help with weather. Use get_city_weather when asked.",
+        tools=[get_city_weather],
+        tracers=[tracer],
+    )
+
+    runner = Runner(agent=agent, app_name="tracing_demo")
+
+    answer = await runner.run(messages="北京今天天气怎么样？", session_id=SESSION_ID)
+    print("Answer:", answer)
+
+    # Each LLM/tool call was recorded as a span under this trace id. With a
+    # platform exporter enabled (see README), search this id in its UI.
+    print("Trace id:", runner.get_trace_id())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,78 @@
+# VeADK Examples
+
+A hands-on tour of VeADK, from the smallest possible agent to a multi-agent
+workflow. Each folder is self-contained: a single `main.py`, an `.env.example`,
+and a bilingual README (English + 中文).
+
+> 中文版见 [README.zh.md](./README.zh.md)
+
+## Learning path
+
+| # | Example | Level | What you'll learn |
+| --- | --- | --- | --- |
+| 01 | [Quickstart](./01_quickstart/) | Simple | `Agent` + `Runner`, one question |
+| 02 | [Custom tools](./02_custom_tools/) | Simple | Let the agent call your Python functions |
+| 03 | [Short-term memory](./03_short_term_memory/) | Medium | Multi-turn conversation with a persistent session |
+| 04 | [Web search](./04_web_search/) | Medium | Use a built-in Volcengine tool |
+| 05 | [Knowledgebase RAG](./05_knowledgebase_rag/) | Medium | Ground answers in your own documents |
+| 06 | [Multi-agent workflow](./06_multi_agent/) | Complex | Compose specialist agents with `SequentialAgent` |
+| 07 | [Structured output](./07_structured_output/) | Medium | Get schema-validated JSON with `output_schema` |
+| 08 | [Model config](./08_model_config/) | Simple | Model fallbacks + `model_extra_config` per agent |
+| 09 | [Long-term memory](./09_long_term_memory/) | Complex | Recall facts across sessions (`auto_save_session`) |
+| 10 | [Agent routing](./10_agent_routing/) | Complex | A coordinator that delegates to specialists dynamically |
+| 11 | [Tracing](./11_tracing/) | Complex | Observe LLM/tool calls; dump or export spans |
+
+There is also [`a2ui_agent/`](./a2ui_agent/) — a demo of agent-driven UI, run with
+`veadk frontend --agents-dir examples`.
+
+For a deployable **full app** (web UI + agent API in one container, shipped to
+Volcengine AgentKit via `veadk agentkit`), see [`basic-app/`](./basic-app/).
+
+The examples are grouped by concept: 01–02 basics, 03 & 09 memory, 04–05 tools &
+knowledge, 06 & 10 multi-agent, 07–08 model behavior, 11 observability.
+
+## Common setup
+
+1. Install VeADK (examples 05 needs the `extensions` extra):
+
+   ```bash
+   pip install veadk-python
+   # for the RAG example:
+   pip install "veadk-python[extensions]"
+   ```
+
+2. In each example folder, copy the env template and add your keys:
+
+   ```bash
+   cd 01_quickstart
+   cp .env.example .env
+   ```
+
+   VeADK auto-loads `.env` from the current working directory. You can also
+   use a `config.yaml` instead — see the
+   [configuration docs](https://volcengine.github.io/veadk-python/configuration/).
+
+3. Run:
+
+   ```bash
+   python main.py
+   ```
+
+## Key concepts in one place
+
+- **`Agent`** — model + instruction + tools + memory/knowledge. Created once,
+  reads model config from the environment.
+- **`Runner`** — drives a conversation; `await runner.run(messages=..., session_id=...)`
+  returns the final text answer.
+- **Tools** — any Python function with type hints and a docstring; built-ins live
+  under `veadk.tools.builtin_tools`.
+- **Memory** — short-term (conversation context, keyed by `session_id`) and
+  long-term (across sessions).
+- **KnowledgeBase** — RAG over your documents; auto-adds a retrieval tool.
+- **Workflow agents** — `SequentialAgent`, `ParallelAgent`, `LoopAgent` to
+  orchestrate multiple agents.
+
+## Learn more
+
+- Docs: <https://volcengine.github.io/veadk-python/>
+- Tutorial notebook: [`veadk_tutorial.ipynb`](../veadk_tutorial.ipynb)

--- a/examples/README.zh.md
+++ b/examples/README.zh.md
@@ -1,0 +1,72 @@
+# VeADK 示例
+
+一份动手实践的 VeADK 上手指南，从最小可运行的智能体，一路到多智能体工作流。
+每个目录都自成一体：一个 `main.py`、一个 `.env.example`，以及中英双语 README。
+
+> English version: [README.md](./README.md)
+
+## 学习路径
+
+| # | 示例 | 难度 | 你将学到 |
+| --- | --- | --- | --- |
+| 01 | [快速开始](./01_quickstart/) | 简单 | `Agent` + `Runner`，一问一答 |
+| 02 | [自定义工具](./02_custom_tools/) | 简单 | 让智能体调用你的 Python 函数 |
+| 03 | [短期记忆](./03_short_term_memory/) | 中等 | 带持久会话的多轮对话 |
+| 04 | [联网搜索](./04_web_search/) | 中等 | 使用内置的火山引擎工具 |
+| 05 | [知识库 RAG](./05_knowledgebase_rag/) | 中等 | 让回答基于你自己的文档 |
+| 06 | [多智能体工作流](./06_multi_agent/) | 复杂 | 用 `SequentialAgent` 组合多个专家智能体 |
+| 07 | [结构化输出](./07_structured_output/) | 中等 | 用 `output_schema` 获得经校验的 JSON |
+| 08 | [模型配置](./08_model_config/) | 简单 | 模型回退 + 每个智能体的 `model_extra_config` |
+| 09 | [长期记忆](./09_long_term_memory/) | 复杂 | 跨会话回忆事实（`auto_save_session`） |
+| 10 | [智能体路由](./10_agent_routing/) | 复杂 | 协调者动态委派给专家智能体 |
+| 11 | [链路追踪](./11_tracing/) | 复杂 | 观测大模型/工具调用；导出 span |
+
+另外还有 [`a2ui_agent/`](./a2ui_agent/) —— 一个由智能体驱动 UI 的示例，
+可通过 `veadk frontend --agents-dir examples` 运行。
+
+如需一个可部署的**完整应用**（Web 前端 + Agent API 同处一个容器，通过
+`veadk agentkit` 部署到火山引擎 AgentKit），参见 [`basic-app/`](./basic-app/)。
+
+这些示例按概念分组：01–02 基础，03 与 09 记忆，04–05 工具与知识，
+06 与 10 多智能体，07–08 模型行为，11 可观测性。
+
+## 通用准备
+
+1. 安装 VeADK（示例 05 需要 `extensions` 扩展）：
+
+   ```bash
+   pip install veadk-python
+   # RAG 示例需要：
+   pip install "veadk-python[extensions]"
+   ```
+
+2. 在每个示例目录下，复制环境变量模板并填入你的密钥：
+
+   ```bash
+   cd 01_quickstart
+   cp .env.example .env
+   ```
+
+   VeADK 会自动从当前工作目录加载 `.env`。你也可以改用 `config.yaml`，
+   详见[配置文档](https://volcengine.github.io/veadk-python/configuration/)。
+
+3. 运行：
+
+   ```bash
+   python main.py
+   ```
+
+## 核心概念一览
+
+- **`Agent`** —— 模型 + 指令 + 工具 + 记忆/知识。创建一次即可，自动从环境读取模型配置。
+- **`Runner`** —— 驱动一次对话；`await runner.run(messages=..., session_id=...)` 返回最终回答文本。
+- **工具（Tools）** —— 任意带类型注解和 docstring 的 Python 函数；内置工具位于
+  `veadk.tools.builtin_tools`。
+- **记忆（Memory）** —— 短期记忆（对话上下文，按 `session_id` 区分）与长期记忆（跨会话）。
+- **知识库（KnowledgeBase）** —— 对你的文档做 RAG，自动添加检索工具。
+- **工作流智能体** —— `SequentialAgent`、`ParallelAgent`、`LoopAgent`，用于编排多个智能体。
+
+## 了解更多
+
+- 文档：<https://volcengine.github.io/veadk-python/>
+- 教程 Notebook：[`veadk_tutorial.ipynb`](../veadk_tutorial.ipynb)

--- a/examples/a2ui_agent/__init__.py
+++ b/examples/a2ui_agent/__init__.py
@@ -1,0 +1,3 @@
+from . import agent
+
+__all__ = ["agent"]

--- a/examples/a2ui_agent/__init__.py
+++ b/examples/a2ui_agent/__init__.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from . import agent
 
 __all__ = ["agent"]

--- a/examples/a2ui_agent/agent.py
+++ b/examples/a2ui_agent/agent.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Demo agent showcasing A2UI (agent-driven UI).
+
+Run it with the bundled web UI:
+
+    veadk frontend --agents-dir examples
+
+then open http://127.0.0.1:8000 and ask e.g. "show me a flight status card".
+"""
+
+from veadk import Agent
+
+INSTRUCTION = """You are a helpful assistant that can render rich UI.
+
+When the answer is naturally visual or structured (a status card, a summary, a
+list of options, a small form), reply by calling the `send_a2ui_json_to_client`
+tool with A2UI JSON built ONLY from the components in the provided catalog
+(Card, Column, Row, Text, Icon, Button, Divider, ...). Put a `Card` at the root,
+lay content out with `Column`/`Row`, and use `Text` with a `variant` for
+headings. For everything else, just answer in plain text.
+"""
+
+agent = Agent(
+    name="a2ui_agent",
+    description="Demo agent that replies with A2UI rich UI.",
+    instruction=INSTRUCTION,
+    enable_a2ui=True,
+)
+
+# Required by the Google ADK agent loader.
+root_agent = agent

--- a/examples/basic-app/.dockerignore
+++ b/examples/basic-app/.dockerignore
@@ -1,0 +1,28 @@
+# AgentKit configuration
+agentkit.yaml
+agentkit*.yaml
+.agentkit/
+
+# Python cache
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env/
+
+# IDE
+.vscode/
+.idea/
+.windsurf/
+
+# Git
+.git/
+.gitignore
+
+# Docker
+Dockerfile*
+.dockerignore

--- a/examples/basic-app/.env.example
+++ b/examples/basic-app/.env.example
@@ -1,0 +1,14 @@
+# Copy this file to `.env` and fill in your keys.
+# VeADK auto-loads `.env` from the current working directory.
+
+# --- Agent reasoning model (Volcengine Ark) ---
+# Get an API key at https://console.volcengine.com/ark
+MODEL_AGENT_PROVIDER=openai
+MODEL_AGENT_NAME=doubao-seed-1-6-250615
+MODEL_AGENT_API_BASE=https://ark.cn-beijing.volces.com/api/v3/
+MODEL_AGENT_API_KEY=your-ark-api-key-here
+
+# --- Volcengine AK/SK (required by `veadk agentkit` to build & deploy) ---
+# Create access keys at https://console.volcengine.com/iam/keymanage
+VOLCENGINE_ACCESS_KEY=your-volcengine-access-key
+VOLCENGINE_SECRET_KEY=your-volcengine-secret-key

--- a/examples/basic-app/README.md
+++ b/examples/basic-app/README.md
@@ -1,0 +1,93 @@
+# basic-app · Deploy a front+back agent to Volcengine AgentKit
+
+A minimal **full app**: one container that serves both the agent API and a web
+UI, deployed to [Volcengine AgentKit](https://www.volcengine.com/) with the
+`veadk agentkit` command.
+
+> 中文版见 [README.zh.md](./README.zh.md)
+
+## What's inside
+
+```text
+basic-app/
+├── app.py                       # front+back server (the deploy entry point)
+├── agents/
+│   └── basic_app_agent/         # backend agent (A2UI on), exposes root_agent
+├── agentkit.yaml                # AgentKit deployment config (build_script wired)
+├── scripts/install_veadk.sh     # installs veadk[a2ui] from feat/a2ui (build time)
+├── requirements.txt             # empty (veadk is installed by the build script)
+├── .dockerignore
+└── .env.example
+```
+
+- **Backend** — `agents/basic_app_agent` is a normal VeADK `Agent` with
+  `enable_a2ui=True`, so it can answer with rich, declarative UI.
+- **Frontend** — the built web UI ships **inside the veadk package**
+  (`veadk/webui`). `app.py` mounts it, so once veadk[a2ui] is installed the
+  container has everything — there is nothing to bundle into this project.
+- **One process** — `app.py` builds the Google ADK FastAPI app
+  (`/list-apps`, `/run_sse`, sessions, ...) and mounts the UI at `/`, on
+  port 8000. AgentKit runs it with `python -m app`.
+
+> The frontend (`veadk/webui`) and the A2UI Python support aren't on PyPI/`main`
+> yet — they live on the **`feat/a2ui`** branch. So the image installs veadk
+> from that branch via `scripts/install_veadk.sh` (a **shallow + sparse** clone
+> over HTTP/1.1 that fetches only the `veadk/` package). A plain
+> `pip install git+...@feat/a2ui` also works in theory, but a full clone of the
+> repo's large docs history is slow/flaky in the build network, hence the
+> targeted clone.
+
+## 1. Configure
+
+```bash
+cd examples/basic-app
+cp .env.example .env
+# edit .env: MODEL_AGENT_API_KEY + VOLCENGINE_ACCESS_KEY / VOLCENGINE_SECRET_KEY
+```
+
+`veadk agentkit` uses the Volcengine AK/SK to build and deploy.
+
+## 2. Run locally (optional)
+
+```bash
+pip install "veadk-python[a2ui]"
+python app.py            # or: python -m app
+# open http://127.0.0.1:8000
+```
+
+You should see the web UI; ask e.g. "show me a flight status card" and the agent
+replies with rich A2UI. `/list-apps` returns `["basic_app_agent"]` and `/ping`
+returns `{"status": "ok"}`.
+
+## 3. Deploy to AgentKit
+
+```bash
+# fill in account-specific fields in agentkit.yaml (interactive)
+veadk agentkit config
+
+# build the image and deploy in one step
+veadk agentkit launch
+
+# check status / send a test request once it's live
+veadk agentkit status
+veadk agentkit invoke "你好，做一张今天的天气卡片"
+```
+
+`veadk agentkit launch` = `build` + `deploy`. Use `veadk agentkit destroy` to
+tear the runtime down.
+
+## How the frontend reaches the container
+
+AgentKit builds a Docker image whose build context is **this directory**
+(`COPY . .`) and runs `python -m app`. The web UI is *not* copied from here — it
+arrives **inside the veadk package** (`veadk/webui`) when the build script
+installs `veadk[a2ui]` from the `feat/a2ui` branch. `scripts/install_veadk.sh`
+is wired via `docker_build.build_script` in `agentkit.yaml` and runs during the
+image build.
+
+Why a build script rather than a one-line `pip install git+...`: a full clone of
+the veadk repo (large docs/image history) repeatedly failed mid-fetch in the
+build network (`curl 92 HTTP/2 stream not closed cleanly`). The script makes the
+fetch tiny and reliable — `--depth 1 --filter=blob:none --sparse` so it pulls
+only the `veadk/` package, over HTTP/1.1, with retries (~4 MB instead of the
+whole repo).

--- a/examples/basic-app/README.zh.md
+++ b/examples/basic-app/README.zh.md
@@ -1,0 +1,86 @@
+# basic-app · 向火山引擎 AgentKit 部署一个带前后端的 Agent
+
+一个最小的**完整应用**：单个容器同时提供 Agent API 与 Web 前端，使用
+`veadk agentkit` 命令部署到[火山引擎 AgentKit](https://www.volcengine.com/)。
+
+> English version: [README.md](./README.md)
+
+## 目录结构
+
+```text
+basic-app/
+├── app.py                       # 前后端一体服务（部署入口）
+├── agents/
+│   └── basic_app_agent/         # 后端 Agent（已开启 A2UI），暴露 root_agent
+├── agentkit.yaml                # AgentKit 部署配置（已接入 build_script）
+├── scripts/install_veadk.sh     # 构建时从 feat/a2ui 安装 veadk[a2ui]
+├── requirements.txt             # 留空（veadk 由构建脚本安装）
+├── .dockerignore
+└── .env.example
+```
+
+- **后端** —— `agents/basic_app_agent` 是一个普通的 VeADK `Agent`，开启了
+  `enable_a2ui=True`，因此可以用富文本、声明式 UI 作答。
+- **前端** —— 构建好的 Web UI **随 veadk 包一起发布**（位于 `veadk/webui`）。
+  `app.py` 会挂载它，所以只要装好 veadk[a2ui]，容器就具备了全部内容，
+  无需额外打包前端。
+- **单进程** —— `app.py` 构建 Google ADK 的 FastAPI 应用
+  （`/list-apps`、`/run_sse`、会话等），并把 UI 挂载到 `/`，监听 8000 端口。
+  AgentKit 用 `python -m app` 运行它。
+
+> 前端（`veadk/webui`）与 A2UI 的 Python 支持尚未发布到 PyPI/`main`，它们在
+> **`feat/a2ui`** 分支上。因此镜像通过 `scripts/install_veadk.sh` 从该分支安装
+> veadk —— 用**浅克隆 + sparse**、走 HTTP/1.1，只拉取 `veadk/` 包。理论上
+> `pip install git+...@feat/a2ui` 也可以，但仓库庞大的 docs 历史会让整仓克隆在
+> 构建网络里很慢且不稳定，所以改用这种定向克隆。
+
+## 1. 配置
+
+```bash
+cd examples/basic-app
+cp .env.example .env
+# 编辑 .env：MODEL_AGENT_API_KEY + VOLCENGINE_ACCESS_KEY / VOLCENGINE_SECRET_KEY
+```
+
+`veadk agentkit` 会使用火山引擎 AK/SK 进行构建与部署。
+
+## 2. 本地运行（可选）
+
+```bash
+pip install "veadk-python[a2ui]"
+python app.py            # 或：python -m app
+# 打开 http://127.0.0.1:8000
+```
+
+你应当能看到 Web UI；试着问“给我一张航班状态卡片”，Agent 会用富 A2UI 作答。
+`/list-apps` 返回 `["basic_app_agent"]`，`/ping` 返回 `{"status": "ok"}`。
+
+## 3. 部署到 AgentKit
+
+```bash
+# 交互式填写 agentkit.yaml 中与账号相关的字段
+veadk agentkit config
+
+# 一步完成镜像构建与部署
+veadk agentkit launch
+
+# 上线后查看状态 / 发送测试请求
+veadk agentkit status
+veadk agentkit invoke "你好，做一张今天的天气卡片"
+```
+
+`veadk agentkit launch` = `build` + `deploy`。使用 `veadk agentkit destroy`
+可销毁运行时。
+
+## 前端是如何进入容器的
+
+AgentKit 构建的 Docker 镜像，其构建上下文就是**当前目录**（`COPY . .`），
+并以 `python -m app` 运行。Web UI 并不是从这里拷贝的 —— 当构建脚本从
+`feat/a2ui` 分支安装 `veadk[a2ui]` 时，它**随 veadk 包**（`veadk/webui`）一起
+进入容器。`scripts/install_veadk.sh` 通过 `agentkit.yaml` 里的
+`docker_build.build_script` 接入，在镜像构建期间执行。
+
+为什么用构建脚本而不是一行 `pip install git+...`：整仓克隆 veadk（庞大的
+docs/图片历史）在构建网络里多次中途失败（`curl 92 HTTP/2 stream not closed
+cleanly`）。脚本让抓取又小又稳 —— `--depth 1 --filter=blob:none --sparse`
+只拉取 `veadk/` 包，走 HTTP/1.1，并带重试（约 4 MB，而非整个仓库）。

--- a/examples/basic-app/agents/basic_app_agent/__init__.py
+++ b/examples/basic-app/agents/basic_app_agent/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import agent
+
+__all__ = ["agent"]

--- a/examples/basic-app/agents/basic_app_agent/agent.py
+++ b/examples/basic-app/agents/basic_app_agent/agent.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The backend agent for the basic-app demo.
+
+It enables A2UI (agent-driven UI) so the bundled web frontend can render rich,
+declarative UI (cards, lists, forms) in addition to plain text. The Google ADK
+agent loader picks up `root_agent` from this module.
+"""
+
+from veadk import Agent
+
+INSTRUCTION = """You are a helpful assistant that can render rich UI.
+
+When the answer is naturally visual or structured (a status card, a summary, a
+list of options, a small form), reply by calling the `send_a2ui_json_to_client`
+tool with A2UI JSON built ONLY from the components in the provided catalog
+(Card, Column, Row, Text, Icon, Button, Divider, ...). Put a `Card` at the root,
+lay content out with `Column`/`Row`, and use `Text` with a `variant` for
+headings. For everything else, just answer in plain text.
+"""
+
+agent = Agent(
+    name="basic_app_agent",
+    description="Basic front+back demo agent that can reply with A2UI rich UI.",
+    instruction=INSTRUCTION,
+    enable_a2ui=True,
+)
+
+# Required by the Google ADK agent loader.
+root_agent = agent

--- a/examples/basic-app/app.py
+++ b/examples/basic-app/app.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deployable front+back server for the basic-app demo.
+
+One process serves BOTH:
+- the agent API (Google ADK FastAPI app: /list-apps, /run_sse, sessions, ...)
+- the A2UI web frontend, which ships inside the installed veadk package at
+  `veadk/webui` (so a plain `pip install veadk-python[a2ui]` is enough — there
+  is nothing to bundle into this project).
+
+AgentKit runs this container with `python -m app` on port 8000, which is exactly
+what this module does. Locally it is equivalent to `veadk frontend
+--agents-dir examples/basic-app/agents`.
+"""
+
+import os
+from pathlib import Path
+
+import uvicorn
+import veadk
+from fastapi.staticfiles import StaticFiles
+from google.adk.cli.fast_api import get_fast_api_app
+
+# Agent apps live next to this file; each subdir exposes a `root_agent`.
+AGENTS_DIR = str(Path(__file__).resolve().parent / "agents")
+
+# The built UI shipped with the veadk package (committed at veadk/webui).
+WEBUI_DIR = Path(veadk.__file__).resolve().parent / "webui"
+
+HOST = os.getenv("HOST", "0.0.0.0")
+PORT = int(os.getenv("PORT", "8000"))
+
+
+def build_app():
+    app = get_fast_api_app(agents_dir=AGENTS_DIR, web=False)
+
+    # A simple health endpoint for the runtime's liveness checks.
+    @app.get("/ping")
+    def ping() -> dict[str, str]:
+        return {"status": "ok"}
+
+    if (WEBUI_DIR / "index.html").is_file():
+        # Mount last so it doesn't shadow the API routes registered above.
+        app.mount("/", StaticFiles(directory=str(WEBUI_DIR), html=True), name="webui")
+    return app
+
+
+app = build_app()
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host=HOST, port=PORT)

--- a/examples/basic-app/requirements.txt
+++ b/examples/basic-app/requirements.txt
@@ -1,0 +1,4 @@
+# veadk-python[a2ui] is installed from the feat/a2ui branch by the build script
+# (scripts/install_veadk.sh, wired via docker_build.build_script in agentkit.yaml)
+# using a shallow + sparse clone, because the frontend (veadk/webui) and the
+# a2ui Python support are not on PyPI yet. Nothing to install here.

--- a/examples/basic-app/scripts/install_veadk.sh
+++ b/examples/basic-app/scripts/install_veadk.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Install veadk-python (with the a2ui extra) from the feat/a2ui branch.
+#
+# Why a build script instead of a plain `pip install git+...`:
+#   The veadk repo carries a large docs/ image history, and a full git clone of
+#   it from the build network repeatedly failed mid-fetch
+#   ("curl 92 HTTP/2 stream not closed cleanly"). Here we make the fetch small
+#   and robust:
+#     - --depth 1            : only the tip commit, no history
+#     - --filter=blob:none   : download blobs lazily
+#     - --sparse + set veadk : fetch only the veadk/ package (incl. veadk/webui),
+#                              skipping docs/ images entirely
+#     - HTTP/1.1             : avoids the HTTP/2 stream error seen above
+#   This pulls a few MB instead of the whole repo, so it is fast and reliable.
+set -e
+
+BRANCH="feat/a2ui"
+REPO="https://github.com/volcengine/veadk-python.git"
+SRC="/tmp/veadk-src"
+
+git config --global http.version HTTP/1.1
+git config --global http.postBuffer 524288000
+
+n=0
+until [ "$n" -ge 3 ]; do
+    rm -rf "$SRC"
+    if git clone --depth 1 --filter=blob:none --sparse --branch "$BRANCH" "$REPO" "$SRC"; then
+        break
+    fi
+    n=$((n + 1))
+    echo "git clone failed, retry $n/3..."
+    sleep 5
+done
+
+cd "$SRC"
+git sparse-checkout set veadk
+uv pip install ".[a2ui]"


### PR DESCRIPTION
A runnable, bilingual (EN/zh) example set under examples/, from simplest to most advanced:
- 01 quickstart, 02 custom tools, 03 short-term memory, 04 web search, 05 knowledgebase RAG, 06 multi-agent, 07 structured output, 08 model config, 09 long-term memory, 10 agent routing, 11 tracing
- basic-app: a front+back agent (A2UI web UI + agent API) deployable to Volcengine AgentKit via 'veadk agentkit' Each example ships a main.py, .env.example, and README.md + README.zh.md.