### PR TITLE
fix(runtime): import AsyncCodex from openai_codex, not codex_app_server

### DIFF
--- a/veadk/runtime/__init__.py
+++ b/veadk/runtime/__init__.py
@@ -61,8 +61,8 @@ def get_runtime(name: str) -> BaseRuntime:
         except ModuleNotFoundError as e:
             raise ImportError(
                 f"The 'codex' runtime requires extra dependencies (missing: {e.name}). "
-                "Install the Codex binary and the codex_app_server SDK, plus: "
-                "pip install fastapi uvicorn"
+                "Install them with: pip install openai-codex fastapi uvicorn "
+                "(openai-codex bundles the Codex binary via openai-codex-cli-bin)."
             ) from e
 
         return CodexRuntime()

--- a/veadk/runtime/codex/runtime.py
+++ b/veadk/runtime/codex/runtime.py
@@ -28,7 +28,8 @@ Key guarantees (mirroring the ``cc`` runtime):
 - Codex only speaks the Responses API, so requests are routed through an
   in-process Responses→chat shim (see :mod:`veadk.runtime.codex.proxy`).
 
-Note: this requires the Codex binary on PATH and the ``codex_app_server`` SDK.
+Note: this requires the ``openai-codex`` SDK (``pip install openai-codex``),
+which bundles the Codex CLI binary via its ``openai-codex-cli-bin`` dependency.
 """
 
 from __future__ import annotations
@@ -37,7 +38,7 @@ import os
 import tempfile
 from typing import TYPE_CHECKING, AsyncGenerator
 
-from codex_app_server import AsyncCodex  # type: ignore[import-not-found]
+from openai_codex import AsyncCodex  # type: ignore[import-not-found]
 
 from veadk.runtime.base_runtime import BaseRuntime, build_system_append
 from veadk.runtime.codex.proxy import get_shim_url


### PR DESCRIPTION
## Problem

`Agent(runtime="codex")` fails at import:

```
ImportError: The 'codex' runtime requires extra dependencies (missing: codex_app_server).
```

`veadk/runtime/codex/runtime.py` imported `from codex_app_server import AsyncCodex`, but **`codex_app_server` does not exist on PyPI** (404). The OpenAI Codex Python SDK publishes the symbol as **`openai_codex.AsyncCodex`** (`pip install openai-codex`).

## Fix

- Import `AsyncCodex` from `openai_codex`. Its API matches our existing usage unchanged: `async with AsyncCodex()` → `thread_start(model=...)` → `await thread.run(prompt)`.
- Update the docstring and the `get_runtime` error message to point at the real package.

## Pure-pip, no binary setup

`openai-codex` depends on **`openai-codex-cli-bin`**, which ships the Codex CLI binary as a platform wheel (installed under `site-packages/codex_cli_bin/bin/`). The SDK locates it automatically — **no npm/brew/PATH setup required**. The runtime's other deps (`fastapi`, `uvicorn`) are unchanged.

Install:

```bash
pip install openai-codex fastapi uvicorn
```

## Verification

With `openai-codex` installed, a minimal `Agent(runtime="codex")` run now executes end-to-end through the runtime — loads the bundled binary, starts a thread, and reaches a live model turn (the only remaining error observed was a transient upstream "high demand" from the bridged model backend, not a code/setup issue).

ruff check + format pass (pre-commit).