### PR TITLE
fix(deps): support google-adk>=1.32.0 (migrate optional deps to openai 2.x)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,19 +57,19 @@ veadk = "veadk.cli.cli:veadk"
 extensions = [
     "redis>=5.0",                                           # For Redis database
     "cozeloop>=0.1.21",                                     # For Cozeloop Prompt manager
-    "llama-index==0.14.0",                                  # For KnowledgeBase and LongTermMemory
-    "llama-index-embeddings-openai-like==0.2.2",            # For Embeddings
-    "llama-index-llms-openai-like==0.5.1",                  # For KnowledgeBase and LongTermMemory
+    "llama-index>=0.14.0",                                  # For KnowledgeBase and LongTermMemory
+    "llama-index-embeddings-openai-like>=0.2.2",            # For Embeddings
+    "llama-index-llms-openai-like>=0.5.1",                  # For KnowledgeBase and LongTermMemory
     "llama-index-vector-stores-redis>=0.6.1",               # For Redis database
-    "llama-index-vector-stores-opensearch==0.6.1",          # For Opensearch database
-    "opensearch-py==2.8.0",
+    "llama-index-vector-stores-opensearch>=0.6.1",          # For Opensearch database
+    "opensearch-py>=2.8.0",
     "lark-oapi",
 ]
 database = [
     "redis>=5.0",                   # For Redis database
     "pymysql>=1.1.1",               # For MySQL database
     "volcengine>=1.0.193",          # For Viking DB
-    "mem0ai==0.1.118",              # For mem0
+    "mem0ai>=1.0.0,<2",             # For mem0; >=1.0 lifts the openai<1.110 cap (coexist with litellm openai 2.x), <2 keeps the kwargs add()/search() API veadk uses (2.x switched to an options object)
 ]
 speech = []
 a2ui = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,13 @@ dependencies = [
     "pydantic-settings==2.10.1", # Config management
     "a2a-sdk==0.3.7", # For Google Agent2Agent protocol
     "deprecated==1.2.18",
-    "google-adk==1.32.0", # For basic agent architecture
+    "google-adk>=1.32.0", # For basic agent architecture
+    # litellm and sqlalchemy are required by code paths veadk always uses
+    # (LiteLlm models, sessions). google-adk ships them in base on 1.x but moved
+    # them behind extras ([extensions]/[db]) on 2.x, so declare them directly to
+    # stay compatible across google-adk >= 1.32.0 (including 2.x).
+    "litellm>=1.83.7,<=1.83.14", # google-adk LiteLlm model ([extensions] on 2.x)
+    "sqlalchemy>=2,<3", # google-adk sessions ([db] on 2.x)
     "loguru==0.7.3", # For better logging
     "opentelemetry-exporter-otlp==1.37.0",
     "opentelemetry-instrumentation-logging>=0.56b0",


### PR DESCRIPTION
## What

Make veadk install & run across **google-adk 1.x and 2.x** (`google-adk>=1.32.0`).

## Why

- google-adk **2.x moved `litellm` and `sqlalchemy` behind extras**
  (`[extensions]`/`[db]`). veadk uses both unconditionally (LiteLlm models,
  `sessions`), so a bare install on adk 2.x failed at import. Declare them
  directly in base.
- adk's `litellm` (>=1.83.7) pins **openai 2.x** (`openai==2.24.0`/`2.30.0`),
  which clashed with veadk's optional extras that pinned **openai 1.x**
  (`mem0ai==0.1.118` → `openai<1.110`; `llama-index==0.14.0` stack →
  `llama-index-llms-openai` 0.5.x → openai 1.x). Resolving `--all-extras` was
  therefore unsatisfiable. Migrate those optional deps to openai-2.x-compatible
  versions.

## Changes (`pyproject.toml` only)

- `google-adk` → `>=1.32.0`.
- base: add `litellm>=1.83.7,<=1.83.14`, `sqlalchemy>=2,<3` (adk's own ranges).
- `[extensions]`: relax the `llama-index*` pins to `>=` (resolve to 0.14.22 +
  `llama-index-llms-openai` 0.7.9, which support openai 2.x).
- `[database]`: `mem0ai==0.1.118` → `mem0ai>=1.0.0,<2`. `>=1.0` lifts the
  `openai<1.110` cap; `<2` keeps the kwargs `add()`/`search()` API veadk's
  mem0 backend uses (mem0 2.x switched to an `options` object — would break at
  runtime).

## Verification

`uv pip compile --all-extras` resolves on **py3.10 and py3.13**. Fresh
`--all-extras` install (252 pkgs): google-adk 2.2.0, litellm 1.83.14,
openai 2.24.0, llama-index 0.14.22, mem0ai 1.0.11, sqlalchemy 2.0.50.

- `uv pip check` → clean.
- Module import sweep (incl. knowledgebase / long_term_memory / mem0 backend) → OK.
- `mem0.MemoryClient.add/search` signatures match veadk's usage on 1.0.x.
- Local KnowledgeBase add+search (real llama-index + Ark embedding) → correct results.
- Real Agent invoke (Agent → Runner → Ark) → OK.

## Note

Behavior change: fresh installs now resolve to google-adk 2.x. The
Agent/Runner/sessions, RAG, and mem0-signature paths are verified; reviewers may
still want to smoke-test the full RAG/long-term-memory flows against live
backends (OpenSearch/Redis/Viking/mem0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)