### PR TITLE
chore: remove direct litellm dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "a2a-sdk==0.3.7", # For Google Agent2Agent protocol
     "deprecated==1.2.18",
     "google-adk==1.32.0", # For basic agent architecture
-    "litellm>=1.74.3,<=1.82.6", # For model inference
     "loguru==0.7.3", # For better logging
     "opentelemetry-exporter-otlp==1.37.0",
     "opentelemetry-instrumentation-logging>=0.56b0",


### PR DESCRIPTION
Remove the direct litellm dependency from pyproject.toml.

litellm version constraints should follow google-adk, which already manages the dependency constraint.