### PR TITLE
test: add contract/signature tests for new + core modules

### DIFF
--- a/tests/agent/test_agent_contract.py
+++ b/tests/agent/test_agent_contract.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for the ``veadk.Agent`` public field surface.
+
+``Agent`` is a pydantic model whose fields are its public configuration API
+(used directly by callers and by the Harness server / web studio codegen). These
+tests pin the veadk-specific fields and their defaults. They intentionally do
+*not* assert the full field set — that includes inherited google-adk
+``LlmAgent`` fields, which would make the test brittle against ADK upgrades.
+"""
+
+from veadk import Agent
+
+# veadk-specific fields with simple, stable defaults. (model_* fields are
+# default_factory-bound to settings and so are checked only for presence.)
+_EXPECTED_DEFAULTS = {
+    "enable_responses": False,
+    "enable_responses_cache": True,
+    "enable_authz": False,
+    "auto_save_session": False,
+    "enable_supervisor": False,
+    "enable_ghostchar": False,
+    "enable_dataset_gen": False,
+    "enable_dynamic_load_skills": False,
+    "enable_skills_checklist": False,
+    "enable_tunnel": False,
+    "runtime": "adk",
+}
+
+_EXPECTED_PRESENT = {
+    "name",
+    "description",
+    "instruction",
+    "model_name",
+    "model_provider",
+    "model_api_base",
+    "model_api_key",
+    "model_extra_config",
+    "tools",
+    "sub_agents",
+    "knowledgebase",
+    "short_term_memory",
+    "long_term_memory",
+    "tracers",
+    "skills",
+    "skills_mode",
+}
+
+
+def test_agent_is_pydantic_model():
+    assert hasattr(Agent, "model_fields")
+
+
+def test_expected_fields_present():
+    missing = _EXPECTED_PRESENT - set(Agent.model_fields)
+    assert not missing, f"Agent lost expected fields: {missing}"
+
+
+def test_field_defaults():
+    fields = dict(Agent.model_fields)
+    for name, expected in _EXPECTED_DEFAULTS.items():
+        assert name in fields, f"Agent lost field {name!r}"
+        assert fields[name].default == expected, (
+            f"Agent.{name} default changed: {fields[name].default!r} != {expected!r}"
+        )
+
+
+def test_skills_defaults_to_empty_list():
+    # default_factory=list -> assert via an instantiation-free factory call.
+    factory = Agent.model_fields["skills"].default_factory
+    assert factory is not None
+    assert factory() == []  # type: ignore[call-arg]  # pydantic's overloaded factory type

--- a/tests/cli/test_cli_agentkit_harness_contract.py
+++ b/tests/cli/test_cli_agentkit_harness_contract.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for the ``veadk agentkit harness`` CLI commands.
+
+These pin the click command tree, option names, required flags, defaults, and
+the ``HARNESS_URL`` / ``HARNESS_KEY`` env-var bindings, so a rename or a changed
+default that would break documented usage is caught here.
+"""
+
+import click
+
+from veadk.cli.cli_agentkit import harness
+
+
+def _options(command: click.Command) -> dict[str | None, click.Parameter]:
+    """Map of parameter name -> click Parameter for ``command``."""
+    return {param.name: param for param in command.params}
+
+
+def test_harness_is_a_group_with_add_and_invoke():
+    assert isinstance(harness, click.Group)
+    assert set(harness.commands) == {"add", "invoke"}
+
+
+class TestHarnessAdd:
+    def setup_method(self):
+        self.cmd = harness.commands["add"]
+        self.opts = _options(self.cmd)
+
+    def test_option_names(self):
+        assert set(self.opts) == {
+            "name",
+            "model_name",
+            "system_prompt",
+            "tools",
+            "skills",
+            "url",
+            "key",
+        }
+
+    def test_required_flags(self):
+        assert self.opts["name"].required is True
+        assert self.opts["url"].required is True
+        # Optional ones must stay optional.
+        for name in ("model_name", "system_prompt", "tools", "skills", "key"):
+            assert self.opts[name].required is False
+
+    def test_default_system_prompt(self):
+        assert self.opts["system_prompt"].default == "You are a helpful assistant."
+
+    def test_env_var_bindings(self):
+        assert self.opts["url"].envvar == "HARNESS_URL"
+        assert self.opts["key"].envvar == "HARNESS_KEY"
+
+
+class TestHarnessInvoke:
+    def setup_method(self):
+        self.cmd = harness.commands["invoke"]
+        self.opts = _options(self.cmd)
+
+    def test_parameters(self):
+        # One positional MESSAGE argument plus the named options.
+        assert set(self.opts) == {
+            "message",
+            "harness_name",
+            "model_name",
+            "system_prompt",
+            "tools",
+            "skills",
+            "user_id",
+            "session_id",
+            "url",
+            "key",
+        }
+
+    def test_message_is_positional_argument(self):
+        assert isinstance(self.opts["message"], click.Argument)
+        assert self.opts["message"].required is True
+
+    def test_required_flags(self):
+        assert self.opts["harness_name"].required is True
+        assert self.opts["url"].required is True
+
+    def test_session_defaults(self):
+        assert self.opts["user_id"].default == "cli-user"
+        assert self.opts["session_id"].default == "cli-session"
+
+    def test_env_var_bindings(self):
+        assert self.opts["url"].envvar == "HARNESS_URL"
+        assert self.opts["key"].envvar == "HARNESS_KEY"

--- a/tests/cloud/test_harness_app_contract.py
+++ b/tests/cloud/test_harness_app_contract.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for the Harness server (``veadk.cloud.harness_app``).
+
+These pin the HTTP request/response *schemas* and the ``HarnessApp`` surface so
+that a change to a model field name, default, or route silently breaking the
+deployed server (or the ``veadk agentkit harness`` CLI client) is caught here
+rather than in production. No network or model access is required.
+"""
+
+import inspect
+
+from veadk.cloud import harness_app
+from veadk.cloud.harness_app import (
+    AddHarnessRequest,
+    AddHarnessResponse,
+    Harness,
+    HarnessApp,
+    InvokeHarnessRequest,
+    InvokeHarnessResponse,
+    RunAgentRequest,
+)
+from veadk.consts import DEFAULT_MODEL_AGENT_NAME
+
+
+def _fields(model) -> dict:
+    """Map of pydantic field name -> FieldInfo for ``model``."""
+    return dict(model.model_fields)
+
+
+class TestHarnessModel:
+    def test_fields(self):
+        assert set(_fields(Harness)) == {
+            "model_name",
+            "tools",
+            "skills",
+            "system_prompt",
+        }
+
+    def test_defaults(self):
+        fields = _fields(Harness)
+        assert fields["model_name"].default == DEFAULT_MODEL_AGENT_NAME
+        assert fields["tools"].default == ""
+        assert fields["skills"].default == ""
+        assert fields["system_prompt"].default == "You are a helpful assistant."
+
+    def test_tools_and_skills_are_csv_strings(self):
+        # The server splits these with _split_csv(); they must stay plain
+        # strings, not lists, to keep the CLI/curl pass-through contract.
+        h = Harness()
+        assert isinstance(h.tools, str)
+        assert isinstance(h.skills, str)
+
+
+class TestRequestResponseSchemas:
+    def test_add_request_fields(self):
+        assert set(_fields(AddHarnessRequest)) == {"harness_name", "harness"}
+
+    def test_add_response_fields_and_defaults(self):
+        fields = _fields(AddHarnessResponse)
+        assert set(fields) == {"code", "msg", "harness_name"}
+        assert fields["code"].default == 200
+
+    def test_run_agent_request_fields(self):
+        assert set(_fields(RunAgentRequest)) == {"user_id", "session_id"}
+
+    def test_invoke_request_fields(self):
+        assert set(_fields(InvokeHarnessRequest)) == {
+            "prompt",
+            "harness_name",
+            "harness",
+            "run_agent_request",
+        }
+
+    def test_invoke_request_harness_is_optional(self):
+        # A null `harness` means "use the stored one"; a non-null one is the
+        # once-time override. The field must therefore allow None.
+        assert _fields(InvokeHarnessRequest)["harness"].default is None
+
+    def test_invoke_response_fields_and_defaults(self):
+        fields = _fields(InvokeHarnessResponse)
+        assert set(fields) == {"harness_name", "overwrite", "output"}
+        assert fields["overwrite"].default is False
+
+
+class TestHarnessApp:
+    def test_public_methods_exist(self):
+        for name in ("mount", "serve"):
+            assert callable(getattr(HarnessApp, name))
+
+    def test_serve_signature_defaults(self):
+        sig = inspect.signature(HarnessApp.serve)
+        assert sig.parameters["host"].default == "0.0.0.0"
+        assert sig.parameters["port"].default == 8000
+
+    def test_routes_registered(self):
+        app = HarnessApp()
+        paths = {getattr(route, "path", None) for route in app.app.routes}
+        assert {"/harness/add", "/harness/invoke"} <= paths
+
+
+class TestSplitCsv:
+    def test_splits_and_trims(self):
+        assert harness_app._split_csv("web_search, web_fetch") == [
+            "web_search",
+            "web_fetch",
+        ]
+
+    def test_empty_string_is_empty_list(self):
+        assert harness_app._split_csv("") == []
+
+    def test_drops_blank_segments(self):
+        assert harness_app._split_csv("a,,  ,b") == ["a", "b"]

--- a/tests/runner/test_runner_contract.py
+++ b/tests/runner/test_runner_contract.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for ``veadk.runner.Runner``.
+
+``Runner.__init__`` and ``Runner.run`` are the primary entry points callers and
+examples use. These tests pin their parameter names and defaults so a silent
+signature change (e.g. a renamed/removed kwarg) is caught here.
+"""
+
+import inspect
+
+from veadk.runner import Runner
+
+
+class TestRunnerInit:
+    def test_parameter_order(self):
+        sig = inspect.signature(Runner.__init__)
+        # Leading, explicitly-named parameters before *args/**kwargs pass-through.
+        ordered = [
+            name
+            for name, param in sig.parameters.items()
+            if param.kind
+            in (
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            )
+        ]
+        assert ordered == [
+            "self",
+            "agent",
+            "short_term_memory",
+            "app_name",
+            "user_id",
+            "upload_inline_data_to_tos",
+            "run_processor",
+        ]
+
+    def test_defaults(self):
+        params = inspect.signature(Runner.__init__).parameters
+        assert params["agent"].default is None
+        assert params["short_term_memory"].default is None
+        assert params["app_name"].default is None
+        assert params["user_id"].default == "veadk_default_user"
+        assert params["upload_inline_data_to_tos"].default is False
+        assert params["run_processor"].default is None
+
+    def test_accepts_var_args_and_kwargs(self):
+        # *args/**kwargs are part of the contract: they pass through to ADKRunner
+        # (e.g. session_service / memory_service overrides).
+        kinds = {p.kind for p in inspect.signature(Runner.__init__).parameters.values()}
+        assert inspect.Parameter.VAR_POSITIONAL in kinds
+        assert inspect.Parameter.VAR_KEYWORD in kinds
+
+
+class TestRunnerRun:
+    def test_is_coroutine(self):
+        assert inspect.iscoroutinefunction(Runner.run)
+
+    def test_parameters(self):
+        sig = inspect.signature(Runner.run)
+        assert list(sig.parameters) == [
+            "self",
+            "messages",
+            "user_id",
+            "session_id",
+            "run_config",
+            "save_tracing_data",
+            "upload_inline_data_to_tos",
+            "run_processor",
+        ]
+
+    def test_defaults(self):
+        params = inspect.signature(Runner.run).parameters
+        assert params["user_id"].default == ""
+        assert isinstance(params["session_id"].default, str)
+        assert params["run_config"].default is None
+        assert params["save_tracing_data"].default is False
+        assert params["upload_inline_data_to_tos"].default is False
+        assert params["run_processor"].default is None
+
+
+def test_public_helper_methods_exist():
+    for name in (
+        "get_trace_id",
+        "save_tracing_file",
+        "save_eval_set",
+        "save_session_to_long_term_memory",
+    ):
+        assert callable(getattr(Runner, name))

--- a/tests/tools/builtin_tools/test_web_fetch_contract.py
+++ b/tests/tools/builtin_tools/test_web_fetch_contract.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for the ``web_fetch`` built-in tool.
+
+``web_fetch`` is exposed to agents as a function tool, so its signature *is* the
+schema the model sees. These tests pin the parameter names and defaults and the
+shape of the dict it returns, without making any network request.
+"""
+
+import inspect
+
+from veadk.tools import get_builtin_tool
+from veadk.tools.builtin_tools.web_fetch import web_fetch
+
+
+def test_signature():
+    sig = inspect.signature(web_fetch)
+    assert list(sig.parameters) == ["url", "extract_mode", "max_chars", "tool_context"]
+
+
+def test_defaults():
+    params = inspect.signature(web_fetch).parameters
+    assert params["url"].default is inspect.Parameter.empty  # required
+    assert params["extract_mode"].default == "markdown"
+    assert isinstance(params["max_chars"].default, int)
+    assert params["tool_context"].default is None
+
+
+def test_registered_as_web_fetch():
+    assert get_builtin_tool("web_fetch") is web_fetch
+
+
+def test_invalid_url_returns_error_dict():
+    # A non-public / malformed URL must fail closed with an "error" key rather
+    # than raising — the agent gets a tool result, not an exception.
+    result = web_fetch("not-a-valid-url")
+    assert isinstance(result, dict)
+    assert "error" in result

--- a/tests/tools/test_builtin_registry_contract.py
+++ b/tests/tools/test_builtin_registry_contract.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for the built-in tool registry (``veadk.tools``).
+
+The Harness server resolves harness ``tools`` strings through this registry, so
+a renamed/removed built-in tool would break harnesses that reference it by name.
+These tests pin the registry API and the set of advertised names.
+"""
+
+import inspect
+
+import pytest
+
+from veadk.tools import get_builtin_tool, list_builtin_tools
+
+# Names that callers (harnesses, docs, examples) rely on. New tools may be
+# added freely; removing/renaming one should be a deliberate, reviewed change
+# that updates this list.
+_EXPECTED_NAMES = {
+    "web_search",
+    "web_fetch",
+    "parallel_web_search",
+    "vesearch",
+    "link_reader",
+    "run_code",
+    "coding",
+    "image_generate",
+    "image_edit",
+    "video_generate",
+    "text_to_speech",
+}
+
+
+def test_list_builtin_tools_is_sorted():
+    names = list_builtin_tools()
+    assert names == sorted(names)
+
+
+def test_expected_names_present():
+    assert _EXPECTED_NAMES <= set(list_builtin_tools())
+
+
+def test_get_builtin_tool_signature():
+    sig = inspect.signature(get_builtin_tool)
+    assert list(sig.parameters) == ["name"]
+
+
+@pytest.mark.parametrize("name", sorted(_EXPECTED_NAMES))
+def test_every_advertised_tool_resolves(name):
+    # Lazy import inside get_builtin_tool must succeed and return something
+    # callable/usable (a function or a tool/toolset object).
+    tool = get_builtin_tool(name)
+    assert tool is not None
+
+
+def test_unknown_tool_raises_key_error():
+    with pytest.raises(KeyError):
+        get_builtin_tool("definitely_not_a_tool")

--- a/tests/tools/test_builtin_registry_contract.py
+++ b/tests/tools/test_builtin_registry_contract.py
@@ -20,10 +20,17 @@ These tests pin the registry API and the set of advertised names.
 """
 
 import inspect
+import os
 
 import pytest
 
-from veadk.tools import get_builtin_tool, list_builtin_tools
+# Some generation tools (image/video) read ``settings.model.api_key`` at import
+# time, which fetches a live ARK token over the network when MODEL_AGENT_API_KEY
+# is unset (e.g. in CI). Provide a dummy so resolving every tool stays offline;
+# a real value in the local environment is preserved by setdefault.
+os.environ.setdefault("MODEL_AGENT_API_KEY", "test-model-api-key")
+
+from veadk.tools import get_builtin_tool, list_builtin_tools  # noqa: E402
 
 # Names that callers (harnesses, docs, examples) rely on. New tools may be
 # added freely; removing/renaming one should be a deliberate, reviewed change

--- a/tests/tunnel/test_tunnel_contract.py
+++ b/tests/tunnel/test_tunnel_contract.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for ``veadk.tunnel``.
+
+The tunnel has three sides (cloud / agent / enterprise connector) that talk to
+each other across processes and machines. A drift in the public types, their
+fields, or the wire ``descriptor()`` shape would silently break that handshake.
+These tests pin the public surface; they create no sockets and dial no network.
+"""
+
+import dataclasses
+import inspect
+
+import veadk.tunnel as tunnel
+from veadk.tunnel import (
+    LocalServer,
+    ServerDescriptor,
+    TunnelConnector,
+    TunnelRegistry,
+    TunnelToolset,
+    get_registry,
+    mount_tunnel,
+    mount_tunnel_if_enabled,
+)
+
+
+def test_public_exports():
+    assert set(tunnel.__all__) == {
+        "LocalServer",
+        "TunnelConnector",
+        "ServerDescriptor",
+        "TunnelRegistry",
+        "get_registry",
+        "mount_tunnel",
+        "mount_tunnel_if_enabled",
+        "TunnelToolset",
+    }
+    for name in tunnel.__all__:
+        assert hasattr(tunnel, name)
+
+
+class TestLocalServer:
+    def test_is_dataclass_with_expected_fields(self):
+        assert dataclasses.is_dataclass(LocalServer)
+        names = {f.name for f in dataclasses.fields(LocalServer)}
+        assert names == {
+            "name",
+            "address",
+            "protocol",
+            "tool_filter",
+            "headers",
+            "query",
+        }
+
+    def test_protocol_default_is_mcp(self):
+        server = LocalServer(name="db", address="http://host:9000/mcp")
+        assert server.protocol == "mcp"
+
+    def test_descriptor_keeps_address_connector_side(self):
+        # descriptor() is sent to the cloud; address/headers/query must NOT be
+        # in it (they stay on the connector).
+        server = LocalServer(name="db", address="http://host:9000/mcp")
+        descriptor = server.descriptor()
+        assert set(descriptor) == {"name", "protocol", "tool_filter"}
+        assert "address" not in descriptor
+
+
+class TestServerDescriptor:
+    def test_fields_and_defaults(self):
+        fields = dict(ServerDescriptor.model_fields)
+        assert set(fields) == {
+            "name",
+            "protocol",
+            "address",
+            "tool_filter",
+            "headers",
+            "query",
+        }
+        assert fields["protocol"].default == "mcp"
+        assert fields["address"].default == ""
+        assert fields["tool_filter"].default is None
+
+
+class TestTunnelConnector:
+    def test_init_signature(self):
+        sig = inspect.signature(TunnelConnector.__init__)
+        params = list(sig.parameters)
+        assert params == [
+            "self",
+            "cloud_url",
+            "agent",
+            "servers",
+            "token",
+            "extra_headers",
+        ]
+        assert sig.parameters["token"].default is None
+        assert sig.parameters["extra_headers"].default is None
+
+    def test_start_is_coroutine(self):
+        assert inspect.iscoroutinefunction(TunnelConnector.start)
+
+    def test_cloud_url_is_stripped(self):
+        connector = TunnelConnector(
+            cloud_url="https://example.com/",
+            agent="ops",
+            servers=[LocalServer(name="db", address="http://host:9000/mcp")],
+        )
+        assert connector.cloud_url == "https://example.com"
+        assert connector.agent == "ops"
+
+
+class TestTunnelRegistry:
+    def test_public_methods(self):
+        for name in (
+            "add_connection",
+            "remove_connection",
+            "list_servers",
+            "find_connection",
+            "has_agent",
+        ):
+            assert callable(getattr(TunnelRegistry, name))
+
+    def test_get_registry_is_singleton(self):
+        assert get_registry() is get_registry()
+        assert isinstance(get_registry(), TunnelRegistry)
+
+    def test_unknown_agent_has_no_servers(self):
+        registry = TunnelRegistry()
+        assert registry.has_agent("nobody") is False
+        assert registry.list_servers("nobody") == []
+
+
+class TestMountAndToolset:
+    def test_mount_tunnel_signature(self):
+        sig = inspect.signature(mount_tunnel)
+        # `app` is positional; the rest are keyword-only with safe defaults.
+        assert list(sig.parameters) == [
+            "app",
+            "token",
+            "allowed_agents",
+            "auth",
+            "registry",
+        ]
+        for name in ("token", "allowed_agents", "auth", "registry"):
+            assert sig.parameters[name].default is None
+
+    def test_mount_tunnel_if_enabled_signature(self):
+        sig = inspect.signature(mount_tunnel_if_enabled)
+        assert list(sig.parameters)[:2] == ["app", "agents"]
+
+    def test_toolset_init_signature(self):
+        sig = inspect.signature(TunnelToolset.__init__)
+        assert list(sig.parameters) == ["self", "agent_name", "registry"]
+        assert sig.parameters["registry"].default is None


### PR DESCRIPTION
## What

Adds **contract/signature tests** organized by module directory (mirroring the package, google-adk test style). They pin public interfaces — function/method signatures, pydantic model fields, CLI options, and tool-registry names — so that a renamed parameter, changed default, dropped field, or removed route is caught by CI rather than in production.

No network or model access; the whole set runs in a few seconds.

## Layout

```
tests/
├── cloud/test_harness_app_contract.py          # Harness server schemas + routes + _split_csv
├── cli/test_cli_agentkit_harness_contract.py   # veadk agentkit harness add/invoke options
├── tools/test_builtin_registry_contract.py     # built-in tool registry
├── tools/builtin_tools/test_web_fetch_contract.py
├── tunnel/test_tunnel_contract.py              # connector / registry / mount / toolset surface
├── agent/test_agent_contract.py                # veadk-specific Agent fields + defaults
└── runner/test_runner_contract.py              # Runner.__init__ / run signatures
```

## Design notes

- **Contract-first**: assertions use `inspect.signature`, pydantic `model_fields`, and click `command.params` — they fail the moment an interface changes.
- **Upgrade-safe**: `Agent` pins only veadk's own fields, not inherited google-adk `LlmAgent` fields, so ADK upgrades don't cause false failures.
- **No I/O**: `web_fetch` is exercised only on a malformed URL (rejected at the scheme check, returns an `error` dict — no DNS/HTTP).

## Verification

- `pytest`: full suite **281 passed** (212 existing + 69 new), no regressions
- `ruff check` / `ruff format --check`: clean
- `pyright`: 0 errors

Targeted modules moved from **0% → 40–100%** coverage (harness_app 47%, tunnel registry 70%, tools registry 100%, agent 48%, runner 43%); overall veadk coverage 24% → 27%. This is a first step toward the google-adk baseline (81%); lightweight mocked behavior tests are the natural follow-up.