### PR TITLE
fix: enable PDF upload support for Web UI agents

### DIFF
--- a/examples/dogfooding/agent.py
+++ b/examples/dogfooding/agent.py
@@ -24,6 +24,7 @@ other examples and powers the web UI's "智能模式" (smart mode).
 import os
 
 from veadk import Agent
+from veadk.utils.pdf_to_images import pdf_to_images_before_model_callback
 
 # The schema mirrors the web UI's AgentDraft and the codegen catalog
 # (frontend/src/create/veadkCatalog.ts). Output values MUST come from the
@@ -90,6 +91,7 @@ agent = Agent(
     name="agent_builder",
     description="VeADK Agent Builder：把自然语言需求转化为智能体配置 JSON（前端据此生成 VeADK 项目）。",
     instruction=lambda _ctx: INSTRUCTION,
+    before_model_callback=pdf_to_images_before_model_callback,
     **({"model_name": _MODEL_A} if _MODEL_A else {}),
 )
 

--- a/examples/dogfooding_b/agent.py
+++ b/examples/dogfooding_b/agent.py
@@ -24,6 +24,7 @@ the two stay in sync.
 import os
 
 from veadk import Agent
+from veadk.utils.pdf_to_images import pdf_to_images_before_model_callback
 
 # The two builder apps share one instruction. ADK puts the agents dir on
 # sys.path, so the sibling app package is importable; fall back to the
@@ -39,6 +40,7 @@ agent = Agent(
     name="agent_builder_b",
     description="VeADK Agent Builder (B)：A/B 对比中的第二个构建器。",
     instruction=lambda _ctx: INSTRUCTION,
+    before_model_callback=pdf_to_images_before_model_callback,
     **({"model_name": _MODEL_B} if _MODEL_B else {}),
 )
 

--- a/examples/front_with_sso/agent.py
+++ b/examples/front_with_sso/agent.py
@@ -20,11 +20,13 @@ the GitHub / Google / custom-OIDC env vars and how to run it.
 """
 
 from veadk import Agent
+from veadk.utils.pdf_to_images import pdf_to_images_before_model_callback
 
 agent = Agent(
     name="sso_demo_agent",
     description="Demo agent served behind an SSO login page.",
     instruction="You are a helpful assistant. Answer concisely.",
+    before_model_callback=pdf_to_images_before_model_callback,
 )
 
 # Required by the Google ADK agent loader.

--- a/examples/web_demo/agent.py
+++ b/examples/web_demo/agent.py
@@ -24,6 +24,7 @@ in the UI's dropdown (it is returned by ``/list-apps``).
 """
 
 from veadk import Agent
+from veadk.utils.pdf_to_images import pdf_to_images_before_model_callback
 
 agent = Agent(
     name="web_demo",
@@ -32,6 +33,7 @@ agent = Agent(
         "You are a helpful assistant. Answer clearly and concisely in the "
         "user's language."
     ),
+    before_model_callback=pdf_to_images_before_model_callback,
 )
 
 # Required by the ADK agent loader.


### PR DESCRIPTION
## 问题描述

修复 Web UI 中 PDF 文件上传时的错误：

用户在 `web_demo`、`dogfooding`、`dogfooding_b`、`front_with_sso` 等 agent 中上传 PDF 文件时，系统报错：
Missing credentials. Please pass an 'api_key', 'workload_identity', 'admin_api_key',
or set the 'OPENAI_API_KEY' or 'OPENAI_ADMIN_KEY' environment variable.

## 根本原因

- 这些 Web UI agent 没有配置 `before_model_callback` 参数
- 导致后端使用 Google ADK 的默认 PDF 处理逻辑，尝试调用 OpenAI API
- 但环境中没有配置 OpenAI API key，导致失败

## 修复方案

为所有 Web UI agent 添加 VeADK 内置的 PDF 处理回调：

```python
from veadk.utils.pdf_to_images import pdf_to_images_before_model_callback

agent = Agent(
    ...
    before_model_callback=pdf_to_images_before_model_callback,
)
该回调使用本地库（pypdfium2）将 PDF 转换为图像，无需依赖外部 API。

修改文件
examples/web_demo/agent.py - 添加 PDF 处理回调
examples/dogfooding/agent.py - 添加 PDF 处理回调（智能模式 agent builder）
examples/dogfooding_b/agent.py - 添加 PDF 处理回调（A/B 对比模式 agent builder）
examples/front_with_sso/agent.py - 添加 PDF 处理回调
frontend/bug-fixes/fix-enable-pdf-support.md - 修复文档
frontend/bug-fixes/README.md - 更新索引
测试验证
✅ 已测试通过：

启动 Web UI agent
上传多页 PDF 文件
确认 LLM 能够正确理解 PDF 内容
无错误信息
影响范围
✅ 启用所有 Web UI agent 的 PDF 上传功能
✅ 不影响其他文件类型（图片、文本等）的处理
✅ 无副作用，仅依赖项目已有的库（pypdfium2、pillow）
相关文档
详细修复记录：[frontend/bug-fixes/fix-enable-pdf-support.md](vscode-webview://1otdvgdcg0p2ak8hjfmagbmpuoblu3cvn1rv9khotabfk8ajbrrb/frontend/bug-fixes/fix-enable-pdf-support.md)