### PR TITLE
docs(cli): add Harness command reference (zh/en)

### DIFF
--- a/docs/content/docs/cli/harness-cli.en.mdx
+++ b/docs/content/docs/cli/harness-cli.en.mdx
@@ -1,0 +1,105 @@
+---
+title: "Harness Commands"
+description: "Register and invoke harnesses (agent specs) on a deployed Harness server from the CLI."
+---
+
+`veadk agentkit harness` is a thin set of HTTP client commands for a deployed
+**Harness server** (`veadk.cloud.harness_app`).
+
+A *harness* is a named agent spec — **model + system prompt + tools + skills**.
+The Harness server exposes `/harness/add` and `/harness/invoke`, letting you
+register and invoke harnesses at runtime without redeploying.
+
+<Callout type="info">
+  Before you start, deploy the Harness server to Volcengine AgentKit (see the
+  [`14_harness_server_on_agentkit`](https://github.com/volcengine/veadk-python/tree/main/examples/14_harness_server_on_agentkit)
+  example) and grab its **endpoint URL** and gateway **API key**.
+</Callout>
+
+## Command reference
+
+| Command | Description |
+| :-- | :-- |
+| `veadk agentkit harness add` | Register a new harness on the server. |
+| `veadk agentkit harness invoke` | Invoke a harness and print its output. |
+
+## Connection options
+
+Both commands need the server address and auth, supplied via options or
+environment variables:
+
+| Option | Env var | Description |
+| :-- | :-- | :-- |
+| `--url` | `HARNESS_URL` | Harness server base URL (required). |
+| `--key` | `HARNESS_KEY` | Gateway API key for Bearer auth (optional). |
+| — | `HARNESS_TIMEOUT` | Client request timeout in seconds, default `600` (agent runs can be slow). |
+
+## `harness add`
+
+Register a named harness on the server.
+
+```bash
+veadk agentkit harness add \
+  --name research-agent \
+  --model-name doubao-seed-1-6-250615 \
+  --system-prompt "You are a research assistant." \
+  --tools web_search,web_fetch \
+  --url "<ENDPOINT>" --key "<API_KEY>"
+```
+
+| Option | Required | Description |
+| :-- | :-- | :-- |
+| `--name` | Yes | Harness (agent) name. |
+| `--model-name` | No | Model name; defaults to the server's `MODEL_AGENT_NAME`. |
+| `--system-prompt` | No | System prompt; defaults to `You are a helpful assistant.`. |
+| `--tools` | No | Comma-separated built-in tool names, e.g. `web_search,web_fetch`. |
+| `--skills` | No | Comma-separated skill hub names, e.g. `clawhub/lgwventrue/system-file-handler`. |
+
+<Callout type="warn">
+  If a harness with the same name already exists, the server returns `code: 400`
+  and does not overwrite it.
+</Callout>
+
+## `harness invoke`
+
+Invoke an **already-registered** harness and print its output. The message is a
+positional argument.
+
+```bash
+veadk agentkit harness invoke \
+  --harness research-agent \
+  --url "<ENDPOINT>" --key "<API_KEY>" \
+  "Summarize the latest on reinforcement learning."
+```
+
+| Option | Required | Description |
+| :-- | :-- | :-- |
+| `MESSAGE` (positional) | Yes | The message to send to the harness. |
+| `--harness` | Yes | Harness name to invoke. |
+| `--user-id` | No | User id for the session, default `cli-user`. |
+| `--session-id` | No | Session id for the call, default `cli-session`. |
+| `--model-name` | No | Override the model for this call only (creates a one-time harness). |
+| `--system-prompt` | No | Override the system prompt for this call only (creates a one-time harness). |
+| `--tools` | No | Override tools for this call only, comma-separated (creates a one-time harness). |
+| `--skills` | No | Override skills for this call only, comma-separated (creates a one-time harness). |
+
+### One-time harness override
+
+If any of `--model-name` / `--system-prompt` / `--tools` / `--skills` is passed
+to `invoke`, the server builds a **one-time harness** from those fields that
+applies to this single call only — the stored harness of the same name is left
+untouched:
+
+```bash
+veadk agentkit harness invoke \
+  --harness research-agent \
+  --system-prompt "Answer in one sentence." \
+  --url "<ENDPOINT>" --key "<API_KEY>" \
+  "What is reinforcement learning?"
+```
+
+## Full example
+
+For the end-to-end deploy-and-invoke flow (including the `curl` equivalents),
+see the [`14_harness_server_on_agentkit`](https://github.com/volcengine/veadk-python/tree/main/examples/14_harness_server_on_agentkit)
+example.

--- a/docs/content/docs/cli/harness-cli.mdx
+++ b/docs/content/docs/cli/harness-cli.mdx
@@ -1,0 +1,92 @@
+---
+title: "Harness 命令"
+description: "通过命令行注册并调用部署在 Harness server 上的 harness（智能体规格）。"
+---
+
+`veadk agentkit harness` 是一组轻量的 HTTP 客户端命令，用于操作已部署的 **Harness server**（`veadk.cloud.harness_app`）。
+
+一个 *harness* 就是一份具名的智能体规格 —— **模型 + 系统提示词 + 工具 + 技能**。Harness server 暴露 `/harness/add` 与 `/harness/invoke` 两个接口，让你在运行时动态注册并调用 harness，无需重新部署。
+
+<Callout type="info">
+  使用前需先把 Harness server 部署到火山引擎 AgentKit（参见示例 [`14_harness_server_on_agentkit`](https://github.com/volcengine/veadk-python/tree/main/examples/14_harness_server_on_agentkit)），并拿到服务的 **Endpoint URL** 与网关 **API Key**。
+</Callout>
+
+## 命令一览
+
+| 命令 | 描述 |
+| :-- | :-- |
+| `veadk agentkit harness add` | 在服务端注册一个新的 harness。 |
+| `veadk agentkit harness invoke` | 调用一个 harness 并打印输出。 |
+
+## 连接参数
+
+两个命令都需要指定 Harness server 的地址与鉴权，可通过命令行选项或环境变量提供：
+
+| 选项 | 环境变量 | 说明 |
+| :-- | :-- | :-- |
+| `--url` | `HARNESS_URL` | Harness server 的基础 URL（必填）。 |
+| `--key` | `HARNESS_KEY` | 网关 API Key，用于 Bearer 鉴权（可选）。 |
+| — | `HARNESS_TIMEOUT` | 客户端请求超时秒数，默认 `600`（智能体执行可能耗时较长）。 |
+
+## `harness add`
+
+在服务端注册一个具名 harness。
+
+```bash
+veadk agentkit harness add \
+  --name research-agent \
+  --model-name doubao-seed-1-6-250615 \
+  --system-prompt "You are a research assistant." \
+  --tools web_search,web_fetch \
+  --url "<ENDPOINT>" --key "<API_KEY>"
+```
+
+| 选项 | 必填 | 说明 |
+| :-- | :-- | :-- |
+| `--name` | 是 | harness（智能体）名称。 |
+| `--model-name` | 否 | 模型名称，缺省使用服务端的 `MODEL_AGENT_NAME`。 |
+| `--system-prompt` | 否 | 系统提示词，默认 `You are a helpful assistant.`。 |
+| `--tools` | 否 | 逗号分隔的内置工具名，如 `web_search,web_fetch`。 |
+| `--skills` | 否 | 逗号分隔的技能 hub 名，如 `clawhub/lgwventrue/system-file-handler`。 |
+
+<Callout type="warn">
+  若同名 harness 已存在，服务端返回 `code: 400`，不会覆盖。
+</Callout>
+
+## `harness invoke`
+
+调用一个**已注册**的 harness，并打印其输出。消息作为位置参数传入。
+
+```bash
+veadk agentkit harness invoke \
+  --harness research-agent \
+  --url "<ENDPOINT>" --key "<API_KEY>" \
+  "总结一下强化学习的最新进展。"
+```
+
+| 选项 | 必填 | 说明 |
+| :-- | :-- | :-- |
+| `MESSAGE`（位置参数） | 是 | 发送给 harness 的消息。 |
+| `--harness` | 是 | 要调用的 harness 名称。 |
+| `--user-id` | 否 | 会话所属用户 id，默认 `cli-user`。 |
+| `--session-id` | 否 | 本次调用的会话 id，默认 `cli-session`。 |
+| `--model-name` | 否 | 仅本次调用覆盖模型（生成一次性 harness）。 |
+| `--system-prompt` | 否 | 仅本次调用覆盖系统提示词（生成一次性 harness）。 |
+| `--tools` | 否 | 仅本次调用覆盖工具，逗号分隔（生成一次性 harness）。 |
+| `--skills` | 否 | 仅本次调用覆盖技能，逗号分隔（生成一次性 harness）。 |
+
+### 一次性 harness 覆盖
+
+`invoke` 时若提供了 `--model-name` / `--system-prompt` / `--tools` / `--skills` 中的任意一个，服务端会用这些字段构造一个**一次性 harness**，仅对本次调用生效，不影响已注册的同名 harness：
+
+```bash
+veadk agentkit harness invoke \
+  --harness research-agent \
+  --system-prompt "只用一句话回答。" \
+  --url "<ENDPOINT>" --key "<API_KEY>" \
+  "什么是强化学习？"
+```
+
+## 完整示例
+
+端到端的部署与调用流程（含 `curl` 等价写法）参见示例 [`14_harness_server_on_agentkit`](https://github.com/volcengine/veadk-python/tree/main/examples/14_harness_server_on_agentkit)。

--- a/docs/content/docs/cli/index.en.mdx
+++ b/docs/content/docs/cli/index.en.mdx
@@ -12,4 +12,5 @@ veadk --help
 <Cards>
   <Card title="VeADK CLI" href="/en/docs/cli/veadk-cli" description="Full reference for init, create, web, kb, deploy, eval, prompt, uploadevalset, pipeline, and more." />
   <Card title="AgentKit compatibility" href="/en/docs/cli/agentkit-cli" description="Reuse the AgentKit workflow through veadk agentkit." />
+  <Card title="Harness commands" href="/en/docs/cli/harness-cli" description="Register and invoke harnesses on a deployed Harness server." />
 </Cards>

--- a/docs/content/docs/cli/index.mdx
+++ b/docs/content/docs/cli/index.mdx
@@ -12,4 +12,5 @@ veadk --help
 <Cards>
   <Card title="VeADK CLI" href="/cn/docs/cli/veadk-cli" description="init、create、web、kb、deploy、eval、prompt、uploadevalset、pipeline 等命令的完整参考。" />
   <Card title="AgentKit 命令兼容" href="/cn/docs/cli/agentkit-cli" description="通过 veadk agentkit 复用 AgentKit 工作流。" />
+  <Card title="Harness 命令" href="/cn/docs/cli/harness-cli" description="注册并调用部署在 Harness server 上的 harness。" />
 </Cards>

--- a/docs/content/docs/cli/meta.en.json
+++ b/docs/content/docs/cli/meta.en.json
@@ -2,5 +2,5 @@
   "title": "CLI",
   "icon": "Terminal",
   "root": true,
-  "pages": ["index", "veadk-cli", "agentkit-cli"]
+  "pages": ["index", "veadk-cli", "agentkit-cli", "harness-cli"]
 }

--- a/docs/content/docs/cli/meta.json
+++ b/docs/content/docs/cli/meta.json
@@ -2,5 +2,5 @@
   "title": "命令行工具",
   "icon": "Terminal",
   "root": true,
-  "pages": ["index", "veadk-cli", "agentkit-cli"]
+  "pages": ["index", "veadk-cli", "agentkit-cli", "harness-cli"]
 }


### PR DESCRIPTION
## What

Adds a CLI documentation page for the `veadk agentkit harness` commands, the HTTP client for a deployed Harness server (`veadk.cloud.harness_app`).

## Pages

- `docs/content/docs/cli/harness-cli.mdx` (中文)
- `docs/content/docs/cli/harness-cli.en.mdx` (English)

Wired into CLI nav: `meta.json` / `meta.en.json` page order + a card in `index.mdx` / `index.en.mdx`.

## Content

Sourced from the actual implementation in `veadk/cli/cli_agentkit.py` and `veadk/cloud/harness_app.py`:

- **Concept** — a harness = model + system prompt + tools + skills, registered/invoked at runtime against a deployed server.
- **Connection options** — `--url`/`HARNESS_URL`, `--key`/`HARNESS_KEY`, `HARNESS_TIMEOUT` (default 600s).
- **`harness add`** — full option table; notes the 400-on-duplicate behavior (no overwrite).
- **`harness invoke`** — positional `MESSAGE`, `--harness`, `--user-id`/`--session-id`, plus the one-time harness override (any of `--model-name`/`--system-prompt`/`--tools`/`--skills` applies to that single call only).
- Links to the end-to-end `14_harness_server_on_agentkit` example.

## Notes

- Commands are documented under `veadk agentkit harness ...` since `harness` is a subgroup of the `agentkit` group, not a top-level command.
- biome passes on the JSON; `.mdx` is excluded by the docs biome config (same as the existing `agentkit-cli.mdx`).