### PR TITLE
fix(tracing): zero-pad trace_id to 32 hex + flesh out the tracing example

### DIFF
--- a/examples/11_tracing/.env.example
+++ b/examples/11_tracing/.env.example
@@ -1,4 +1,4 @@
-# Copy this file to `.env` and fill in your key.
+# Copy this file to `.env` and fill in your keys.
 
 # --- Agent reasoning model (Volcengine Ark) ---
 # Get an API key at https://console.volcengine.com/ark
@@ -7,12 +7,29 @@ MODEL_AGENT_NAME=doubao-seed-1-6-250615
 MODEL_AGENT_API_BASE=https://ark.cn-beijing.volces.com/api/v3/
 MODEL_AGENT_API_KEY=your-ark-api-key-here
 
-# --- Optional: ship traces to a Volcengine observability platform ---
-# Uncomment + configure to export instead of (or in addition to) the local dump.
+# --- Volcengine AK/SK ---
+# Used by exporters that auto-fetch a token (e.g. APMPlus) and for Volcengine
+# auth in general. Create at https://console.volcengine.com/iam/keymanage
+VOLCENGINE_ACCESS_KEY=your-volcengine-access-key
+VOLCENGINE_SECRET_KEY=your-volcengine-secret-key
+
+# --- Exporters (optional) -------------------------------------------------
+# With none of these enabled, traces are collected in-memory and you still get
+# a trace_id. Set ENABLE_* = true to also ship traces to that platform.
+# Endpoints have sensible defaults, so usually you only set the key / id below.
+
+# APMPlus — https://console.volcengine.com/apmplus-server
+# The API key is optional if VOLCENGINE_ACCESS_KEY/SECRET_KEY are set (auto token).
+# ENABLE_APMPLUS=true
+# OBSERVABILITY_OPENTELEMETRY_APMPLUS_SERVICE_NAME=veadk-tracing-demo
+# OBSERVABILITY_OPENTELEMETRY_APMPLUS_API_KEY=your-apmplus-api-key
+
+# CozeLoop — https://www.coze.cn/loop  (SERVICE_NAME is the space id)
 # ENABLE_COZELOOP=true
 # OBSERVABILITY_OPENTELEMETRY_COZELOOP_API_KEY=your-cozeloop-api-key
 # OBSERVABILITY_OPENTELEMETRY_COZELOOP_SERVICE_NAME=your-cozeloop-space-id
-#
-# ENABLE_APMPLUS=true
-# OBSERVABILITY_OPENTELEMETRY_APMPLUS_API_KEY=your-apmplus-api-key
-# OBSERVABILITY_OPENTELEMETRY_APMPLUS_SERVICE_NAME=your-service-name
+
+# Volcengine TLS — https://console.volcengine.com/tls  (SERVICE_NAME is the topic id)
+# ENABLE_TLS=true
+# OBSERVABILITY_OPENTELEMETRY_TLS_SERVICE_NAME=your-tls-topic-id
+# OBSERVABILITY_OPENTELEMETRY_TLS_REGION=cn-beijing

--- a/examples/11_tracing/README.md
+++ b/examples/11_tracing/README.md
@@ -1,7 +1,8 @@
 # 11 · Tracing & observability
 
 See exactly what the agent did — every LLM call and tool call — by attaching a
-tracer. Each run gets a `trace_id` you can search in an observability platform.
+tracer. Each run gets a `trace_id` (32 hex chars) you can search in an
+observability platform.
 
 > 中文版见 [README.zh.md](./README.zh.md)
 
@@ -10,7 +11,7 @@ tracer. Each run gets a `trace_id` you can search in an observability platform.
 ```python
 from veadk.tracing.telemetry.opentelemetry_tracer import OpentelemetryTracer
 
-tracer = OpentelemetryTracer()
+tracer = OpentelemetryTracer(exporters=[...])   # exporters optional
 agent = Agent(tracers=[tracer], tools=[...])
 
 answer = await runner.run(messages="...", session_id="demo-session")
@@ -19,35 +20,50 @@ runner.get_trace_id()    # the trace id to correlate in your backend
 
 - **`tracers=[...]`** — attach one or more tracers to the agent.
 - Each LLM call and tool call becomes a span with timing, inputs, and outputs.
-- **`runner.get_trace_id()`** — the id that ties those spans together; search it
-  in your observability platform's UI.
+- **`runner.get_trace_id()`** — the 32-char id that ties those spans together;
+  search it in your observability platform's UI.
+- With **no exporter** the spans are kept in-memory (no creds needed); you still
+  get a `trace_id`. Add exporters to also ship them to a platform.
 
 ## Run it
 
 ```bash
 pip install veadk-python
-cp .env.example .env   # then set MODEL_AGENT_API_KEY
+cp .env.example .env   # set MODEL_AGENT_API_KEY (+ AK/SK and ENABLE_* to export)
 python main.py
 ```
 
-The script prints the answer and the trace id.
+The script prints which exporters are active, the answer, and the trace id.
 
-> ℹ️ The local `runner.save_tracing_file(...)` dump is intentionally omitted
-> here: on the current VeADK + Google ADK 2.0 combination its session→trace
-> filter can return an empty file. The platform exporters below are the reliable
-> way to inspect traces.
+## Exporters
 
-## Exporting to a platform
+This example builds exporters based on `ENABLE_*` env flags (config comes from
+`.env`):
 
-To ship traces to **CozeLoop**, **APMPlus**, or **TLS** instead of (or in
-addition to) the local dump, set the corresponding env vars — VeADK wires up the
-exporters automatically:
+- **APMPlus** (`ENABLE_APMPLUS=true`) — auth via `VOLCENGINE_ACCESS_KEY` /
+  `SECRET_KEY` (auto token) or `..._APMPLUS_API_KEY`; service name via
+  `..._APMPLUS_SERVICE_NAME`.
+- **CozeLoop** (`ENABLE_COZELOOP=true`) — `..._COZELOOP_API_KEY`;
+  `..._COZELOOP_SERVICE_NAME` is the space id.
+- **Volcengine TLS** (`ENABLE_TLS=true`) — Volcengine AK/SK;
+  `..._TLS_SERVICE_NAME` is the topic id, `..._TLS_REGION` the region.
 
-```bash
-ENABLE_COZELOOP=true
-OBSERVABILITY_OPENTELEMETRY_COZELOOP_API_KEY=...
-OBSERVABILITY_OPENTELEMETRY_COZELOOP_SERVICE_NAME=...   # space id
+(Full env var names are `OBSERVABILITY_OPENTELEMETRY_<PLATFORM>_*`; see
+`.env.example`.) Endpoints have defaults, so you usually only set the key / id.
+
+```python
+from veadk.tracing.telemetry.exporters.apmplus_exporter import APMPlusExporter
+from veadk.tracing.telemetry.exporters.cozeloop_exporter import CozeloopExporter
+from veadk.tracing.telemetry.exporters.tls_exporter import TLSExporter
+
+tracer = OpentelemetryTracer(exporters=[APMPlusExporter(), CozeloopExporter(), TLSExporter()])
 ```
 
-See `.env.example` for the APMPlus equivalents and the
-[configuration docs](https://volcengine.github.io/veadk-python/) for the rest.
+You can enable several at once — the same spans are sent to all of them, and
+also kept in-memory.
+
+> ℹ️ The local `runner.save_tracing_file(...)` dump is intentionally not used
+> here: on the current VeADK + Google ADK combination its session→trace filter
+> can return an empty file. The platform exporters above are the reliable way to
+> inspect traces. See the
+> [configuration docs](https://volcengine.github.io/veadk-python/) for more.

--- a/examples/11_tracing/README.zh.md
+++ b/examples/11_tracing/README.zh.md
@@ -1,7 +1,7 @@
 # 11 · 链路追踪与可观测性
 
 通过挂载 tracer，清楚地看到智能体做了什么 —— 每一次大模型调用、每一次工具调用。
-每次运行都会得到一个 `trace_id`，可在可观测平台中检索。
+每次运行都会得到一个 `trace_id`（32 位十六进制），可在可观测平台中检索。
 
 > English version: [README.md](./README.md)
 
@@ -10,7 +10,7 @@
 ```python
 from veadk.tracing.telemetry.opentelemetry_tracer import OpentelemetryTracer
 
-tracer = OpentelemetryTracer()
+tracer = OpentelemetryTracer(exporters=[...])   # exporters 可选
 agent = Agent(tracers=[tracer], tools=[...])
 
 answer = await runner.run(messages="...", session_id="demo-session")
@@ -19,32 +19,46 @@ runner.get_trace_id()    # 用于在后端平台关联检索的 trace id
 
 - **`tracers=[...]`** —— 为智能体挂载一个或多个 tracer。
 - 每一次大模型调用与工具调用都会成为一个 span，包含耗时、输入与输出。
-- **`runner.get_trace_id()`** —— 串联这些 span 的 id；在可观测平台 UI 中检索它。
+- **`runner.get_trace_id()`** —— 串联这些 span 的 32 位 id；在可观测平台 UI 中检索它。
+- **不配 exporter** 时 span 仅在内存中收集（无需凭证），你依然能拿到 `trace_id`；
+  加上 exporter 就能同时上报到平台。
 
 ## 运行步骤
 
 ```bash
 pip install veadk-python
-cp .env.example .env   # 然后填入 MODEL_AGENT_API_KEY
+cp .env.example .env   # 填入 MODEL_AGENT_API_KEY（要上报再填 AK/SK 和 ENABLE_*）
 python main.py
 ```
 
-脚本会打印回答与 trace id。
+脚本会打印启用了哪些 exporter、回答，以及 trace id。
 
-> ℹ️ 这里有意没有演示本地的 `runner.save_tracing_file(...)` 导出：在当前
-> VeADK + Google ADK 2.0 的组合下，其“会话→trace”过滤可能返回空文件。
-> 下方的平台 exporter 才是查看 trace 的可靠方式。
+## Exporter
 
-## 导出到平台
+本示例根据 `ENABLE_*` 环境变量来构建 exporter（具体配置从 `.env` 读取）：
 
-若想把 trace 上报到 **CozeLoop**、**APMPlus** 或 **TLS**（替代或叠加本地导出），
-只需设置对应的环境变量，VeADK 会自动接好 exporter：
+- **APMPlus**（`ENABLE_APMPLUS=true`）—— 用 `VOLCENGINE_ACCESS_KEY` /
+  `SECRET_KEY` 自动取 token，或填 `..._APMPLUS_API_KEY`；服务名用
+  `..._APMPLUS_SERVICE_NAME`。
+- **CozeLoop**（`ENABLE_COZELOOP=true`）—— `..._COZELOOP_API_KEY`；
+  `..._COZELOOP_SERVICE_NAME` 是 space id。
+- **火山 TLS**（`ENABLE_TLS=true`）—— 火山 AK/SK；`..._TLS_SERVICE_NAME` 是
+  topic id，`..._TLS_REGION` 是地域。
 
-```bash
-ENABLE_COZELOOP=true
-OBSERVABILITY_OPENTELEMETRY_COZELOOP_API_KEY=...
-OBSERVABILITY_OPENTELEMETRY_COZELOOP_SERVICE_NAME=...   # space id
+（完整环境变量名为 `OBSERVABILITY_OPENTELEMETRY_<平台>_*`，见 `.env.example`。）
+端点都有默认值，通常只需填 key / id。
+
+```python
+from veadk.tracing.telemetry.exporters.apmplus_exporter import APMPlusExporter
+from veadk.tracing.telemetry.exporters.cozeloop_exporter import CozeloopExporter
+from veadk.tracing.telemetry.exporters.tls_exporter import TLSExporter
+
+tracer = OpentelemetryTracer(exporters=[APMPlusExporter(), CozeloopExporter(), TLSExporter()])
 ```
 
-APMPlus 的等价配置见 `.env.example`，其余配置见
-[配置文档](https://volcengine.github.io/veadk-python/)。
+可以同时开启多个 —— 同一批 span 会发往所有平台，并同时保留在内存中。
+
+> ℹ️ 这里有意没有用本地的 `runner.save_tracing_file(...)` 导出：在当前
+> VeADK + Google ADK 的组合下，其“会话→trace”过滤可能返回空文件。
+> 上面的平台 exporter 才是查看 trace 的可靠方式。更多见
+> [配置文档](https://volcengine.github.io/veadk-python/)。

--- a/examples/11_tracing/main.py
+++ b/examples/11_tracing/main.py
@@ -12,23 +12,50 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Observe what the agent did with tracing.
+"""Observe what the agent did with tracing — local, and/or cloud exporters.
 
 Attach a tracer via `tracers=[...]`. Every LLM call and tool call becomes a span,
-and the run gets a `trace_id` you can correlate in an observability backend.
+and the run gets a `trace_id` (32 hex chars) you can search in your backend.
 
-To ship traces to a platform, set the matching env vars
-(`ENABLE_COZELOOP=true`, `ENABLE_APMPLUS=true`, `ENABLE_TLS=true`) and configure
-their endpoints/keys; VeADK wires up the exporters automatically and you can then
-search for the printed `trace_id` in that platform's UI.
+By default spans are collected in-memory (no credentials needed). Set any of
+`ENABLE_APMPLUS` / `ENABLE_COZELOOP` / `ENABLE_TLS` to `true` (and fill in the
+matching creds in `.env`) to also ship traces to those Volcengine observability
+platforms. APMPlus can authenticate with your Volcengine AK/SK; CozeLoop and TLS
+use their own key / ids. See `.env.example`.
 """
 
 import asyncio
+import os
 
 from veadk import Agent, Runner
+from veadk.tracing.telemetry.exporters.base_exporter import BaseExporter
 from veadk.tracing.telemetry.opentelemetry_tracer import OpentelemetryTracer
 
 SESSION_ID = "demo-session"
+
+
+def _enabled(env_name: str) -> bool:
+    return os.getenv(env_name, "").lower() == "true"
+
+
+def build_exporters() -> list[BaseExporter]:
+    """Build the cloud exporters enabled via env (their config is read from .env)."""
+    exporters: list[BaseExporter] = []
+    if _enabled("ENABLE_APMPLUS"):
+        from veadk.tracing.telemetry.exporters.apmplus_exporter import APMPlusExporter
+
+        exporters.append(APMPlusExporter())
+    if _enabled("ENABLE_COZELOOP"):
+        from veadk.tracing.telemetry.exporters.cozeloop_exporter import (
+            CozeloopExporter,
+        )
+
+        exporters.append(CozeloopExporter())
+    if _enabled("ENABLE_TLS"):
+        from veadk.tracing.telemetry.exporters.tls_exporter import TLSExporter
+
+        exporters.append(TLSExporter())
+    return exporters
 
 
 def get_city_weather(city: str) -> dict[str, str]:
@@ -41,7 +68,14 @@ def get_city_weather(city: str) -> dict[str, str]:
 
 
 async def main() -> None:
-    tracer = OpentelemetryTracer()
+    # No exporters -> in-memory only (still yields a trace_id). With ENABLE_* set,
+    # the same spans are also shipped to those platforms.
+    exporters = build_exporters()
+    tracer = OpentelemetryTracer(exporters=exporters)
+    print(
+        "Exporters:",
+        [type(e).__name__ for e in exporters] or "in-memory only (no cloud export)",
+    )
 
     agent = Agent(
         name="traced_agent",
@@ -55,8 +89,8 @@ async def main() -> None:
     answer = await runner.run(messages="北京今天天气怎么样？", session_id=SESSION_ID)
     print("Answer:", answer)
 
-    # Each LLM/tool call was recorded as a span under this trace id. With a
-    # platform exporter enabled (see README), search this id in its UI.
+    # 32-char hex id tying all spans of this run together. With an exporter
+    # enabled, search this id in that platform's UI.
     print("Trace id:", runner.get_trace_id())
 
 

--- a/veadk/tracing/telemetry/opentelemetry_tracer.py
+++ b/veadk/tracing/telemetry/opentelemetry_tracer.py
@@ -239,7 +239,11 @@ class OpentelemetryTracer(BaseModel, BaseTracer):
                 placeholder string if trace ID cannot be retrieved
         """
         try:
-            trace_id = hex(int(self._inmemory_exporter._exporter.trace_id))[2:]  # type: ignore
+            # OTel/W3C trace ids are 128-bit -> 32 lowercase hex chars,
+            # zero-padded. `hex(...)[2:]` drops leading zeros (yielding a
+            # 31-char id when the high nibble is 0), so format with `032x` to
+            # match what the cloud exporters report.
+            trace_id = format(int(self._inmemory_exporter._exporter.trace_id), "032x")  # type: ignore
             return trace_id
         except Exception as e:
             logger.error(f"Failed to get trace_id from InMemoryExporter: {e}")


### PR DESCRIPTION
## Fix: trace_id missing a leading zero

OpenTelemetry/W3C trace ids are 128-bit = **32 lowercase hex chars, zero-padded**. The tracer formatted it with `hex(int(...))[2:]`, which drops leading zeros — so a trace id with a high zero nibble printed as **31 chars locally** while the cloud exporters (using the OTel SDK) reported the correct 32:

```
local (buggy): e836a7c2ff2c2f9302d15c0d14b030e   (31)
cloud (right): 0e836a7c2ff2c2f9302d15c0d14b030e  (32)
```

Fix: `format(int(...), "032x")`. Verified the property now returns the full 32-char id matching the cloud.

## Example: `examples/11_tracing` fleshed out

Per review, the tracing example now covers real exporters, not just the local case:

- **`.env.example`** adds Volcengine **AK/SK** and the **APMPlus / CozeLoop / TLS** exporter env vars (`ENABLE_*` + `OBSERVABILITY_OPENTELEMETRY_*`; endpoints default).
- **`main.py`** builds the enabled exporters from `ENABLE_APMPLUS` / `ENABLE_COZELOOP` / `ENABLE_TLS` and passes them to `OpentelemetryTracer`; with none set it stays in-memory only and still yields a `trace_id`.
- **bilingual README** documents the three exporters, their auth (APMPlus can auto-auth via AK/SK), and that trace ids are 32 hex chars.

## Verified locally (real Ark call)

```
Exporters: in-memory only (no cloud export)
Answer: 北京今天天气晴朗，气温为 25°C ...
Trace id: 648007db310ca869def24fc761e06b0f   (32 chars)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)