### PR TITLE
fix(webui): add skillhub proxy to resolve 404

### DIFF
--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -355,7 +355,9 @@ def frontend(
     # ---- Skill Hub proxy: proxy /skillhub/* to skills.volces.com ----
     SKILLHUB_TARGET = "https://skills.volces.com"
 
-    @app.api_route("/skillhub/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
+    @app.api_route(
+        "/skillhub/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"]
+    )
     async def _skillhub_proxy(request: Request, path: str):
         """Proxy requests to Volcengine Skill Hub API to avoid CORS issues."""
         target_url = f"{SKILLHUB_TARGET}/{path}"

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -231,8 +231,10 @@ def frontend(
 
     # Agent introspection for the UI's agent picker (name, model, tools). Reuses
     # ADK's AgentLoader, which caches each loaded `root_agent`.
-    from fastapi import HTTPException
+    from fastapi import HTTPException, Request
+    from fastapi.responses import Response
     from google.adk.cli.utils.agent_loader import AgentLoader
+    import httpx
 
     _agent_loader = AgentLoader(agents_dir)
 
@@ -350,6 +352,37 @@ def frontend(
         ]
         return {"mounted": True, "results": results}
 
+    # ---- Skill Hub proxy: proxy /skillhub/* to skills.volces.com ----
+    SKILLHUB_TARGET = "https://skills.volces.com"
+
+    @app.api_route("/skillhub/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
+    async def _skillhub_proxy(request: Request, path: str):
+        """Proxy requests to Volcengine Skill Hub API to avoid CORS issues."""
+        target_url = f"{SKILLHUB_TARGET}/{path}"
+        if request.url.query:
+            target_url += f"?{request.url.query}"
+
+        headers = dict(request.headers)
+        headers.pop("host", None)
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.request(
+                    method=request.method,
+                    url=target_url,
+                    headers=headers,
+                    content=await request.body(),
+                    timeout=30.0,
+                )
+                return Response(
+                    content=response.content,
+                    status_code=response.status_code,
+                    headers=dict(response.headers),
+                )
+        except Exception as e:
+            logger.error(f"Skillhub proxy error: {e}")
+            raise HTTPException(status_code=502, detail=f"Proxy error: {str(e)}")
+
     # ---- SSO (optional): VeIdentity user pool, or a generic provider via env ----
     redirect_uri = oauth2_redirect_uri or f"http://{host}:{port}/oauth2/callback"
     pool_ok = oauth2_user_pool or oauth2_user_pool_uid
@@ -406,7 +439,7 @@ def frontend(
             app,
             oauth2_config,
             exempt_paths={"/", "/index.html", "/favicon.ico", "/web/auth-config"},
-            exempt_prefixes={"/assets"},
+            exempt_prefixes={"/assets", "/skillhub"},
         )
         logger.info(
             f"OAuth2 SSO enabled (provider={provider_id}, redirect_uri={redirect_uri})"


### PR DESCRIPTION
## Summary
修复生产环境下技能搜索返回 404 的问题,通过在 FastAPI 后端添加 `/skillhub` 代理路由。

## Bug Description
用户在自定义创建 Agent 时使用技能搜索功能,所有请求返回 404 错误。开发环境（Vite dev server）正常工作,但生产环境（`veadk frontend` 命令）出现问题。

**Root Cause**:
- 开发环境: Vite 配置了 `/skillhub` 代理到 `https://skills.volces.com`
- 生产环境: FastAPI 后端缺少对应的代理路由
- Volcengine Skill Hub API 不支持 CORS,必须通过服务端代理访问

## Changes
- **veadk/cli/cli_frontend.py**: 添加 `/skillhub/{path:path}` 代理路由
  - 使用 `httpx.AsyncClient` 异步转发请求到 `https://skills.volces.com`
  - 支持 GET/POST/PUT/DELETE/PATCH 方法
  - 保留原始请求头和查询参数
  - 30 秒超时防止挂起
- **veadk/cli/cli_frontend.py**: 在 OAuth2 `exempt_prefixes` 中添加 `/skillhub`（未登录用户也可搜索技能）

## Testing
✅ 技能搜索功能恢复正常（搜索"画图"、"PDF"等关键词返回结果列表）  
✅ 其他 API 路由不受影响  
✅ OAuth2 登录流程正常  
✅ 静态资源和 WebSocket 连接正常  