### PR TITLE
feat(docs): add Ask-AI agent + VeFaaS deploy pipeline

### DIFF
--- a/.github/workflows/deploy-docs-agent.yaml
+++ b/.github/workflows/deploy-docs-agent.yaml
@@ -1,0 +1,53 @@
+name: Deploy Docs Agent
+
+# Auto-deploys the docs "Ask AI" agent to Volcengine VeFaaS whenever the agent
+# (or the docs it indexes) changes. The deployed agent serves the A2A protocol;
+# after deploying, put its public URL into the `AI_CHAT_URL` repo variable so
+# the docs site (deploy-docs.yaml) can talk to it.
+
+# Deploy uses Volcengine AK/SK from secrets — the GITHUB_TOKEN only needs to
+# read the repo for checkout.
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/ask-ai-agent/**'
+      - 'docs/content/docs/**'           # docs changed -> rebuild the search index
+      - '.github/workflows/deploy-docs-agent.yaml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install VeADK
+        run: pip install .
+
+      - name: Rebuild docs search index
+        run: python docs/ask-ai-agent/build_index.py
+
+      - name: Deploy to VeFaaS
+        env:
+          VOLCENGINE_ACCESS_KEY: ${{ secrets.VOLCENGINE_ACCESS_KEY }}
+          VOLCENGINE_SECRET_KEY: ${{ secrets.VOLCENGINE_SECRET_KEY }}
+          # The deployed agent gets its Ark token from the VeFaaS IAM role, so no
+          # model API key is needed at runtime — only the model name.
+          MODEL_AGENT_NAME: deepseek-v4-flash-260425
+        run: |
+          ARGS="--vefaas-app-name ${{ vars.VEFAAS_APP_NAME || 'veadk-docs-assistant' }} --path docs/ask-ai-agent"
+          if [ -n "${{ vars.VEFAAS_IAM_ROLE }}" ]; then
+            ARGS="$ARGS --iam-role ${{ vars.VEFAAS_IAM_ROLE }}"
+          fi
+          echo "veadk deploy $ARGS"
+          veadk deploy $ARGS

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -30,3 +30,6 @@ next-env.d.ts
 !/lib
 !/lib/**
 !/build
+
+# Generated docs search index for the Ask-AI agent (rebuilt by build_index.py / CI).
+/ask-ai-agent/docs_index.json

--- a/docs/ask-ai-agent/.env.example
+++ b/docs/ask-ai-agent/.env.example
@@ -1,0 +1,16 @@
+# --- Model (Volcengine Ark) — required to actually answer questions ---
+MODEL_AGENT_PROVIDER=openai
+MODEL_AGENT_NAME=doubao-seed-1-6-250615
+MODEL_AGENT_API_BASE=https://ark.cn-beijing.volces.com/api/v3/
+MODEL_AGENT_API_KEY=your-ark-api-key
+
+# --- Local A2A server ---
+ASK_AI_HOST=0.0.0.0
+ASK_AI_PORT=8000
+# Allowed browser origins (the docs site). "*" for local dev; in prod set the
+# GitHub Pages origin, e.g. https://volcengine.github.io
+ASK_AI_ALLOW_ORIGINS=*
+
+# --- Only needed for `veadk deploy` (the CI pipeline reads these from secrets) ---
+# VOLCENGINE_ACCESS_KEY=
+# VOLCENGINE_SECRET_KEY=

--- a/docs/ask-ai-agent/README.md
+++ b/docs/ask-ai-agent/README.md
@@ -1,0 +1,41 @@
+# VeADK docs "Ask AI" agent
+
+A VeADK agent that answers questions about the documentation. It exposes one
+tool, `search_docs`, which does keyword search over a prebuilt index of the docs
+(`docs_index.json`) — no embeddings or vector DB required. The agent is served
+over the **A2A** protocol, the same protocol it speaks once deployed to VeFaaS,
+so the docs frontend talks to one protocol everywhere.
+
+## Files
+
+| File | Purpose |
+| :-- | :-- |
+| `agent.py` | The `Agent` + `search_docs` tool (`root_agent` for deploy). |
+| `docs_search.py` | Dependency-free BM25-style keyword search (EN + CJK). |
+| `build_index.py` | Builds `docs_index.json` from `../content/docs/**/*.mdx`. |
+| `serve.py` | Serves the agent as an A2A app (local dev + VeFaaS) with CORS. |
+
+## Run locally
+
+```bash
+cd docs/ask-ai-agent
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+
+cp .env.example .env        # then fill MODEL_AGENT_API_KEY (Volcengine Ark)
+python build_index.py       # regenerate the index from the docs
+python serve.py             # A2A server on http://localhost:8000
+```
+
+Point the docs site at it with `NEXT_PUBLIC_AI_CHAT_URL=http://localhost:8000`
+(see `docs/.env.local`), then run `pnpm dev`.
+
+## Deploy to VeFaaS
+
+```bash
+python build_index.py
+veadk deploy --vefaas-app-name veadk-docs-assistant --iam-role <role>
+```
+
+This is automated by `.github/workflows/deploy-ask-ai.yaml`, which rebuilds the
+index and runs `veadk deploy` whenever `docs/ask-ai-agent/**` changes.

--- a/docs/ask-ai-agent/agent.py
+++ b/docs/ask-ai-agent/agent.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VeADK documentation assistant — the "Ask AI" agent for the docs site.
+
+A VeADK `Agent` with one tool, `search_docs`, that does keyword search over the
+prebuilt docs index (`docs_index.json`). The model retrieves relevant pages,
+then answers grounded in them and cites the page URLs.
+
+Run locally:   python serve.py
+Deploy:        veadk deploy --vefaas-app-name veadk-docs-assistant ...
+"""
+
+import os
+
+from veadk import Agent
+
+from docs_search import search
+
+# Model name (Volcengine Ark). Overridable via MODEL_AGENT_NAME.
+MODEL_NAME = os.getenv("MODEL_AGENT_NAME") or "deepseek-v4-flash-260425"
+
+INSTRUCTION = """\
+You are the documentation assistant for VeADK (Volcengine Agent Development Kit).
+
+Your job is to answer questions about VeADK using ONLY the official documentation.
+
+Workflow for every question:
+1. Call the `search_docs` tool with a focused query (you may call it several times
+   with different queries to gather enough context).
+2. Answer strictly based on the returned excerpts. Do not invent APIs, flags, or
+   behavior that the docs do not mention.
+3. If the docs do not contain the answer, say so plainly and suggest the closest
+   relevant page.
+
+Style:
+- Reply in the SAME language as the user's question (Chinese or English).
+- Be concise and concrete; prefer short code snippets when the docs show them.
+- Always cite the pages you used as a short "Sources" list of their `url`s.
+"""
+
+
+def search_docs(query: str, language: str = "") -> dict:
+    """Search the VeADK documentation and return the most relevant pages.
+
+    Args:
+        query: A focused search query, in the user's language. Keep it to the key
+            terms (e.g. "deploy to VeFaaS", "短期记忆 MySQL").
+        language: Optional language filter: "cn" for Chinese pages, "en" for
+            English, or "" to search both.
+
+    Returns:
+        A dict with a "results" list; each result has `title`, `url`, `lang`, and
+        an `excerpt` of the page content to ground your answer.
+    """
+    lang = language.strip().lower() or None
+    if lang not in (None, "cn", "en"):
+        lang = None
+    return {"results": search(query, top_k=5, lang=lang)}
+
+
+agent = Agent(
+    name="veadk_docs_assistant",
+    description="Answers questions about VeADK using the official documentation.",
+    instruction=INSTRUCTION,
+    model_name=MODEL_NAME,
+    tools=[search_docs],
+)
+
+# Required by the Google ADK / VeADK agent loader and `veadk deploy`.
+root_agent = agent

--- a/docs/ask-ai-agent/build_index.py
+++ b/docs/ask-ai-agent/build_index.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build a lightweight search index from the Fumadocs MDX content.
+
+The Ask-AI agent searches this index (no embeddings / vector DB needed). Run
+this whenever the docs change — the deploy pipeline regenerates it before
+shipping the agent.
+
+    python build_index.py
+
+Writes `docs_index.json` next to this file: a list of
+`{ "url", "title", "lang", "headings", "text" }` page records.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+CONTENT_DIR = Path(__file__).resolve().parent.parent / "content" / "docs"
+OUTPUT = Path(__file__).resolve().parent / "docs_index.json"
+
+_FRONTMATTER = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+_IMPORT = re.compile(r"^\s*import\s.+$", re.MULTILINE)
+_JSX_TAG = re.compile(r"</?[A-Za-z][^>]*>")
+_CODE_FENCE = re.compile(r"^```.*$", re.MULTILINE)
+_MD_LINK = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+_MULTI_BLANK = re.compile(r"\n{3,}")
+_TITLE = re.compile(r'(?:^|\n)title:\s*["\']?(.+?)["\']?\s*(?:\n|$)')
+_HEADING = re.compile(r"^#{1,4}\s+(.+)$", re.MULTILINE)
+
+
+def _route(path: Path) -> tuple[str, str]:
+    """Map an MDX file path to (url, lang)."""
+    rel = path.relative_to(CONTENT_DIR).as_posix()
+    if rel.endswith(".en.mdx"):
+        lang, slug = "en", rel[: -len(".en.mdx")]
+    else:
+        lang, slug = "cn", rel[: -len(".mdx")]
+    if slug.endswith("/index"):
+        slug = slug[: -len("/index")]
+    elif slug == "index":
+        slug = ""
+    url = f"/{lang}/docs/{slug}".rstrip("/")
+    return url, lang
+
+
+def _to_text(raw: str) -> tuple[str, str, list[str]]:
+    fm = _FRONTMATTER.match(raw)
+    title = ""
+    body = raw
+    if fm:
+        m = _TITLE.search(fm.group(1))
+        if m:
+            title = m.group(1).strip()
+        body = raw[fm.end() :]
+    headings = [h.strip() for h in _HEADING.findall(body)]
+    body = _IMPORT.sub("", body)
+    body = _CODE_FENCE.sub("", body)
+    body = _JSX_TAG.sub("", body)
+    body = _MD_LINK.sub(r"\1", body)
+    body = _MULTI_BLANK.sub("\n\n", body).strip()
+    if not title and headings:
+        title = headings[0]
+    return title, body, headings
+
+
+def build() -> list[dict]:
+    pages: list[dict] = []
+    for path in sorted(CONTENT_DIR.rglob("*.mdx")):
+        raw = path.read_text(encoding="utf-8")
+        title, text, headings = _to_text(raw)
+        url, lang = _route(path)
+        if not text:
+            continue
+        pages.append(
+            {
+                "url": url,
+                "title": title,
+                "lang": lang,
+                "headings": headings,
+                "text": text,
+            }
+        )
+    return pages
+
+
+if __name__ == "__main__":
+    pages = build()
+    OUTPUT.write_text(json.dumps(pages, ensure_ascii=False, indent=0), encoding="utf-8")
+    print(f"Indexed {len(pages)} pages -> {OUTPUT}")

--- a/docs/ask-ai-agent/docs_search.py
+++ b/docs/ask-ai-agent/docs_search.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dependency-free keyword search over the docs index.
+
+Tokenizes both Latin words and CJK character bigrams, then scores pages with a
+BM25-style ranking (title + headings weighted higher than body). No embeddings,
+no external services — just the prebuilt `docs_index.json`.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from functools import lru_cache
+from pathlib import Path
+
+_INDEX_PATH = Path(__file__).resolve().parent / "docs_index.json"
+
+_LATIN = re.compile(r"[a-zA-Z0-9_]+")
+_CJK = re.compile(r"[一-鿿]")
+
+
+def _tokenize(text: str) -> list[str]:
+    text = text.lower()
+    tokens = _LATIN.findall(text)
+    cjk = _CJK.findall(text)
+    # CJK character bigrams (plus singletons for short queries)
+    tokens += ["".join(pair) for pair in zip(cjk, cjk[1:])]
+    tokens += cjk
+    return tokens
+
+
+@lru_cache(maxsize=1)
+def _load() -> tuple[list[dict], list[dict], dict[str, int], float]:
+    pages = json.loads(_INDEX_PATH.read_text(encoding="utf-8"))
+    postings: list[dict[str, int]] = []
+    df: dict[str, int] = {}
+    total_len = 0
+    for page in pages:
+        blob = " ".join(
+            [page.get("title", "")] * 3
+            + page.get("headings", []) * 2
+            + [page.get("text", "")]
+        )
+        toks = _tokenize(blob)
+        total_len += len(toks)
+        tf: dict[str, int] = {}
+        for t in toks:
+            tf[t] = tf.get(t, 0) + 1
+        postings.append(tf)
+        for t in tf:
+            df[t] = df.get(t, 0) + 1
+    avg_len = (total_len / len(pages)) if pages else 1.0
+    return pages, postings, df, avg_len
+
+
+def search(query: str, top_k: int = 5, lang: str | None = None) -> list[dict]:
+    """Return the top-k most relevant doc pages for a query."""
+    pages, postings, df, avg_len = _load()
+    n = len(pages)
+    q_terms = set(_tokenize(query))
+    if not q_terms:
+        return []
+
+    k1, b = 1.5, 0.75
+    scored: list[tuple[float, int]] = []
+    for i, tf in enumerate(postings):
+        if lang and pages[i].get("lang") != lang:
+            continue
+        doc_len = sum(tf.values()) or 1
+        score = 0.0
+        for term in q_terms:
+            f = tf.get(term, 0)
+            if not f:
+                continue
+            idf = math.log(1 + (n - df[term] + 0.5) / (df[term] + 0.5))
+            score += idf * (f * (k1 + 1)) / (f + k1 * (1 - b + b * doc_len / avg_len))
+        if score > 0:
+            scored.append((score, i))
+
+    scored.sort(reverse=True)
+    results = []
+    for score, i in scored[:top_k]:
+        page = pages[i]
+        results.append(
+            {
+                "title": page["title"],
+                "url": page["url"],
+                "lang": page["lang"],
+                "excerpt": _excerpt(page["text"], q_terms),
+                "score": round(score, 3),
+            }
+        )
+    return results
+
+
+def _excerpt(text: str, q_terms: set[str], width: int = 600) -> str:
+    """A snippet centered on the first query-term hit."""
+    low = text.lower()
+    pos = -1
+    for term in q_terms:
+        p = low.find(term)
+        if p != -1 and (pos == -1 or p < pos):
+            pos = p
+    if pos == -1:
+        return text[:width].strip()
+    start = max(0, pos - width // 3)
+    return text[start : start + width].strip()

--- a/docs/ask-ai-agent/requirements.txt
+++ b/docs/ask-ai-agent/requirements.txt
@@ -1,0 +1,3 @@
+veadk-python
+python-dotenv
+uvicorn

--- a/docs/ask-ai-agent/serve.py
+++ b/docs/ask-ai-agent/serve.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Serve the docs assistant as an A2A application (local dev + VeFaaS).
+
+The deployed VeFaaS function (via `veadk deploy`) serves the same A2A protocol,
+so the docs frontend talks to one protocol everywhere. CORS is enabled so the
+static docs site can call this endpoint cross-origin.
+
+    python serve.py            # http://localhost:8000
+"""
+
+import os
+
+# Load .env before importing the agent so model credentials are picked up.
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
+
+from starlette.middleware.cors import CORSMiddleware
+
+from veadk.a2a.utils.agent_to_a2a import to_a2a
+
+from agent import agent
+
+HOST = os.getenv("ASK_AI_HOST", "0.0.0.0")
+PORT = int(os.getenv("ASK_AI_PORT", os.getenv("PORT", "8000")))
+# Comma-separated allowed origins for the browser (docs site). "*" by default.
+ALLOW_ORIGINS = [
+    o.strip() for o in os.getenv("ASK_AI_ALLOW_ORIGINS", "*").split(",") if o.strip()
+]
+
+app = to_a2a(agent, host=HOST, port=PORT)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOW_ORIGINS,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host=HOST, port=PORT)


### PR DESCRIPTION
A VeADK agent that answers VeADK documentation questions. It searches a prebuilt index of the docs (keyword/BM25, EN + CJK; no embeddings) and answers grounded in the official docs, citing page paths. Served over A2A — the same protocol it speaks once deployed to Volcengine VeFaaS.

- docs/ask-ai-agent/: agent.py (search_docs tool), docs_search.py, build_index.py (-> docs_index.json, generated), serve.py (A2A + CORS), requirements, README, .env.example.
- Model: deepseek-v4-flash-260425 (overridable via MODEL_AGENT_NAME).
- .github/workflows/deploy-docs-agent.yaml: rebuild the index and run `veadk deploy` when the agent or docs content change (manual dispatch too). The deployed agent obtains its Ark token from the VeFaaS IAM role.