### PR TITLE
build: derive version from git tags via setuptools-scm

### DIFF
--- a/.github/workflows/publish-tag-to-pypi.yaml
+++ b/.github/workflows/publish-tag-to-pypi.yaml
@@ -11,6 +11,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          # setuptools-scm derives the version from git tags, so the build
+          # needs full history and all tags (not the default shallow clone).
+          fetch-depth: 0
+          fetch-tags: true
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
+[build-system]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "veadk-python"
-version = "0.5.35"
+dynamic = ["version"]
 description = "Volcengine agent development kit, integrations with Volcengine cloud services."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -96,6 +100,13 @@ include-package-data = true
 
 [tool.setuptools.package-data]
 "veadk" = ["**/*"]
+
+# Derive the package version from the latest git tag (e.g. tag "0.5.36"
+# publishes version 0.5.36). No version string is hardcoded anywhere; release
+# by tagging. ``fallback_version`` is used only when building outside a git
+# checkout (e.g. from a source tarball that carries no SCM metadata).
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
 
 [tool.ruff]
 exclude = [

--- a/veadk/version.py
+++ b/veadk/version.py
@@ -12,4 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "0.5.35"
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _get_version
+
+try:
+    # Single source of truth: the version recorded at install/build time,
+    # which setuptools-scm derives from the latest git tag.
+    VERSION = _get_version("veadk-python")
+except PackageNotFoundError:
+    # Importing from a source tree that has not been installed (no dist
+    # metadata). setuptools-scm only computes the version at build/install.
+    VERSION = "0.0.0+unknown"


### PR DESCRIPTION
## 背景

当前版本号被硬编码在**两处**，每次发版都要手动同步：
- `pyproject.toml` → `version = "0.5.35"`
- `veadk/version.py` → `VERSION = "0.5.35"`（再导出为 `veadk.VERSION`，用于遥测 header、User-Agent、CLI 日志、span 属性）

而且 `publish-tag-to-pypi` 流水线只是用 `pyproject.toml` 里写死的版本号构建发布，**完全不读 tag 名**——也就是说打 tag `0.5.36` 仍会发布 `0.5.35`，除非你先改两个文件。

## 改动

让 **git tag 成为版本号的唯一真实来源**（setuptools-scm）：

- **`pyproject.toml`**：新增 `[build-system]`（setuptools + setuptools-scm），将 `[project].version` 改为 `dynamic = ["version"]`，新增 `[tool.setuptools_scm]`。
- **`veadk/version.py`**：通过 `importlib.metadata.version("veadk-python")` 读取安装时记录的版本；源码树未安装时回退到 `0.0.0+unknown`。
- **`publish-tag-to-pypi.yaml`**：checkout 改为 `fetch-depth: 0` + `fetch-tags: true`，否则默认的浅克隆会让 setuptools-scm 算出 `0.0.0`。

## 效果

发版流程变为：

```bash
git tag 0.5.36 && git push --tags   # → CI 自动构建并发布 0.5.36
```

无需再改任何文件。现有 tag 是裸 `0.5.35`（无 `v` 前缀），setuptools-scm 原生支持；`v0.5.36` 也可以。

## 验证

- `setuptools_scm` 在当前 main 上算出 `0.5.36.dev8+g08209ee…`，在 tag 上算出干净的 `0.5.36`。
- `python -m build` 产出版本号正确的 wheel + sdist。
- 运行时：已安装 → metadata 返回 scm 版本；未安装 → 回退 `0.0.0+unknown`。
- ruff + license header + pre-commit 全部通过；workflow YAML 校验通过。

## 注意

两次发版之间，本地/开发环境会显示形如 `0.5.36.dev8+g08209ee` 的开发版本号而非干净数字——这是预期行为，仅影响显示（遥测 header、CLI 日志、span 属性）。