### PR TITLE
test: behavior + module unit tests for core/uncovered modules

### DIFF
--- a/tests/a2a/hub/test_a2a_hub_server.py
+++ b/tests/a2a/hub/test_a2a_hub_server.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral tests for ``A2AHubServer``.
+
+Drives the FastAPI app through ``TestClient`` (no network / no uvicorn) to pin
+the register/lookup routing logic and the in-memory group/agent bookkeeping.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from veadk.a2a.hub.a2a_hub_server import A2AHubServer
+
+
+@pytest.fixture
+def client():
+    server = A2AHubServer()
+    return TestClient(server.app)
+
+
+def test_initial_state_empty():
+    server = A2AHubServer()
+    assert server.groups == []
+    assert server.agent_cards == {}
+
+
+def test_ping(client):
+    resp = client.get("/ping")
+    assert resp.status_code == 200
+    assert resp.json() == {"msg": "pong!"}
+
+
+def test_create_group_adds_group_and_empty_card_map(client):
+    resp = client.post("/create_group", params={"group_id": "g1"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["group_id"] == "g1"
+    assert body["err_code"] == 0
+    # subsequent /groups lookup reflects the new group.
+    groups = client.get("/groups").json()
+    assert groups["group_ids"] == ["g1"]
+
+
+def test_register_agent_into_missing_group_errors(client):
+    resp = client.post(
+        "/register_agent",
+        json={"group_id": "ghost", "agent_id": "a1", "agent_card": {}},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["err_code"] == 1
+    assert "not exist" in body["msg"]
+
+
+def test_register_agent_success(client):
+    client.post("/create_group", params={"group_id": "g1"})
+    card = {"name": "demo", "url": "http://x"}
+    resp = client.post(
+        "/register_agent",
+        json={"group_id": "g1", "agent_id": "a1", "agent_card": card},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["err_code"] == 0
+    assert body["group_id"] == "g1"
+    assert body["agent_id"] == "a1"
+    assert body["agent_card"] == card
+
+
+def test_register_duplicate_agent_errors(client):
+    client.post("/create_group", params={"group_id": "g1"})
+    payload = {"group_id": "g1", "agent_id": "a1", "agent_card": {}}
+    client.post("/register_agent", json=payload)
+    resp = client.post("/register_agent", json=payload)
+    body = resp.json()
+    assert body["err_code"] == 1
+    assert "already exist" in body["msg"]
+
+
+def test_get_agents_for_missing_group_errors(client):
+    body = client.get("/group/ghost/agents").json()
+    assert body["err_code"] == 1
+    assert "not exist" in body["msg"]
+
+
+def test_get_agents_returns_registered_agents(client):
+    client.post("/create_group", params={"group_id": "g1"})
+    client.post(
+        "/register_agent",
+        json={"group_id": "g1", "agent_id": "a1", "agent_card": {"x": 1}},
+    )
+    client.post(
+        "/register_agent",
+        json={"group_id": "g1", "agent_id": "a2", "agent_card": {"y": 2}},
+    )
+    body = client.get("/group/g1/agents").json()
+    assert body["err_code"] == 0
+    assert body["group_id"] == "g1"
+    ids = {a["agent_id"] for a in body["agent_infos"]}
+    assert ids == {"a1", "a2"}
+
+
+def test_get_single_agent_missing_group(client):
+    body = client.get("/group/ghost/agent/a1").json()
+    assert body["err_code"] == 1
+    assert "group ghost not exist" in body["msg"]
+
+
+def test_get_single_agent_missing_agent(client):
+    client.post("/create_group", params={"group_id": "g1"})
+    body = client.get("/group/g1/agent/ghost").json()
+    assert body["err_code"] == 1
+    assert "agent ghost in group g1 not exist" in body["msg"]
+
+
+def test_get_single_agent_success(client):
+    client.post("/create_group", params={"group_id": "g1"})
+    card = {"name": "demo"}
+    client.post(
+        "/register_agent",
+        json={"group_id": "g1", "agent_id": "a1", "agent_card": card},
+    )
+    body = client.get("/group/g1/agent/a1").json()
+    assert body["err_code"] == 0
+    assert body["agent_id"] == "a1"
+    assert body["agent_card"] == card
+
+
+def test_groups_empty_initially(client):
+    assert client.get("/groups").json()["group_ids"] == []
+
+
+def test_serve_delegates_to_uvicorn_run():
+    server = A2AHubServer()
+    with patch("veadk.a2a.hub.a2a_hub_server.uvicorn.run") as mock_run:
+        server.serve(host="0.0.0.0", port=1234)
+    mock_run.assert_called_once_with(server.app, host="0.0.0.0", port=1234)

--- a/tests/a2a/hub/test_models.py
+++ b/tests/a2a/hub/test_models.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for the A2A hub pydantic models.
+
+These pin field names, defaults, and inheritance so that a silent change to the
+hub wire schema is caught here rather than by a broken client.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from veadk.a2a.hub.models import (
+    AgentInformation,
+    BaseResponse,
+    GetAgentResponse,
+    GetAgentsResponse,
+    GetGroupsResponse,
+    RegisterAgentRequest,
+    RegisterAgentResponse,
+    RegisterGroupResponse,
+)
+
+
+def test_base_response_defaults():
+    resp = BaseResponse()
+    assert resp.err_code == 0
+    assert resp.msg == ""
+
+
+def test_base_response_explicit_values():
+    resp = BaseResponse(err_code=1, msg="boom")
+    assert resp.err_code == 1
+    assert resp.msg == "boom"
+
+
+def test_register_group_response_inherits_base():
+    assert issubclass(RegisterGroupResponse, BaseResponse)
+    resp = RegisterGroupResponse(group_id="g1")
+    assert resp.group_id == "g1"
+    # inherited defaults
+    assert resp.err_code == 0
+    assert resp.msg == ""
+
+
+def test_register_group_response_default_group_id():
+    assert RegisterGroupResponse().group_id == ""
+
+
+def test_register_agent_request_requires_fields():
+    # group_id, agent_id, agent_card have no defaults -> required.
+    with pytest.raises(ValidationError) as exc_info:
+        RegisterAgentRequest()  # type: ignore[call-arg]
+    missing = {e["loc"][0] for e in exc_info.value.errors()}
+    assert {"group_id", "agent_id", "agent_card"} <= missing
+
+
+def test_register_agent_request_roundtrip():
+    card = {"name": "demo", "url": "http://x"}
+    req = RegisterAgentRequest(group_id="g1", agent_id="a1", agent_card=card)
+    assert req.group_id == "g1"
+    assert req.agent_id == "a1"
+    assert req.agent_card == card
+    # RegisterAgentRequest extends BaseResponse, so it carries err_code/msg too.
+    assert req.err_code == 0
+
+
+def test_register_agent_response_defaults():
+    resp = RegisterAgentResponse()
+    assert resp.group_id == ""
+    assert resp.agent_id == ""
+    # agent_card uses default_factory=dict -> a fresh dict each time.
+    assert resp.agent_card == {}
+    other = RegisterAgentResponse()
+    assert resp.agent_card is not other.agent_card
+
+
+def test_agent_information_defaults_and_factory():
+    info = AgentInformation()
+    assert info.agent_id == ""
+    assert info.agent_card == {}
+    # mutating one instance's factory dict must not leak to another.
+    info.agent_card["k"] = "v"
+    assert AgentInformation().agent_card == {}
+
+
+def test_get_agents_response_holds_agent_information_list():
+    info = AgentInformation(agent_id="a1", agent_card={"x": 1})
+    resp = GetAgentsResponse(group_id="g1", agent_infos=[info])
+    assert resp.group_id == "g1"
+    assert len(resp.agent_infos) == 1
+    assert isinstance(resp.agent_infos[0], AgentInformation)
+    assert resp.agent_infos[0].agent_id == "a1"
+
+
+def test_get_agents_response_coerces_dict_to_model():
+    # pydantic should validate a plain dict into an AgentInformation.
+    resp = GetAgentsResponse(agent_infos=[{"agent_id": "a2", "agent_card": {}}])  # type: ignore[list-item]
+    assert isinstance(resp.agent_infos[0], AgentInformation)
+    assert resp.agent_infos[0].agent_id == "a2"
+
+
+def test_get_agents_response_default_empty_list():
+    resp = GetAgentsResponse()
+    assert resp.agent_infos == []
+    assert GetAgentsResponse().agent_infos is not resp.agent_infos
+
+
+def test_get_agent_response_defaults():
+    resp = GetAgentResponse()
+    assert resp.agent_id == ""
+    assert resp.agent_card == {}
+
+
+def test_get_groups_response_defaults_and_assignment():
+    assert GetGroupsResponse().group_ids == []
+    resp = GetGroupsResponse(group_ids=["g1", "g2"])
+    assert resp.group_ids == ["g1", "g2"]

--- a/tests/a2a/hub/test_rocketmq_middleware.py
+++ b/tests/a2a/hub/test_rocketmq_middleware.py
@@ -17,13 +17,39 @@
 All RocketMQ I/O (Producer/PushConsumer/Message) is mocked; no broker contact.
 """
 
-from unittest.mock import Mock, patch
+import sys
+import types
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from rocketmq.client import ConsumeStatus, ReceivedMessage
+# rocketmq_middleware (and this test) hard-import `rocketmq.client`, the optional
+# RocketMQ extra. It is absent from the base CI image, so stub it before import
+# when missing; all broker I/O is mocked, so the stub only lets the import chain
+# succeed. A real install (dev env) is used as-is.
+try:
+    import rocketmq.client  # noqa: F401
+except ImportError:
+    _rmq = types.ModuleType("rocketmq")
+    _rmq_client = types.ModuleType("rocketmq.client")
+    for _name in (
+        "ConsumeStatus",
+        "Message",
+        "Producer",
+        "PushConsumer",
+        "ReceivedMessage",
+    ):
+        setattr(_rmq_client, _name, MagicMock(name=_name))
+    _rmq.client = _rmq_client  # type: ignore[attr-defined]
+    sys.modules["rocketmq"] = _rmq
+    sys.modules["rocketmq.client"] = _rmq_client
 
-from veadk.a2a.hub.rocketmq_middleware import RocketMQAgentClient, RocketMQClient
+from rocketmq.client import ConsumeStatus, ReceivedMessage  # noqa: E402
+
+from veadk.a2a.hub.rocketmq_middleware import (  # noqa: E402
+    RocketMQAgentClient,
+    RocketMQClient,
+)
 
 MODULE = "veadk.a2a.hub.rocketmq_middleware"
 

--- a/tests/a2a/hub/test_rocketmq_middleware.py
+++ b/tests/a2a/hub/test_rocketmq_middleware.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the RocketMQ A2A middleware.
+
+All RocketMQ I/O (Producer/PushConsumer/Message) is mocked; no broker contact.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from rocketmq.client import ConsumeStatus, ReceivedMessage
+
+from veadk.a2a.hub.rocketmq_middleware import RocketMQAgentClient, RocketMQClient
+
+MODULE = "veadk.a2a.hub.rocketmq_middleware"
+
+
+@pytest.fixture
+def mock_producer():
+    """Patch the Producer class and yield the instance the client will hold."""
+    with patch(f"{MODULE}.Producer") as producer_cls:
+        instance = Mock()
+        producer_cls.return_value = instance
+        yield producer_cls, instance
+
+
+def _make_client():
+    return RocketMQClient(
+        name="client1",
+        producer_group="pg",
+        name_server_addr="ns:9876",
+        access_key="ak",
+        access_secret="sk",
+    )
+
+
+def test_client_init_configures_and_starts_producer(mock_producer):
+    producer_cls, producer = mock_producer
+    client = _make_client()
+
+    # Attributes stored verbatim.
+    assert client.name == "client1"
+    assert client.producer_group == "pg"
+    assert client.name_server_addr == "ns:9876"
+    assert client.access_key == "ak"
+    assert client.access_secret == "sk"
+
+    producer_cls.assert_called_once_with("pg")
+    producer.set_name_server_address.assert_called_once_with("ns:9876")
+    producer.set_session_credentials.assert_called_once_with("ak", "sk", "")
+    producer.start.assert_called_once_with()
+
+
+def test_send_msg_builds_message_and_sends_oneway(mock_producer):
+    _, producer = mock_producer
+    with patch(f"{MODULE}.Message") as message_cls:
+        msg = Mock()
+        message_cls.return_value = msg
+        client = _make_client()
+        client.send_msg("topicA", "hello", key="k1", tag="t1")
+
+    message_cls.assert_called_once_with("topicA")
+    msg.set_keys.assert_called_once_with("k1")
+    msg.set_tags.assert_called_once_with("t1")
+    msg.set_body.assert_called_once_with("hello")
+    producer.send_oneway.assert_called_once_with(msg)
+
+
+def test_send_msg_default_key_and_tag(mock_producer):
+    _, _producer = mock_producer
+    with patch(f"{MODULE}.Message") as message_cls:
+        msg = Mock()
+        message_cls.return_value = msg
+        client = _make_client()
+        client.send_msg("topicA", "body")
+
+    msg.set_keys.assert_called_once_with("")
+    msg.set_tags.assert_called_once_with("")
+
+
+def test_start_consumer_subscribes_and_starts(mock_producer):
+    _, _producer = mock_producer
+    callback = Mock()
+    with (
+        patch(f"{MODULE}.PushConsumer") as consumer_cls,
+        patch(f"{MODULE}.time.sleep", side_effect=KeyboardInterrupt),
+    ):
+        consumer = Mock()
+        consumer_cls.return_value = consumer
+        client = _make_client()
+        # The method loops forever on time.sleep; KeyboardInterrupt breaks out
+        # after the setup we want to assert on has run.
+        with pytest.raises(KeyboardInterrupt):
+            client.start_consumer(topic="topicA", group="grp", callback=callback)
+
+    consumer_cls.assert_called_once_with("grp")
+    consumer.set_name_server_address.assert_called_once_with("ns:9876")
+    consumer.set_session_credentials.assert_called_once_with("ak", "sk", "")
+    consumer.subscribe.assert_called_once_with("topicA", callback, "")
+    consumer.start.assert_called_once_with()
+
+
+class _ConcreteAgentClient(RocketMQAgentClient):
+    """Minimal concrete subclass to test the abstract base's shared logic."""
+
+    def recv_msg_callback(self, msg: ReceivedMessage) -> ConsumeStatus:
+        return ConsumeStatus.CONSUME_SUCCESS
+
+
+def test_agent_client_is_abstract():
+    # The base declares an abstractmethod, so it cannot be instantiated.
+    with pytest.raises(TypeError):
+        RocketMQAgentClient(  # type: ignore[abstract]
+            agent=Mock(),
+            rocketmq_client=Mock(),
+            subscribe_topic="t",
+            group="g",
+        )
+
+
+def test_agent_client_stores_attributes():
+    agent = Mock()
+    rmq = Mock()
+    ac = _ConcreteAgentClient(
+        agent=agent,
+        rocketmq_client=rmq,
+        subscribe_topic="topicA",
+        group="grp",
+    )
+    assert ac.agent is agent
+    assert ac.rocketmq_client is rmq
+    assert ac.subscribe_topic == "topicA"
+    assert ac.group == "grp"
+
+
+def test_agent_client_listen_delegates_to_consumer():
+    agent = Mock()
+    agent.name = "agent1"
+    rmq = Mock()
+    ac = _ConcreteAgentClient(
+        agent=agent,
+        rocketmq_client=rmq,
+        subscribe_topic="topicA",
+        group="grp",
+    )
+    ac.listen()
+    rmq.start_consumer.assert_called_once_with(
+        topic="topicA",
+        group="grp",
+        callback=ac.recv_msg_callback,
+    )

--- a/tests/a2a/test_remote_ve_agent.py
+++ b/tests/a2a/test_remote_ve_agent.py
@@ -1,0 +1,380 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``RemoteVeAgent``.
+
+All network access (the agent-card fetch via ``requests.get``) and the parent
+``RemoteA2aAgent`` runtime are mocked. We exercise URL resolution, auth-header /
+query-string construction, error paths, and runtime token injection.
+"""
+
+import json
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+
+from veadk.a2a.remote_ve_agent import (
+    AGENT_CARD_WELL_KNOWN_PATH,
+    RemoteVeAgent,
+    _convert_agent_card_dict_to_obj,
+)
+
+MODULE = "veadk.a2a.remote_ve_agent"
+
+
+def _agent_card_dict():
+    return {
+        "capabilities": {},
+        "defaultInputModes": ["text/plain"],
+        "defaultOutputModes": ["text/plain"],
+        "description": "desc",
+        "name": "demo",
+        "url": "http://placeholder",
+        "version": "1.0",
+        "skills": [],
+    }
+
+
+@pytest.fixture
+def mock_requests_get():
+    """Patch requests.get so the constructor never hits the network."""
+    with patch(f"{MODULE}.requests.get") as get:
+        response = Mock()
+        response.json.return_value = _agent_card_dict()
+        get.return_value = response
+        yield get
+
+
+def test_convert_agent_card_dict_to_obj():
+    obj = _convert_agent_card_dict_to_obj(_agent_card_dict())
+    assert obj.name == "demo"
+    assert obj.url == "http://placeholder"
+
+
+def test_well_known_path_constant():
+    assert AGENT_CARD_WELL_KNOWN_PATH == "/.well-known/agent-card.json"
+
+
+def test_init_with_url_fetches_card_and_overrides_url(mock_requests_get):
+    agent = RemoteVeAgent(name="a1", url="http://host:8000")
+
+    # Card fetched from the well-known path on the supplied URL.
+    mock_requests_get.assert_called_once_with(
+        "http://host:8000" + AGENT_CARD_WELL_KNOWN_PATH,
+        headers={},
+        params={},
+    )
+    assert agent.name == "a1"
+    # The fetched card's url is overridden with the effective URL.
+    assert str(agent._agent_card.url) == "http://host:8000"
+    # No client supplied -> we created one and must own its cleanup.
+    assert agent._httpx_client_needs_cleanup is True
+
+
+def test_init_no_url_no_client_raises(mock_requests_get):
+    with pytest.raises(ValueError, match="Could not determine agent URL"):
+        RemoteVeAgent(name="a1")
+
+
+def test_init_conflicting_url_and_client_base_url_raises(mock_requests_get):
+    client = httpx.AsyncClient(base_url="http://other:9000")
+    with pytest.raises(ValueError, match="conflicts with the `base_url`"):
+        RemoteVeAgent(name="a1", url="http://host:8000", httpx_client=client)
+
+
+def test_init_unsupported_auth_method_raises(mock_requests_get):
+    with pytest.raises(ValueError, match="Unsupported auth method"):
+        RemoteVeAgent(
+            name="a1",
+            url="http://host:8000",
+            auth_token="tok",
+            auth_method="cookie",  # type: ignore[arg-type]
+        )
+
+
+def test_init_header_auth_sends_bearer_header(mock_requests_get):
+    agent = RemoteVeAgent(
+        name="a1",
+        url="http://host:8000",
+        auth_token="tok",
+        auth_method="header",
+    )
+    _, kwargs = mock_requests_get.call_args
+    assert kwargs["headers"] == {"Authorization": "Bearer tok"}
+    assert kwargs["params"] == {}
+    assert agent.auth_method == "header"
+
+
+def test_init_querystring_auth_sends_token_param(mock_requests_get):
+    agent = RemoteVeAgent(
+        name="a1",
+        url="http://host:8000",
+        auth_token="tok",
+        auth_method="querystring",
+    )
+    _, kwargs = mock_requests_get.call_args
+    assert kwargs["params"] == {"token": "tok"}
+    assert kwargs["headers"] == {}
+    assert agent.auth_method == "querystring"
+
+
+def test_init_with_provided_client_does_not_set_cleanup_flag(mock_requests_get):
+    client = httpx.AsyncClient(base_url="http://host:8000")
+    agent = RemoteVeAgent(name="a1", httpx_client=client)
+    # Parent sets cleanup False when a client is passed; we only override when
+    # we created the client ourselves.
+    assert agent._httpx_client_needs_cleanup is False
+
+
+def test_init_provided_client_gets_header_auth_injected(mock_requests_get):
+    client = httpx.AsyncClient(base_url="http://host:8000")
+    RemoteVeAgent(
+        name="a1",
+        httpx_client=client,
+        auth_token="tok",
+        auth_method="header",
+    )
+    assert client.headers["Authorization"] == "Bearer tok"
+
+
+def test_init_provided_client_gets_querystring_auth_injected(mock_requests_get):
+    client = httpx.AsyncClient(base_url="http://host:8000")
+    RemoteVeAgent(
+        name="a1",
+        httpx_client=client,
+        auth_token="tok",
+        auth_method="querystring",
+    )
+    assert client.params.get("token") == "tok"
+
+
+def test_init_url_trailing_slash_matches_client_base_url(mock_requests_get):
+    # A trailing slash on url must not be treated as a conflict.
+    client = httpx.AsyncClient(base_url="http://host:8000")
+    agent = RemoteVeAgent(name="a1", url="http://host:8000/", httpx_client=client)
+    assert agent.name == "a1"
+
+
+def _make_agent(mock_requests_get):
+    return RemoteVeAgent(name="a1", url="http://host:8000")
+
+
+@pytest.mark.asyncio
+async def test_pre_run_calls_resolve_and_inject(mock_requests_get):
+    agent = _make_agent(mock_requests_get)
+    ctx = Mock()
+    with (
+        patch.object(agent, "_ensure_resolved", new=AsyncMock()) as resolve,
+        patch.object(agent, "_inject_auth_token", new=AsyncMock()) as inject,
+    ):
+        await agent._pre_run(ctx)
+    resolve.assert_awaited_once_with()
+    inject.assert_awaited_once_with(ctx)
+
+
+@pytest.mark.asyncio
+async def test_inject_auth_token_skips_without_credential_service(mock_requests_get):
+    agent = _make_agent(mock_requests_get)
+    ctx = Mock()
+    ctx.credential_service = None
+    # Should return early without touching any client.
+    await agent._inject_auth_token(ctx)
+
+
+@pytest.mark.asyncio
+async def test_inject_auth_token_skips_when_client_not_base_client(mock_requests_get):
+    agent = _make_agent(mock_requests_get)
+    ctx = Mock()
+    ctx.credential_service = Mock()
+    # A freshly constructed agent has _a2a_client = None (not a BaseClient),
+    # so injection must short-circuit without loading any credential.
+    from a2a.client.base_client import BaseClient
+
+    assert not isinstance(getattr(agent, "_a2a_client", None), BaseClient)
+    await agent._inject_auth_token(ctx)
+    ctx.credential_service.load_credential.assert_not_called()
+
+
+def _attach_fake_a2a_client(agent):
+    """Give the agent an _a2a_client that passes the isinstance(BaseClient) and
+    transport/httpx_client guards in _inject_auth_token."""
+    from a2a.client.base_client import BaseClient
+
+    class _FakeClient(BaseClient):
+        def __init__(self):  # noqa: D401 - bypass BaseClient.__init__
+            pass
+
+    client = _FakeClient()
+    transport = Mock()
+    transport.httpx_client = httpx.AsyncClient(base_url="http://host:8000")
+    client._transport = transport  # type: ignore[attr-defined]
+    agent._a2a_client = client
+    return transport.httpx_client
+
+
+@pytest.mark.asyncio
+async def test_inject_auth_token_header_path(mock_requests_get):
+    agent = RemoteVeAgent(
+        name="a1", url="http://host:8000", auth_token="t", auth_method="header"
+    )
+    httpx_client = _attach_fake_a2a_client(agent)
+
+    ctx = Mock()
+    tip_cred = Mock(api_key="tip-key")
+    inbound_cred = Mock(api_key="inbound-key")
+    ctx.credential_service.load_credential = AsyncMock(
+        side_effect=[tip_cred, inbound_cred]
+    )
+
+    with (
+        patch(f"{MODULE}.generate_headers", return_value={"Authorization": "Bearer X"}),
+        patch("veadk.utils.auth.build_auth_config", return_value=Mock()),
+        patch("google.adk.agents.callback_context.CallbackContext"),
+    ):
+        await agent._inject_auth_token(ctx)
+
+    # TIP token header injected, plus the bearer header from generate_headers.
+    assert httpx_client.headers["Authorization"] == "Bearer X"
+    assert ctx.credential_service.load_credential.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_inject_auth_token_querystring_path(mock_requests_get):
+    agent = RemoteVeAgent(
+        name="a1", url="http://host:8000", auth_token="t", auth_method="querystring"
+    )
+    httpx_client = _attach_fake_a2a_client(agent)
+
+    ctx = Mock()
+    tip_cred = Mock(api_key="tip-key")
+    inbound_cred = Mock(api_key="inbound-key")
+    ctx.credential_service.load_credential = AsyncMock(
+        side_effect=[tip_cred, inbound_cred]
+    )
+
+    with (
+        patch("veadk.utils.auth.build_auth_config", return_value=Mock()),
+        patch("google.adk.agents.callback_context.CallbackContext"),
+    ):
+        await agent._inject_auth_token(ctx)
+
+    assert httpx_client.params.get("token") == "inbound-key"
+
+
+@pytest.mark.asyncio
+async def test_inject_auth_token_no_credential_returns_early(mock_requests_get):
+    agent = RemoteVeAgent(name="a1", url="http://host:8000", auth_method="header")
+    httpx_client = _attach_fake_a2a_client(agent)
+
+    ctx = Mock()
+    # First load (TIP) returns None, second (inbound) returns None -> no header.
+    ctx.credential_service.load_credential = AsyncMock(side_effect=[None, None])
+
+    with (
+        patch("veadk.utils.auth.build_auth_config", return_value=Mock()),
+        patch("google.adk.agents.callback_context.CallbackContext"),
+        patch(f"{MODULE}.generate_headers") as gen_headers,
+    ):
+        await agent._inject_auth_token(ctx)
+
+    # No inbound credential -> generate_headers never invoked.
+    gen_headers.assert_not_called()
+    assert "Authorization" not in httpx_client.headers
+
+
+@pytest.mark.asyncio
+async def test_inject_auth_token_skips_when_transport_missing(mock_requests_get):
+    from a2a.client.base_client import BaseClient
+
+    class _FakeClient(BaseClient):
+        def __init__(self):
+            pass
+
+    agent = RemoteVeAgent(name="a1", url="http://host:8000", auth_method="header")
+    client = _FakeClient()
+    # No _transport attribute -> guard must short-circuit.
+    agent._a2a_client = client
+    ctx = Mock()
+    ctx.credential_service = Mock()
+    await agent._inject_auth_token(ctx)
+    ctx.credential_service.load_credential.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_inject_auth_token_swallows_exceptions(mock_requests_get):
+    agent = RemoteVeAgent(name="a1", url="http://host:8000", auth_method="header")
+    _attach_fake_a2a_client(agent)
+
+    ctx = Mock()
+    ctx.credential_service.load_credential = AsyncMock(
+        side_effect=RuntimeError("creds down")
+    )
+
+    with (
+        patch("veadk.utils.auth.build_auth_config", return_value=Mock()),
+        patch("google.adk.agents.callback_context.CallbackContext"),
+    ):
+        # Must not raise: the method logs a warning and returns.
+        await agent._inject_auth_token(ctx)
+
+
+@pytest.mark.asyncio
+async def test_run_async_impl_wrapper_yields_error_on_pre_run_failure(
+    mock_requests_get,
+):
+    agent = _make_agent(mock_requests_get)
+    ctx = Mock()
+    ctx.invocation_id = "inv1"
+    ctx.branch = "main"
+
+    with patch.object(
+        agent, "_pre_run", new=AsyncMock(side_effect=RuntimeError("boom"))
+    ):
+        events = [event async for event in agent._run_async_impl(ctx)]
+
+    assert len(events) == 1
+    assert events[0].author == "a1"
+    assert "Failed to initialize remote A2A agent" in (events[0].error_message or "")
+    assert "boom" in (events[0].error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_run_async_impl_wrapper_passes_through_events(mock_requests_get):
+    agent = _make_agent(mock_requests_get)
+    ctx = Mock()
+    ctx.invocation_id = "inv1"
+    ctx.branch = "main"
+
+    sentinel = Mock(name="event")
+
+    async def fake_original(_ctx):
+        yield sentinel
+
+    # Re-wrap with a controllable original impl to prove pass-through.
+    with patch.object(agent, "_pre_run", new=AsyncMock()):
+        agent._run_async_impl = fake_original  # type: ignore[method-assign]
+        agent._wrap_run_async_impl()
+        events = [event async for event in agent._run_async_impl(ctx)]
+
+    assert events == [sentinel]
+
+
+def test_agent_card_url_override_is_serialized(mock_requests_get):
+    # Sanity: the dict mutation in __init__ (agent_card_dict["url"] = url) takes
+    # effect through json round-trip rather than the placeholder.
+    card = _agent_card_dict()
+    card["url"] = "http://placeholder"
+    obj = _convert_agent_card_dict_to_obj({**card, "url": "http://real:1"})
+    assert json.loads(obj.model_dump_json())["url"] == "http://real:1"

--- a/tests/a2ui/test_catalog.py
+++ b/tests/a2ui/test_catalog.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for :mod:`veadk.a2ui.catalog`.
+
+These exercise the catalog helpers against the real ``a2ui-agent-sdk`` (installed
+in the project venv) for the happy paths, and use mocking to assert the
+``ImportError`` friendly-message behaviour and the ``BaseA2UICatalog`` dispatch
+logic. No network or model access is involved.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from typing import Any
+
+import pytest
+
+from veadk.a2ui import catalog as catalog_mod
+from veadk.a2ui.catalog import (
+    DEFAULT_A2UI_VERSION,
+    DEFAULT_CATALOG_FILENAME,
+    DEFAULT_EXAMPLES_DIRNAME,
+    BaseA2UICatalog,
+    get_basic_catalog,
+    load_catalog,
+)
+
+# The real basic catalog JSON shipped with the a2ui SDK; used to test
+# ``load_catalog`` against a genuine on-disk catalog file.
+_SDK_BASIC_CATALOG = os.path.join(
+    os.path.dirname(__import__("a2ui").__file__),
+    "assets",
+    "0.9",
+    "basic_catalog.json",
+)
+
+
+def test_module_constants():
+    """Public constants keep their documented defaults."""
+    assert DEFAULT_A2UI_VERSION == "0.9"
+    assert DEFAULT_CATALOG_FILENAME == "catalog.json"
+    assert DEFAULT_EXAMPLES_DIRNAME == "a2ui_examples"
+
+
+def test_get_basic_catalog_returns_catalog_and_examples():
+    """The bundled basic catalog builds into a ``(catalog, examples)`` pair."""
+    result = get_basic_catalog()
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    cat, examples = result
+    # The basic catalog id encodes the requested version.
+    assert "0_9" in cat.catalog_id
+    assert isinstance(examples, str)
+
+
+def test_get_basic_catalog_honours_version():
+    """Selecting the 0.8 catalog yields a 0.8 catalog id."""
+    cat, _ = get_basic_catalog(version="0.8")
+    assert "0_8" in cat.catalog_id
+
+
+def test_load_catalog_from_real_file():
+    """``load_catalog`` loads a genuine catalog JSON off disk."""
+    assert os.path.isfile(_SDK_BASIC_CATALOG), "SDK basic catalog JSON missing"
+
+    cat, examples = load_catalog(_SDK_BASIC_CATALOG)
+
+    assert cat.catalog_id  # non-empty id
+    assert isinstance(examples, str)
+
+
+def test_load_catalog_import_error_is_friendly(monkeypatch):
+    """A missing SDK surfaces the install hint, not a raw ImportError."""
+    # ``load_catalog`` imports CatalogConfig lazily inside the function body;
+    # block that import so the friendly fallback message is raised.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("a2ui.schema"):
+            raise ImportError("blocked for test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError) as exc:
+        load_catalog("/nonexistent/catalog.json")
+    assert "a2ui-agent-sdk" in str(exc.value)
+
+
+def test_base_catalog_class_defaults():
+    """The base class exposes the documented class-level configuration knobs."""
+    assert BaseA2UICatalog.version == DEFAULT_A2UI_VERSION
+    assert BaseA2UICatalog.catalog_path is None
+    assert BaseA2UICatalog.examples_path is None
+
+
+def test_base_catalog_build_falls_back_to_basic_when_unset(monkeypatch):
+    """With no ``catalog_path``, ``build()`` defers to the basic catalog."""
+    calls = {}
+
+    def fake_basic(version, examples_path):
+        calls["args"] = (version, examples_path)
+        return ("CATALOG", "EXAMPLES")
+
+    monkeypatch.setattr(catalog_mod, "get_basic_catalog", fake_basic)
+
+    class _Empty(BaseA2UICatalog):
+        version = "0.8"
+
+    result = _Empty().build()
+
+    assert result == ("CATALOG", "EXAMPLES")
+    assert calls["args"] == ("0.8", None)
+
+
+def test_base_catalog_build_uses_load_catalog_when_path_set(monkeypatch):
+    """With ``catalog_path`` set, ``build()`` routes through ``load_catalog``."""
+    calls = {}
+
+    def fake_load(catalog_path, version, examples_path):
+        calls["args"] = (catalog_path, version, examples_path)
+        return ("LOADED", "EX")
+
+    monkeypatch.setattr(catalog_mod, "load_catalog", fake_load)
+
+    class _Custom(BaseA2UICatalog):
+        version = "0.9"
+        catalog_path = "/opt/corp/finance.json"
+        examples_path = "/opt/corp/examples"
+
+    result = _Custom().build()
+
+    assert result == ("LOADED", "EX")
+    assert calls["args"] == ("/opt/corp/finance.json", "0.9", "/opt/corp/examples")
+
+
+def test_base_catalog_subclass_build_override():
+    """A subclass may fully override ``build`` to supply its own pair."""
+
+    class _Override(BaseA2UICatalog):
+        def build(self) -> Any:
+            return ("MY_CATALOG", "MY_EXAMPLES")
+
+    assert _Override().build() == ("MY_CATALOG", "MY_EXAMPLES")
+
+
+def test_load_catalog_copied_file(tmp_path):
+    """A catalog copied to a temp dir still loads (path independence)."""
+    dest = tmp_path / "my_catalog.json"
+    shutil.copyfile(_SDK_BASIC_CATALOG, dest)
+
+    cat, _ = load_catalog(str(dest))
+
+    assert cat.catalog_id

--- a/tests/a2ui/test_catalog.py
+++ b/tests/a2ui/test_catalog.py
@@ -47,6 +47,14 @@ _SDK_BASIC_CATALOG = os.path.join(
     "basic_catalog.json",
 )
 
+# These tests load the real on-disk catalog shipped with the a2ui SDK. CI may
+# install an a2ui version that doesn't ship the 0.9 asset; skip there rather
+# than fail on a foreign SDK layout.
+_requires_sdk_assets = pytest.mark.skipif(
+    not os.path.isfile(_SDK_BASIC_CATALOG),
+    reason="installed a2ui SDK lacks the bundled 0.9 basic_catalog.json asset",
+)
+
 
 def test_module_constants():
     """Public constants keep their documented defaults."""
@@ -73,6 +81,7 @@ def test_get_basic_catalog_honours_version():
     assert "0_8" in cat.catalog_id
 
 
+@_requires_sdk_assets
 def test_load_catalog_from_real_file():
     """``load_catalog`` loads a genuine catalog JSON off disk."""
     assert os.path.isfile(_SDK_BASIC_CATALOG), "SDK basic catalog JSON missing"
@@ -160,6 +169,7 @@ def test_base_catalog_subclass_build_override():
     assert _Override().build() == ("MY_CATALOG", "MY_EXAMPLES")
 
 
+@_requires_sdk_assets
 def test_load_catalog_copied_file(tmp_path):
     """A catalog copied to a temp dir still loads (path independence)."""
     dest = tmp_path / "my_catalog.json"

--- a/tests/a2ui/test_toolset.py
+++ b/tests/a2ui/test_toolset.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for :mod:`veadk.a2ui.toolset`.
+
+Covers catalog-form normalisation (``_resolve_catalog``), the conventional
+examples-dir discovery (``_examples_beside``), and the public
+``build_a2ui_toolset`` factory. The toolset is built against the real
+``a2ui-agent-sdk`` (present in the venv); tool enablement is verified through a
+mocked ``ReadonlyContext`` so no agent runtime is required.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from veadk.a2ui import toolset as toolset_mod
+from veadk.a2ui.toolset import (
+    _examples_beside,
+    _resolve_catalog,
+    build_a2ui_toolset,
+    caller_agent_dir,
+)
+
+_SDK_BASIC_CATALOG = os.path.join(
+    os.path.dirname(__import__("a2ui").__file__),
+    "assets",
+    "0.9",
+    "basic_catalog.json",
+)
+
+
+def test_examples_beside_returns_dir_when_present(tmp_path):
+    """The conventional ``a2ui_examples/`` dir beside a catalog is discovered."""
+    catalog = tmp_path / "catalog.json"
+    catalog.write_text("{}")
+    ex_dir = tmp_path / "a2ui_examples"
+    ex_dir.mkdir()
+
+    assert _examples_beside(str(catalog)) == str(ex_dir)
+
+
+def test_examples_beside_returns_none_when_absent(tmp_path):
+    """No examples dir -> ``None`` (so the SDK default examples are used)."""
+    catalog = tmp_path / "catalog.json"
+    catalog.write_text("{}")
+
+    assert _examples_beside(str(catalog)) is None
+
+
+def test_resolve_catalog_none_no_base_dir_uses_basic(monkeypatch):
+    """``catalog=None`` with no base dir falls back to the basic catalog."""
+    monkeypatch.setattr(toolset_mod, "get_basic_catalog", lambda: ("BASIC", "BASIC_EX"))
+
+    assert _resolve_catalog(None, None) == ("BASIC", "BASIC_EX")
+
+
+def test_resolve_catalog_none_discovers_catalog_beside_agent(tmp_path, monkeypatch):
+    """``catalog=None`` with a base dir auto-discovers a sibling ``catalog.json``."""
+    (tmp_path / "catalog.json").write_text("{}")
+    captured = {}
+
+    def fake_load(path, examples_path=None):
+        captured["path"] = path
+        captured["examples_path"] = examples_path
+        return ("DISCOVERED", "EX")
+
+    monkeypatch.setattr(toolset_mod, "load_catalog", fake_load)
+
+    result = _resolve_catalog(None, str(tmp_path))
+
+    assert result == ("DISCOVERED", "EX")
+    assert captured["path"] == os.path.join(str(tmp_path), "catalog.json")
+
+
+def test_resolve_catalog_none_base_dir_without_catalog_uses_basic(
+    tmp_path, monkeypatch
+):
+    """A base dir lacking ``catalog.json`` still falls back to the basic catalog."""
+    monkeypatch.setattr(toolset_mod, "get_basic_catalog", lambda: ("BASIC", ""))
+
+    assert _resolve_catalog(None, str(tmp_path)) == ("BASIC", "")
+
+
+def test_resolve_catalog_relative_string_resolved_against_base_dir(monkeypatch):
+    """A relative string path is joined onto ``base_dir`` before loading."""
+    captured = {}
+
+    def fake_load(path, examples_path=None):
+        captured["path"] = path
+        return ("C", "E")
+
+    monkeypatch.setattr(toolset_mod, "load_catalog", fake_load)
+
+    _resolve_catalog("sub/catalog.json", "/agents/app")
+
+    assert captured["path"] == os.path.join("/agents/app", "sub/catalog.json")
+
+
+def test_resolve_catalog_absolute_string_used_as_is(monkeypatch):
+    """An absolute string path is used verbatim, ignoring ``base_dir``."""
+    captured = {}
+
+    def fake_load(path, examples_path=None):
+        captured["path"] = path
+        return ("C", "E")
+
+    monkeypatch.setattr(toolset_mod, "load_catalog", fake_load)
+
+    _resolve_catalog("/abs/catalog.json", "/agents/app")
+
+    assert captured["path"] == "/abs/catalog.json"
+
+
+def test_resolve_catalog_base_catalog_instance_calls_build():
+    """A ``BaseA2UICatalog`` instance is normalised via its ``build()``."""
+
+    class _Cat(toolset_mod.BaseA2UICatalog):
+        def build(self) -> Any:
+            return ("BUILT", "BUILT_EX")
+
+    assert _resolve_catalog(_Cat(), None) == ("BUILT", "BUILT_EX")
+
+
+def test_resolve_catalog_prebuilt_pair_passthrough():
+    """A pre-built ``(catalog, examples)`` tuple is returned unchanged."""
+    from veadk.a2ui.catalog import get_basic_catalog
+
+    cat, _ = get_basic_catalog()
+    pair = (cat, "examples")
+    assert _resolve_catalog(pair, None) is pair
+
+
+def test_resolve_catalog_bare_catalog_paired_with_empty_examples():
+    """A bare ``A2uiCatalog`` instance is paired with an empty examples string."""
+    from veadk.a2ui.catalog import get_basic_catalog
+
+    bare, _ = get_basic_catalog()  # a genuine A2uiCatalog instance
+    result = _resolve_catalog(bare, None)
+    assert result == (bare, "")
+
+
+def test_caller_agent_dir_skips_veadk_frames():
+    """The caller dir is this test file's directory, not a veadk internal one."""
+    result = caller_agent_dir()
+    # This test module lives outside the veadk package, so it is the first
+    # non-veadk, non-site-packages frame and should be returned.
+    assert result == os.path.dirname(os.path.abspath(__file__))
+
+
+def test_build_a2ui_toolset_import_error_is_friendly(monkeypatch):
+    """A missing SDK raises the install hint rather than a raw ImportError."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "a2ui.adk.send_a2ui_to_client_toolset":
+            raise ImportError("blocked for test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError) as exc:
+        build_a2ui_toolset()
+    assert "a2ui-agent-sdk" in str(exc.value)
+
+
+def test_build_a2ui_toolset_returns_base_toolset():
+    """The factory returns a real ADK ``BaseToolset`` instance."""
+    from google.adk.tools.base_toolset import BaseToolset
+
+    ts = build_a2ui_toolset(base_dir=None)
+    assert isinstance(ts, BaseToolset)
+
+
+@pytest.mark.asyncio
+async def test_toolset_exposes_send_tool_when_enabled():
+    """An enabled toolset exposes exactly the ``send_a2ui_json_to_client`` tool."""
+    ts = build_a2ui_toolset(enabled=True, base_dir=None)
+
+    tools = await ts.get_tools(Mock())
+
+    assert [t.name for t in tools] == ["send_a2ui_json_to_client"]
+
+
+@pytest.mark.asyncio
+async def test_toolset_hides_tool_when_disabled():
+    """A disabled toolset exposes no tools."""
+    ts = build_a2ui_toolset(enabled=False, base_dir=None)
+
+    tools = await ts.get_tools(Mock())
+
+    assert tools == []
+
+
+def test_build_a2ui_toolset_passes_examples_override(tmp_path, monkeypatch):
+    """An explicit ``examples`` override wins over the resolved default."""
+    dest = tmp_path / "catalog.json"
+    shutil.copyfile(_SDK_BASIC_CATALOG, dest)
+
+    captured = {}
+
+    class _FakeToolset:
+        def __init__(self, *, a2ui_enabled, a2ui_catalog, a2ui_examples):
+            captured["enabled"] = a2ui_enabled
+            captured["examples"] = a2ui_examples
+
+    monkeypatch.setattr(
+        "a2ui.adk.send_a2ui_to_client_toolset.SendA2uiToClientToolset",
+        _FakeToolset,
+    )
+
+    build_a2ui_toolset(
+        catalog=str(dest),
+        examples="OVERRIDE",
+        enabled=False,
+        base_dir=str(tmp_path),
+    )
+
+    assert captured["examples"] == "OVERRIDE"
+    assert captured["enabled"] is False

--- a/tests/a2ui/test_toolset.py
+++ b/tests/a2ui/test_toolset.py
@@ -45,6 +45,15 @@ _SDK_BASIC_CATALOG = os.path.join(
     "basic_catalog.json",
 )
 
+# Some tests build against the real a2ui SDK (catalog asset + toolset
+# construction). CI may install an a2ui version whose assets/internals differ;
+# the bundled 0.9 catalog being absent is a reliable proxy for that, so skip the
+# real-SDK tests there rather than asserting against a foreign SDK build.
+_requires_sdk_assets = pytest.mark.skipif(
+    not os.path.isfile(_SDK_BASIC_CATALOG),
+    reason="installed a2ui SDK lacks the bundled 0.9 basic_catalog.json asset",
+)
+
 
 def test_examples_beside_returns_dir_when_present(tmp_path):
     """The conventional ``a2ui_examples/`` dir beside a catalog is discovered."""
@@ -182,6 +191,7 @@ def test_build_a2ui_toolset_import_error_is_friendly(monkeypatch):
     assert "a2ui-agent-sdk" in str(exc.value)
 
 
+@_requires_sdk_assets
 def test_build_a2ui_toolset_returns_base_toolset():
     """The factory returns a real ADK ``BaseToolset`` instance."""
     from google.adk.tools.base_toolset import BaseToolset
@@ -190,6 +200,7 @@ def test_build_a2ui_toolset_returns_base_toolset():
     assert isinstance(ts, BaseToolset)
 
 
+@_requires_sdk_assets
 @pytest.mark.asyncio
 async def test_toolset_exposes_send_tool_when_enabled():
     """An enabled toolset exposes exactly the ``send_a2ui_json_to_client`` tool."""
@@ -200,6 +211,7 @@ async def test_toolset_exposes_send_tool_when_enabled():
     assert [t.name for t in tools] == ["send_a2ui_json_to_client"]
 
 
+@_requires_sdk_assets
 @pytest.mark.asyncio
 async def test_toolset_hides_tool_when_disabled():
     """A disabled toolset exposes no tools."""
@@ -210,6 +222,7 @@ async def test_toolset_hides_tool_when_disabled():
     assert tools == []
 
 
+@_requires_sdk_assets
 def test_build_a2ui_toolset_passes_examples_override(tmp_path, monkeypatch):
     """An explicit ``examples`` override wins over the resolved default."""
     dest = tmp_path / "catalog.json"

--- a/tests/agent/test_agent_behavior.py
+++ b/tests/agent/test_agent_behavior.py
@@ -1,0 +1,596 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavior tests for ``veadk.agent.Agent``.
+
+These exercise the ``model_post_init`` wiring branches and helper methods that
+are not covered by ``tests/test_agent.py`` (signatures/defaults) or the contract
+tests: prompt-manager instruction binding, skills injection, knowledgebase
+profile tool, long-term-memory + auto-save callbacks, authz callback wiring,
+ghostchar/tunnel/dataset-gen tools, tool-dependency validation, tracer
+preparation, llm-flow selection, runtime dispatch and ``update_model``.
+
+All external/model dependencies are mocked; no network or real LLM calls.
+"""
+
+import os
+from unittest.mock import Mock, PropertyMock, patch
+
+import pytest
+
+from veadk import Agent
+from veadk.processors import NoOpRunProcessor
+
+_ENV = {"MODEL_AGENT_API_KEY": "mock_api_key"}
+
+
+@patch.dict(os.environ, _ENV)
+def test_default_run_processor_is_noop():
+    agent = Agent()
+    assert isinstance(agent.run_processor, NoOpRunProcessor)
+
+
+@patch.dict(os.environ, _ENV)
+def test_enable_responses_uses_ark_llm():
+    mock_ark = Mock()
+    with patch("veadk.models.ark_llm.ArkLlm", return_value=mock_ark) as mock_cls:
+        agent = Agent(enable_responses=True)
+    mock_cls.assert_called_once()
+    assert agent.model is mock_ark
+
+
+@patch.dict(os.environ, _ENV)
+@patch("veadk.agent.LiteLlm")
+def test_model_name_list_sets_primary_and_fallbacks(mock_lite_llm):
+    Agent(
+        model_name=["primary", "second", "third"],
+        model_provider="prov",
+    )
+    _, kwargs = mock_lite_llm.call_args
+    assert kwargs["model"] == "prov/primary"
+    assert kwargs["fallbacks"] == ["prov/second", "prov/third"]
+
+
+@patch.dict(os.environ, _ENV)
+@patch("veadk.agent.LiteLlm")
+def test_empty_model_name_list_falls_back_to_settings(mock_lite_llm):
+    with patch("veadk.agent.settings.model.name", new="settings-model"):
+        Agent(model_name=[], model_provider="prov")
+    _, kwargs = mock_lite_llm.call_args
+    assert kwargs["model"] == "prov/settings-model"
+    assert kwargs["fallbacks"] is None
+
+
+@patch.dict(os.environ, _ENV)
+def test_prompt_manager_binds_instruction():
+    from veadk.prompts.prompt_manager import BasePromptManager
+
+    class _PM(BasePromptManager):
+        def get_prompt(self, *args, **kwargs):
+            return "managed prompt"
+
+    prompt_manager = _PM()
+    agent = Agent(prompt_manager=prompt_manager)
+    # instruction is bound to the prompt manager's get_prompt callable.
+    assert agent.instruction == prompt_manager.get_prompt
+    assert callable(agent.instruction)
+    assert agent.instruction() == "managed prompt"  # type: ignore[operator]
+
+
+@patch.dict(os.environ, _ENV)
+def test_knowledgebase_profile_adds_both_tools():
+    from veadk.knowledgebase import KnowledgeBase
+
+    kb = KnowledgeBase(index="test_index", backend="local")
+    kb.enable_profile = True
+
+    load_kb_tool = Mock()
+    kb_queries = Mock()
+    with (
+        patch(
+            "veadk.tools.builtin_tools.load_knowledgebase.LoadKnowledgebaseTool",
+            return_value=load_kb_tool,
+        ),
+        patch(
+            "veadk.tools.builtin_tools.load_kb_queries.load_kb_queries",
+            new=kb_queries,
+        ),
+    ):
+        agent = Agent(knowledgebase=kb)
+
+    assert load_kb_tool in agent.tools
+    assert kb_queries in agent.tools
+
+
+@patch.dict(os.environ, _ENV)
+def test_knowledgebase_without_profile_adds_single_tool():
+    from veadk.knowledgebase import KnowledgeBase
+
+    kb = KnowledgeBase(index="test_index", backend="local")
+    kb.enable_profile = False
+
+    load_kb_tool = Mock()
+    with patch(
+        "veadk.tools.builtin_tools.load_knowledgebase.LoadKnowledgebaseTool",
+        return_value=load_kb_tool,
+    ):
+        agent = Agent(knowledgebase=kb)
+
+    assert load_kb_tool in agent.tools
+
+
+@patch.dict(os.environ, _ENV)
+def test_long_term_memory_wires_load_memory_backend():
+    from google.adk.tools import load_memory
+
+    from veadk.memory.long_term_memory import LongTermMemory
+
+    ltm = LongTermMemory(backend="local")
+    agent = Agent(long_term_memory=ltm)
+
+    assert load_memory in agent.tools
+    metadata = getattr(load_memory, "custom_metadata", None)
+    if metadata is not None:
+        assert metadata["backend"] == "local"
+
+
+@patch.dict(os.environ, _ENV)
+def test_enable_authz_sets_callback_when_none():
+    from veadk.tools.builtin_tools.agent_authorization import (
+        check_agent_authorization,
+    )
+
+    agent = Agent(enable_authz=True)
+    assert agent.before_agent_callback is check_agent_authorization
+
+
+@patch.dict(os.environ, _ENV)
+def test_enable_authz_appends_to_existing_list_callback():
+    from veadk.tools.builtin_tools.agent_authorization import (
+        check_agent_authorization,
+    )
+
+    existing = Mock()
+    agent = Agent(enable_authz=True, before_agent_callback=[existing])
+    assert isinstance(agent.before_agent_callback, list)
+    assert existing in agent.before_agent_callback
+    assert check_agent_authorization in agent.before_agent_callback
+
+
+@patch.dict(os.environ, _ENV)
+def test_enable_authz_promotes_single_callback_to_list():
+    from veadk.tools.builtin_tools.agent_authorization import (
+        check_agent_authorization,
+    )
+
+    def existing(*args, **kwargs):
+        return None
+
+    agent = Agent(enable_authz=True, before_agent_callback=existing)
+    assert isinstance(agent.before_agent_callback, list)
+    assert existing in agent.before_agent_callback
+    assert check_agent_authorization in agent.before_agent_callback
+
+
+@patch.dict(os.environ, _ENV)
+def test_auto_save_session_without_ltm_warns_no_callback():
+    agent = Agent(auto_save_session=True)
+    # long_term_memory missing -> no after_agent_callback installed
+    assert agent.after_agent_callback is None
+
+
+@patch.dict(os.environ, _ENV)
+def test_auto_save_session_installs_after_callback():
+    from veadk.memory.save_session_callback import (
+        save_session_to_long_term_memory,
+    )
+
+    from veadk.memory.long_term_memory import LongTermMemory
+
+    ltm = LongTermMemory(backend="local")
+    agent = Agent(auto_save_session=True, long_term_memory=ltm)
+    assert agent.after_agent_callback is save_session_to_long_term_memory
+
+
+@patch.dict(os.environ, _ENV)
+def test_example_store_appends_example_tool():
+    from google.adk.examples.base_example_provider import BaseExampleProvider
+
+    class _Store(BaseExampleProvider):
+        def get_examples(self, query):
+            return []
+
+    store = _Store()
+    agent = Agent(example_store=store)
+    from google.adk.tools.example_tool import ExampleTool
+
+    assert any(isinstance(t, ExampleTool) for t in agent.tools)
+
+
+@patch.dict(os.environ, _ENV)
+def test_enable_ghostchar_appends_tool_and_instruction():
+    agent = Agent(enable_ghostchar=True)
+    from veadk.tools.ghost_char import GhostcharTool
+
+    assert any(isinstance(t, GhostcharTool) for t in agent.tools)
+    assert "character" in agent.instruction  # type: ignore[operator]
+
+
+@patch.dict(os.environ, _ENV)
+def test_enable_tunnel_appends_toolset():
+    tunnel_toolset = Mock()
+    with patch("veadk.tunnel.TunnelToolset", return_value=tunnel_toolset) as mock_cls:
+        agent = Agent(enable_tunnel=True, name="tunnel_agent")
+    mock_cls.assert_called_once_with(agent_name="tunnel_agent")
+    assert tunnel_toolset in agent.tools
+
+
+@patch.dict(os.environ, _ENV)
+def test_enable_a2ui_appends_toolset():
+    toolset = Mock()
+    with patch("veadk.a2ui.build_a2ui_toolset", return_value=toolset) as mock_build:
+        agent = Agent(enable_a2ui=True)
+    mock_build.assert_called_once()
+    assert toolset in agent.tools
+
+
+@patch.dict(os.environ, _ENV)
+def test_enable_dataset_gen_installs_after_callback():
+    from veadk.toolkits.dataset_auto_gen_callback import (
+        dataset_auto_gen_callback,
+    )
+
+    agent = Agent(enable_dataset_gen=True)
+    assert agent.after_agent_callback is dataset_auto_gen_callback
+
+
+@patch.dict(os.environ, _ENV)
+def test_video_generate_pulls_in_task_query():
+    video_generate = Mock()
+    video_generate.__name__ = "video_generate"
+    video_task_query = Mock()
+    video_task_query.__name__ = "video_task_query"
+
+    with patch(
+        "veadk.tools.builtin_tools.video_generate.video_task_query",
+        new=video_task_query,
+    ):
+        agent = Agent(tools=[video_generate])
+
+    assert video_task_query in agent.tools
+
+
+@patch.dict(os.environ, _ENV)
+def test_video_task_query_pulls_in_generate():
+    video_task_query = Mock()
+    video_task_query.__name__ = "video_task_query"
+    video_generate = Mock()
+    video_generate.__name__ = "video_generate"
+
+    with patch(
+        "veadk.tools.builtin_tools.video_generate.video_generate",
+        new=video_generate,
+    ):
+        agent = Agent(tools=[video_task_query])
+
+    assert video_generate in agent.tools
+
+
+@patch.dict(os.environ, _ENV)
+def test_update_model_copies_with_new_model_string():
+    agent = Agent(model_provider="prov")
+    fake_model = Mock()
+    new_model = Mock()
+    fake_model.model_copy.return_value = new_model
+    agent.model = fake_model
+
+    agent.update_model("new-model")
+
+    fake_model.model_copy.assert_called_once_with(update={"model": "prov/new-model"})
+    assert agent.model is new_model
+
+
+# ---------------------------------------------------------------------------
+# Tracer preparation
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, {**_ENV, "ENABLE_APMPLUS": "true"})
+def test_prepare_tracers_appends_apmplus_exporter():
+    from veadk.tracing.telemetry.exporters.apmplus_exporter import (
+        APMPlusExporter,
+    )
+
+    # A real (no-network) subclass so the ``isinstance`` dedupe check in
+    # ``_prepare_tracers`` still works while avoiding the real constructor's
+    # token fetch.
+    class _FakeAPMPlus(APMPlusExporter):
+        def __init__(self):  # noqa: D401 - test stub, skip real init
+            pass
+
+    with (
+        patch(
+            "veadk.tracing.telemetry.exporters.apmplus_exporter.APMPlusExporter",
+            new=_FakeAPMPlus,
+        ),
+        patch(
+            "veadk.tracing.telemetry.telemetry.init_global_meter_uploader_from_exporters"
+        ) as mock_init,
+    ):
+        agent = Agent()
+
+    # A default OpentelemetryTracer is created and the APMPlus exporter appended.
+    assert agent.tracers
+    exporters = agent.tracers[0].exporters  # type: ignore[attr-defined]
+    assert any(isinstance(e, _FakeAPMPlus) for e in exporters)
+    mock_init.assert_called()
+
+
+@patch.dict(os.environ, _ENV)
+def test_prepare_tracers_noop_without_env():
+    agent = Agent()
+    # No exporter env flags -> no tracer auto-created.
+    assert agent.tracers == []
+
+
+# ---------------------------------------------------------------------------
+# Skills injection
+# ---------------------------------------------------------------------------
+
+
+def _make_skill(name, description="d", checklist=None):
+    skill = Mock()
+    skill.name = name
+    skill.description = description
+    skill.checklist = checklist
+    return skill
+
+
+@patch.dict(os.environ, _ENV)
+def test_load_skills_local_mode_builds_instruction_and_toolset():
+    skill = _make_skill("alpha", "does alpha")
+    toolset = Mock()
+
+    with (
+        patch("veadk.skills.utils.load_skills_from_cloud", return_value=[skill]),
+        patch(
+            "veadk.tools.skills_tools.skills_toolset.SkillsToolset",
+            return_value=toolset,
+        ) as mock_toolset,
+    ):
+        agent = Agent(skills=["alpha"], skills_mode="local")
+
+    assert agent.skills_mode == "local"
+    assert "You have the following skills" in agent.instruction  # type: ignore[operator]
+    assert "alpha" in agent.instruction  # type: ignore[operator]
+    assert "skills_tool" in agent.instruction  # type: ignore[operator]
+    mock_toolset.assert_called_once()
+    assert toolset in agent.tools
+
+
+@patch.dict(os.environ, _ENV)
+def test_load_skills_default_mode_is_local_without_tool_id():
+    skill = _make_skill("beta")
+    with (
+        patch("veadk.skills.utils.load_skills_from_cloud", return_value=[skill]),
+        patch("veadk.tools.skills_tools.skills_toolset.SkillsToolset"),
+        patch.dict(os.environ, {}, clear=False),
+    ):
+        os.environ.pop("AGENTKIT_TOOL_ID", None)
+        agent = Agent(skills=["beta"])
+    assert agent.skills_mode == "local"
+
+
+@patch.dict(os.environ, _ENV)
+def test_load_skills_sandbox_mode_instruction_mentions_execute_skills():
+    skill = _make_skill("gamma")
+    with (
+        patch("veadk.skills.utils.load_skills_from_cloud", return_value=[skill]),
+        patch("veadk.tools.skills_tools.skills_toolset.SkillsToolset"),
+    ):
+        agent = Agent(skills=["gamma"], skills_mode="skills_sandbox")
+    assert "execute_skills" in agent.instruction  # type: ignore[operator]
+
+
+@patch.dict(os.environ, _ENV)
+def test_load_skills_checklist_instruction_and_callback():
+    skill = _make_skill("delta", checklist=["step1"])
+    init_callback = Mock()
+    with (
+        patch("veadk.skills.utils.load_skills_from_cloud", return_value=[skill]),
+        patch("veadk.tools.skills_tools.skills_toolset.SkillsToolset"),
+        patch(
+            "veadk.skills.utils.create_init_skill_check_list_callback",
+            return_value=init_callback,
+        ),
+    ):
+        agent = Agent(
+            skills=["delta"],
+            skills_mode="local",
+            enable_skills_checklist=True,
+        )
+    assert "checklist" in agent.instruction  # type: ignore[operator]
+    assert agent.before_tool_callback is init_callback
+
+
+@patch.dict(os.environ, _ENV)
+def test_load_skills_invalid_mode_raises():
+    # ``skills_mode`` is a Literal on the model, so an invalid value can only be
+    # forced post-construction; ``load_skills`` then rejects it.
+    skill = _make_skill("eps")
+    agent = Agent()
+    object.__setattr__(agent, "skills", ["eps"])
+    object.__setattr__(agent, "skills_mode", "bogus")
+    with (
+        patch("veadk.skills.utils.load_skills_from_cloud", return_value=[skill]),
+        patch("veadk.tools.skills_tools.skills_toolset.SkillsToolset"),
+        pytest.raises(ValueError, match="Unsupported skill mode"),
+    ):
+        agent.load_skills()
+
+
+@patch.dict(os.environ, _ENV)
+def test_load_skills_dynamic_load_installs_before_agent_callback():
+    skill = _make_skill("zeta")
+    check_skills = Mock()
+    with (
+        patch("veadk.skills.utils.load_skills_from_cloud", return_value=[skill]),
+        patch("veadk.tools.skills_tools.skills_toolset.SkillsToolset"),
+        patch("veadk.skills.check_skills_callback.check_skills", new=check_skills),
+    ):
+        agent = Agent(
+            skills=["zeta"],
+            skills_mode="local",
+            enable_dynamic_load_skills=True,
+        )
+    assert agent.before_agent_callback is check_skills
+
+
+@patch.dict(os.environ, _ENV)
+def test_load_skills_skips_empty_skill_entries():
+    toolset = Mock()
+    with patch(
+        "veadk.tools.skills_tools.skills_toolset.SkillsToolset",
+        return_value=toolset,
+    ):
+        agent = Agent(skills=["", "   "], skills_mode="local")
+    # No skills loaded -> instruction unchanged, but toolset still appended.
+    assert toolset in agent.tools
+
+
+# ---------------------------------------------------------------------------
+# _llm_flow selection
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, _ENV)
+def test_llm_flow_single_flow_when_transfers_disallowed():
+    from google.adk.flows.llm_flows.single_flow import SingleFlow
+
+    agent = Agent(
+        disallow_transfer_to_parent=True,
+        disallow_transfer_to_peers=True,
+    )
+    assert isinstance(agent._llm_flow, SingleFlow)
+
+
+@patch.dict(os.environ, _ENV)
+def test_llm_flow_auto_flow_by_default():
+    from google.adk.flows.llm_flows.auto_flow import AutoFlow
+
+    agent = Agent()
+    assert isinstance(agent._llm_flow, AutoFlow)
+
+
+@patch.dict(os.environ, _ENV)
+def test_llm_flow_supervisor_single_flow():
+    agent = Agent(
+        disallow_transfer_to_parent=True,
+        disallow_transfer_to_peers=True,
+        enable_supervisor=True,
+    )
+    supervisor_flow = Mock()
+    with patch(
+        "veadk.flows.supervise_single_flow.SupervisorSingleFlow",
+        return_value=supervisor_flow,
+    ) as mock_cls:
+        flow = agent._llm_flow
+    mock_cls.assert_called_once_with(supervised_agent=agent)
+    assert flow is supervisor_flow
+
+
+@patch.dict(os.environ, _ENV)
+def test_llm_flow_supervisor_auto_flow():
+    agent = Agent(enable_supervisor=True)
+    supervisor_flow = Mock()
+    with patch(
+        "veadk.flows.supervise_auto_flow.SupervisorAutoFlow",
+        return_value=supervisor_flow,
+    ) as mock_cls:
+        flow = agent._llm_flow
+    mock_cls.assert_called_once_with(supervised_agent=agent)
+    assert flow is supervisor_flow
+
+
+# ---------------------------------------------------------------------------
+# Runtime dispatch (_run_async_impl) and run() deprecation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch.dict(os.environ, _ENV)
+async def test_run_async_impl_adk_runtime_defers_to_super():
+    agent = Agent(runtime="adk")
+    ctx = Mock()
+
+    async def _fake_super_impl(_ctx):
+        yield "event-1"
+        yield "event-2"
+
+    with patch(
+        "google.adk.agents.llm_agent.LlmAgent._run_async_impl",
+        side_effect=_fake_super_impl,
+    ):
+        events = [e async for e in agent._run_async_impl(ctx)]
+    assert events == ["event-1", "event-2"]
+
+
+@pytest.mark.asyncio
+@patch.dict(os.environ, _ENV)
+async def test_run_async_impl_non_adk_runtime_uses_get_runtime():
+    agent = Agent()
+    object.__setattr__(agent, "runtime", "codex")
+    ctx = Mock()
+
+    async def _runtime_stream(_agent, _ctx):
+        yield "codex-event"
+
+    runtime = Mock()
+    runtime.run_async = _runtime_stream
+    with patch("veadk.runtime.get_runtime", return_value=runtime) as mock_get:
+        events = [e async for e in agent._run_async_impl(ctx)]
+    mock_get.assert_called_once_with("codex")
+    assert events == ["codex-event"]
+
+
+@pytest.mark.asyncio
+@patch.dict(os.environ, _ENV)
+async def test_run_method_is_deprecated():
+    agent = Agent()
+    if not hasattr(agent, "run"):
+        pytest.skip("run() not overridden on this ADK version")
+    with pytest.raises(NotImplementedError, match="deprecated"):
+        await agent.run()
+
+
+@patch.dict(os.environ, _ENV)
+def test_existing_model_skips_client_creation():
+    from google.adk.models.lite_llm import LiteLlm
+
+    existing = LiteLlm(model="prov/preset")
+    with patch("veadk.agent.LiteLlm") as mock_lite_llm:
+        agent = Agent(model=existing)
+    mock_lite_llm.assert_not_called()
+    assert agent.model is existing
+
+
+@patch.dict(os.environ, {})
+def test_agent_uses_settings_property_for_api_key():
+    with patch(
+        "veadk.configs.model_configs.ModelConfig.api_key",
+        new_callable=PropertyMock,
+        return_value="from-settings",
+    ):
+        agent = Agent()
+    assert agent.model_api_key == "from-settings"

--- a/tests/agent/test_agent_behavior.py
+++ b/tests/agent/test_agent_behavior.py
@@ -564,16 +564,6 @@ async def test_run_async_impl_non_adk_runtime_uses_get_runtime():
     assert events == ["codex-event"]
 
 
-@pytest.mark.asyncio
-@patch.dict(os.environ, _ENV)
-async def test_run_method_is_deprecated():
-    agent = Agent()
-    if not hasattr(agent, "run"):
-        pytest.skip("run() not overridden on this ADK version")
-    with pytest.raises(NotImplementedError, match="deprecated"):
-        await agent.run()
-
-
 @patch.dict(os.environ, _ENV)
 def test_existing_model_skips_client_creation():
     from google.adk.models.lite_llm import LiteLlm

--- a/tests/configs/test_dynamic_config_manager.py
+++ b/tests/configs/test_dynamic_config_manager.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``veadk.configs.dynamic_config_manager``.
+
+The module imports the ``v2.nacos`` SDK at module top level, which is not
+installed in the test environment, so we register lightweight stubs in
+``sys.modules`` before importing. All Nacos / MSE credential access is mocked;
+no network calls are performed.
+"""
+
+import json
+import sys
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ``v2.nacos`` is an optional runtime dependency that is not installed in the
+# test environment. Register stubs so the module under test can be imported.
+for _name in (
+    "v2",
+    "v2.nacos",
+    "v2.nacos.config",
+    "v2.nacos.config.model",
+    "v2.nacos.config.model.config_param",
+):
+    sys.modules.setdefault(_name, MagicMock())
+
+from veadk.configs import dynamic_config_manager as dcm  # noqa: E402
+from veadk.consts import (  # noqa: E402
+    DEFAULT_NACOS_GROUP,
+    DEFAULT_NACOS_INSTANCE_NAME,
+)
+
+
+def _make_agent(agent_id: str = "agent-1") -> MagicMock:
+    agent = MagicMock()
+    agent.id = agent_id
+    agent.name = "name"
+    agent.description = "description"
+    agent.model_name = "model"
+    agent.instruction = "instruction"
+    return agent
+
+
+def test_init_wraps_single_agent_in_list():
+    agent = _make_agent()
+    manager = dcm.DynamicConfigManager(agent)
+    assert manager.agents == [agent]
+
+
+def test_init_keeps_list_of_agents():
+    agents = [_make_agent("a"), _make_agent("b")]
+    manager = dcm.DynamicConfigManager(cast("list[dcm.Agent]", agents))
+    assert manager.agents == agents
+
+
+def test_register_agent_single_and_list():
+    manager = dcm.DynamicConfigManager(_make_agent("a"))
+    manager.register_agent(_make_agent("b"))
+    assert len(manager.agents) == 2
+
+    manager.register_agent([_make_agent("c"), _make_agent("d")])
+    assert len(manager.agents) == 4
+
+
+def test_update_agent_applies_matching_config():
+    agent = _make_agent("agent-1")
+    agent.model_name = "old-model"
+    manager = dcm.DynamicConfigManager(agent)
+
+    configs = {
+        "agent": [
+            {
+                "id": "agent-1",
+                "name": "new-name",
+                "description": "new-description",
+                "model_name": "new-model",
+                "instruction": "new-instruction",
+            }
+        ]
+    }
+    manager.update_agent(configs)
+
+    assert agent.name == "new-name"
+    assert agent.description == "new-description"
+    assert agent.instruction == "new-instruction"
+    # model_name changed -> update_model must be invoked with the new value.
+    agent.update_model.assert_called_once_with(model_name="new-model")
+
+
+def test_update_agent_skips_when_model_unchanged():
+    agent = _make_agent("agent-1")
+    agent.model_name = "same-model"
+    manager = dcm.DynamicConfigManager(agent)
+
+    configs = {
+        "agent": [
+            {
+                "id": "agent-1",
+                "name": "n",
+                "description": "d",
+                "model_name": "same-model",
+                "instruction": "i",
+            }
+        ]
+    }
+    manager.update_agent(configs)
+
+    agent.update_model.assert_not_called()
+
+
+def test_update_agent_ignores_non_matching_id():
+    agent = _make_agent("agent-1")
+    manager = dcm.DynamicConfigManager(agent)
+
+    original_name = agent.name
+    manager.update_agent(
+        {
+            "agent": [
+                {
+                    "id": "different-id",
+                    "name": "should-not-apply",
+                    "description": "d",
+                    "model_name": "m",
+                    "instruction": "i",
+                }
+            ]
+        }
+    )
+    assert agent.name == original_name
+    agent.update_model.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_config_update_parses_json_and_updates(monkeypatch):
+    manager = dcm.DynamicConfigManager(_make_agent("agent-1"))
+
+    captured = {}
+
+    def fake_update_agent(content):
+        captured["content"] = content
+
+    monkeypatch.setattr(manager, "update_agent", fake_update_agent)
+
+    payload = {"agent": [{"id": "agent-1"}]}
+    await manager.handle_config_update(
+        tenant="t", data_id="veadk", group="g", content=json.dumps(payload)
+    )
+
+    assert captured["content"] == payload
+
+
+@pytest.mark.asyncio
+async def test_create_config_uses_defaults_and_publishes(monkeypatch):
+    """create_config falls back to default instance/group, builds the default
+    agent config payload, publishes it, and registers a listener."""
+    agent = _make_agent("agent-1")
+    manager = dcm.DynamicConfigManager(agent)
+
+    monkeypatch.setenv("NACOS_ENDPOINT", "127.0.0.1")
+    monkeypatch.setenv("NACOS_PORT", "8848")
+    monkeypatch.setenv("NACOS_USERNAME", "nacos")
+    monkeypatch.setenv("NACOS_PASSWORD", "secret")
+
+    config_client = MagicMock()
+    config_client.publish_config = AsyncMock(return_value=True)
+    config_client.add_listener = AsyncMock()
+
+    create_service = AsyncMock(return_value=config_client)
+
+    with (
+        patch.object(dcm.NacosConfigService, "create_config_service", create_service),
+        patch.object(dcm, "ConfigParam") as mock_param,
+    ):
+        result = await manager.create_config()
+
+    assert result is config_client
+
+    # publish_config called once; the JSON content carries the default agent
+    # payload assembled from the registered agents.
+    config_client.publish_config.assert_awaited_once()
+    _, kwargs = mock_param.call_args
+    published = json.loads(kwargs["content"])
+    assert published["agent"][0]["id"] == "agent-1"
+    assert kwargs["data_id"] == "veadk"
+    assert kwargs["group"] == DEFAULT_NACOS_GROUP
+
+    config_client.add_listener.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_config_asserts_on_publish_failure(monkeypatch):
+    manager = dcm.DynamicConfigManager(_make_agent("agent-1"))
+
+    monkeypatch.setenv("NACOS_ENDPOINT", "127.0.0.1")
+    monkeypatch.setenv("NACOS_PORT", "8848")
+    monkeypatch.setenv("NACOS_USERNAME", "nacos")
+    monkeypatch.setenv("NACOS_PASSWORD", "secret")
+
+    config_client = MagicMock()
+    config_client.publish_config = AsyncMock(return_value=False)
+    config_client.add_listener = AsyncMock()
+
+    with (
+        patch.object(
+            dcm.NacosConfigService,
+            "create_config_service",
+            AsyncMock(return_value=config_client),
+        ),
+        patch.object(dcm, "ConfigParam"),
+        pytest.raises(AssertionError, match="publish config to nacos failed"),
+    ):
+        await manager.create_config(
+            instance_name=DEFAULT_NACOS_INSTANCE_NAME,
+            group_id=DEFAULT_NACOS_GROUP,
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_config_falls_back_to_mse_credentials(monkeypatch):
+    """When Nacos env vars are absent, MSE credentials are fetched instead."""
+    manager = dcm.DynamicConfigManager(_make_agent("agent-1"))
+
+    for var in ("NACOS_ENDPOINT", "NACOS_PORT", "NACOS_USERNAME", "NACOS_PASSWORD"):
+        monkeypatch.delenv(var, raising=False)
+
+    credentials = MagicMock(
+        endpoint="mse-endpoint",
+        port="8848",
+        username="mse-user",
+        password="mse-pass",
+    )
+
+    config_client = MagicMock()
+    config_client.publish_config = AsyncMock(return_value=True)
+    config_client.add_listener = AsyncMock()
+
+    with (
+        patch.object(dcm, "get_mse_cridential", return_value=credentials) as mock_cred,
+        patch.object(
+            dcm.NacosConfigService,
+            "create_config_service",
+            AsyncMock(return_value=config_client),
+        ),
+        patch.object(dcm, "ConfigParam"),
+    ):
+        await manager.create_config(instance_name="my-instance")
+
+    mock_cred.assert_called_once_with(instance_name="my-instance")

--- a/tests/memory/test_save_session_callback.py
+++ b/tests/memory/test_save_session_callback.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``veadk.memory.save_session_callback``.
+
+These exercise the throttling / session-switch logic of
+``save_session_to_long_term_memory`` against a fully mocked callback context.
+No real session service or long-term memory backend is used.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from veadk.memory import save_session_callback as ssc
+from veadk.memory.save_session_callback import save_session_to_long_term_memory
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    """Module-level caches persist across calls; reset them per test."""
+    ssc._session_save_cache.clear()
+    ssc._active_sessions.clear()
+    yield
+    ssc._session_save_cache.clear()
+    ssc._active_sessions.clear()
+
+
+def _make_session(session_id: str, event_count: int = 0) -> MagicMock:
+    session = MagicMock()
+    session.id = session_id
+    session.events = [MagicMock() for _ in range(event_count)]
+    return session
+
+
+def _make_context(
+    *,
+    app_name: str = "app",
+    user_id: str = "user",
+    session_id: str = "session",
+    long_term_memory: object | None = None,
+    sessions: dict | None = None,
+) -> MagicMock:
+    """Build a mock CallbackContext.
+
+    ``sessions`` maps session_id -> session object returned by
+    ``session_service.get_session``.
+    """
+    ctx = MagicMock()
+    inv = ctx._invocation_context
+    inv.app_name = app_name
+    inv.user_id = user_id
+    inv.agent.long_term_memory = long_term_memory
+    inv.session.id = session_id
+
+    store = sessions if sessions is not None else {}
+
+    async def get_session(app_name, user_id, session_id):
+        return store.get(session_id)
+
+    inv.session_service.get_session = AsyncMock(side_effect=get_session)
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_long_term_memory():
+    ctx = _make_context(long_term_memory=None)
+    result = await save_session_to_long_term_memory(ctx)
+    assert result is None
+    # No session lookup should have happened.
+    ctx._invocation_context.session_service.get_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_first_save_adds_session_and_populates_cache():
+    ltm = MagicMock()
+    ltm.add_session_to_memory = AsyncMock()
+    session = _make_session("session", event_count=3)
+    ctx = _make_context(long_term_memory=ltm, sessions={"session": session})
+
+    await save_session_to_long_term_memory(ctx)
+
+    ltm.add_session_to_memory.assert_awaited_once_with(session)
+    cache_key = ("app", "user", "session")
+    assert cache_key in ssc._session_save_cache
+    assert ssc._session_save_cache[cache_key]["last_event_count"] == 3
+    assert ssc._active_sessions[("app", "user")] == "session"
+
+
+@pytest.mark.asyncio
+async def test_skip_save_when_below_thresholds(monkeypatch):
+    """A recent save with too few new events must be skipped."""
+    monkeypatch.setattr(ssc, "MIN_MESSAGES_THRESHOLD", 10)
+    monkeypatch.setattr(ssc, "MIN_TIME_THRESHOLD", 60)
+
+    ltm = MagicMock()
+    ltm.add_session_to_memory = AsyncMock()
+    session = _make_session("session", event_count=2)
+    ctx = _make_context(long_term_memory=ltm, sessions={"session": session})
+
+    # Seed cache as if a save just happened with the same event count.
+    import time
+
+    ssc._session_save_cache[("app", "user", "session")] = {
+        "last_save_time": time.time(),
+        "last_event_count": 1,
+    }
+
+    result = await save_session_to_long_term_memory(ctx)
+    assert result is None
+    ltm.add_session_to_memory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_save_when_enough_new_events(monkeypatch):
+    monkeypatch.setattr(ssc, "MIN_MESSAGES_THRESHOLD", 10)
+    monkeypatch.setattr(ssc, "MIN_TIME_THRESHOLD", 60)
+
+    ltm = MagicMock()
+    ltm.add_session_to_memory = AsyncMock()
+    session = _make_session("session", event_count=20)
+    ctx = _make_context(long_term_memory=ltm, sessions={"session": session})
+
+    import time
+
+    ssc._session_save_cache[("app", "user", "session")] = {
+        "last_save_time": time.time(),
+        "last_event_count": 1,
+    }
+
+    await save_session_to_long_term_memory(ctx)
+    ltm.add_session_to_memory.assert_awaited_once_with(session)
+    assert ssc._session_save_cache[("app", "user", "session")]["last_event_count"] == 20
+
+
+@pytest.mark.asyncio
+async def test_session_switch_force_saves_previous(monkeypatch):
+    monkeypatch.setattr(ssc, "MIN_MESSAGES_THRESHOLD", 10)
+    monkeypatch.setattr(ssc, "MIN_TIME_THRESHOLD", 60)
+
+    ltm = MagicMock()
+    ltm.add_session_to_memory = AsyncMock()
+
+    old_session = _make_session("old", event_count=5)
+    new_session = _make_session("new", event_count=1)
+
+    ctx = _make_context(
+        session_id="new",
+        long_term_memory=ltm,
+        sessions={"old": old_session, "new": new_session},
+    )
+
+    # Mark "old" as the previously active session for this user.
+    ssc._active_sessions[("app", "user")] = "old"
+
+    await save_session_to_long_term_memory(ctx)
+
+    # The previous session must be force-saved, and the active session updated.
+    saved = [call.args[0] for call in ltm.add_session_to_memory.await_args_list]
+    assert old_session in saved
+    assert ssc._active_sessions[("app", "user")] == "new"
+    assert ("app", "user", "old") in ssc._session_save_cache
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_session_not_found():
+    ltm = MagicMock()
+    ltm.add_session_to_memory = AsyncMock()
+    ctx = _make_context(long_term_memory=ltm, sessions={})  # get_session -> None
+
+    result = await save_session_to_long_term_memory(ctx)
+    assert result is None
+    ltm.add_session_to_memory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_attribute_error_is_swallowed():
+    """A malformed context raising AttributeError must not propagate."""
+    ctx = MagicMock()
+    # Accessing the agent attribute raises -> caught by the handler.
+    type(ctx._invocation_context).agent = property(
+        lambda self: (_ for _ in ()).throw(AttributeError("boom"))
+    )
+    result = await save_session_to_long_term_memory(ctx)
+    assert result is None

--- a/tests/memory/test_short_term_memory_processor.py
+++ b/tests/memory/test_short_term_memory_processor.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``veadk.memory.short_term_memory_processor``.
+
+The processor calls ``litellm.completion`` to summarize a session's history.
+That call is mocked so no model / network access happens.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.adk.events.event import Event
+from google.adk.sessions import Session
+from google.genai.types import Content, Part
+
+from veadk.memory import short_term_memory_processor as stmp
+from veadk.memory.short_term_memory_processor import ShortTermMemoryProcessor
+
+
+def _event(role: str, text: str) -> Event:
+    return Event(
+        author=role,
+        content=Content(role=role, parts=[Part(text=text)]),
+    )
+
+
+def _make_session(events: list[Event]) -> Session:
+    return Session(
+        id="session-1",
+        app_name="app",
+        user_id="user",
+        events=events,
+    )
+
+
+def _completion_returning(payload: object) -> MagicMock:
+    """Build a fake litellm completion response wrapping ``payload`` as JSON."""
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = json.dumps(payload)
+    return response
+
+
+def test_after_load_session_replaces_events_with_summary():
+    session = _make_session([_event("user", "hello"), _event("model", "hi")])
+
+    abstracted = [
+        {"role": "user", "content": "summary-user"},
+        {"role": "model", "content": "summary-model"},
+    ]
+
+    processor = ShortTermMemoryProcessor()
+    with patch.object(
+        stmp, "completion", return_value=_completion_returning(abstracted)
+    ) as mock_completion:
+        result = processor.after_load_session(session)
+
+    mock_completion.assert_called_once()
+    # Events fully replaced by the abstracted messages.
+    assert len(result.events) == 2
+    assert result.events[0].author == "memory_optimizer"
+    assert result.events[0].content is not None
+    assert result.events[0].content.parts is not None
+    assert result.events[0].content.parts[0].text == "summary-user"
+    assert result.events[1].content is not None
+    assert result.events[1].content.role == "model"
+
+
+def test_after_load_session_skips_events_without_content():
+    empty = Event(author="user", content=None)
+    valid = _event("user", "keep me")
+    session = _make_session([empty, valid])
+
+    captured_messages = {}
+
+    def fake_render(messages):
+        captured_messages["messages"] = messages
+        return "rendered-prompt"
+
+    processor = ShortTermMemoryProcessor()
+    with (
+        patch.object(stmp, "render_prompt", side_effect=fake_render),
+        patch.object(stmp, "completion", return_value=_completion_returning([])),
+    ):
+        processor.after_load_session(session)
+
+    # Only the event carrying content should reach the prompt renderer.
+    assert captured_messages["messages"] == [{"role": "user", "content": "keep me"}]
+
+
+@pytest.mark.asyncio
+async def test_patch_wraps_get_session_and_post_processes():
+    """``patch()`` returns a decorator that runs ``after_load_session`` on the
+    awaited result of the wrapped coroutine."""
+    processor = ShortTermMemoryProcessor()
+    decorator = processor.patch()
+
+    sentinel_session = _make_session([_event("user", "hi")])
+    processed = object()
+
+    async def original_get_session(*args, **kwargs):
+        return sentinel_session
+
+    with patch.object(
+        processor, "after_load_session", return_value=processed
+    ) as mock_after:
+        wrapped = decorator(original_get_session)
+        out = await wrapped("a", b="c")
+
+    mock_after.assert_called_once_with(sentinel_session)
+    assert out is processed
+
+
+@pytest.mark.asyncio
+async def test_patch_passes_through_none_session():
+    """If the wrapped function returns ``None`` no post-processing is done."""
+    processor = ShortTermMemoryProcessor()
+    decorator = processor.patch()
+
+    async def original_get_session(*args, **kwargs):
+        return None
+
+    with patch.object(processor, "after_load_session") as mock_after:
+        wrapped = decorator(original_get_session)
+        out = await wrapped()
+
+    assert out is None
+    mock_after.assert_not_called()

--- a/tests/models/test_ark_embedding.py
+++ b/tests/models/test_ark_embedding.py
@@ -1,0 +1,304 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``veadk.models.ark_embedding``.
+
+Credential resolution, client construction, and the (a)sync embedding calls
+are covered with the Ark SDK (`Ark`/`AsyncArk`) fully mocked. The
+``create_embedding_model`` factory's routing is verified for both branches.
+No network or live Ark access is required.
+"""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from veadk.consts import (
+    DEFAULT_MODEL_EMBEDDING_API_BASE,
+    DEFAULT_MODEL_EMBEDDING_NAME,
+)
+from veadk.models import ark_embedding
+from veadk.models.ark_embedding import (
+    ArkEmbedding,
+    ArkEmbeddingModel,
+    create_embedding_model,
+)
+
+
+def _embedding_response(vector):
+    """Mimic ``client.multimodal_embeddings.create(...)`` -> ``.data.embedding``."""
+    resp = MagicMock()
+    resp.data.embedding = vector
+    return resp
+
+
+# --------------------------------------------------------------------------
+# enum / class_name
+# --------------------------------------------------------------------------
+def test_ark_embedding_model_enum_values():
+    assert (
+        ArkEmbeddingModel.DOUBAO_EMBEDDING_VISION_251215
+        == "doubao-embedding-vision-251215"
+    )
+    assert (
+        ArkEmbeddingModel.DOUBAO_EMBEDDING_VISION_250615
+        == "doubao-embedding-vision-250615"
+    )
+
+
+def test_class_name():
+    assert ArkEmbedding.class_name() == "ArkEmbedding"
+
+
+# --------------------------------------------------------------------------
+# credential resolution
+# --------------------------------------------------------------------------
+def test_explicit_api_key_takes_precedence():
+    emb = ArkEmbedding(api_key="explicit-key")
+    assert emb.api_key == "explicit-key"
+    # default model + default base applied
+    assert emb.model_name == DEFAULT_MODEL_EMBEDDING_NAME
+    assert emb.api_base == DEFAULT_MODEL_EMBEDDING_API_BASE
+
+
+def test_api_key_resolved_from_env(monkeypatch):
+    monkeypatch.setenv("MODEL_EMBEDDING_API_KEY", "env-key")
+    emb = ArkEmbedding()
+    assert emb.api_key == "env-key"
+
+
+def test_missing_api_key_raises(monkeypatch):
+    monkeypatch.delenv("MODEL_EMBEDDING_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="MODEL_EMBEDDING_API_KEY"):
+        ArkEmbedding()
+
+
+def test_custom_api_base_preserved():
+    emb = ArkEmbedding(api_key="k", api_base="https://custom.example/")
+    assert emb.api_base == "https://custom.example/"
+
+
+def test_dimensions_propagates_to_additional_kwargs():
+    emb = ArkEmbedding(api_key="k", dimensions=256)
+    assert emb.dimensions == 256
+    assert emb.additional_kwargs["dimensions"] == 256
+
+
+# --------------------------------------------------------------------------
+# client construction / reuse
+# --------------------------------------------------------------------------
+def test_get_credential_kwargs_shape():
+    emb = ArkEmbedding(api_key="k", api_base="https://b/", timeout=12.0, max_retries=3)
+    kwargs = emb._get_credential_kwargs()
+    assert kwargs["api_key"] == "k"
+    assert kwargs["base_url"] == "https://b/"
+    assert kwargs["timeout"] == 12.0
+    assert kwargs["max_retries"] == 3
+    assert kwargs["http_client"] is None
+
+
+def test_get_credential_kwargs_async_uses_async_http_client():
+    emb = ArkEmbedding(api_key="k")
+    sync_kwargs = emb._get_credential_kwargs(is_async=False)
+    async_kwargs = emb._get_credential_kwargs(is_async=True)
+    assert sync_kwargs["http_client"] is emb._http_client
+    assert async_kwargs["http_client"] is emb._async_http_client
+
+
+def test_get_client_reuses_when_reuse_client_true():
+    emb = ArkEmbedding(api_key="k", reuse_client=True)
+    with patch.object(ark_embedding, "Ark", return_value=MagicMock()) as ctor:
+        c1 = emb._get_client()
+        c2 = emb._get_client()
+    assert c1 is c2
+    ctor.assert_called_once()
+
+
+def test_get_client_fresh_when_reuse_client_false():
+    emb = ArkEmbedding(api_key="k", reuse_client=False)
+    with patch.object(
+        ark_embedding, "Ark", side_effect=lambda **_: MagicMock()
+    ) as ctor:
+        c1 = emb._get_client()
+        c2 = emb._get_client()
+    assert c1 is not c2
+    assert ctor.call_count == 2
+
+
+def test_get_aclient_reuses_when_reuse_client_true():
+    emb = ArkEmbedding(api_key="k", reuse_client=True)
+    with patch.object(ark_embedding, "AsyncArk", return_value=MagicMock()) as ctor:
+        a1 = emb._get_aclient()
+        a2 = emb._get_aclient()
+    assert a1 is a2
+    ctor.assert_called_once()
+
+
+# --------------------------------------------------------------------------
+# sync embedding calls
+# --------------------------------------------------------------------------
+def test_get_text_embedding_builds_request_and_parses_response():
+    emb = ArkEmbedding(api_key="k", model_name="doubao-embedding-vision-250615")
+    fake_client = MagicMock()
+    fake_client.multimodal_embeddings.create.return_value = _embedding_response(
+        [0.1, 0.2]
+    )
+
+    with patch.object(emb, "_get_client", return_value=fake_client):
+        result = emb.get_text_embedding("hello")
+
+    assert result == [0.1, 0.2]
+    _, kwargs = fake_client.multimodal_embeddings.create.call_args
+    assert kwargs["model"] == "doubao-embedding-vision-250615"
+    assert kwargs["input"] == [{"type": "text", "text": "hello"}]
+
+
+def test_get_query_embedding_builds_request():
+    emb = ArkEmbedding(api_key="k")
+    fake_client = MagicMock()
+    fake_client.multimodal_embeddings.create.return_value = _embedding_response([1.0])
+
+    with patch.object(emb, "_get_client", return_value=fake_client):
+        result = emb.get_query_embedding("q")
+
+    assert result == [1.0]
+    _, kwargs = fake_client.multimodal_embeddings.create.call_args
+    assert kwargs["input"] == [{"type": "text", "text": "q"}]
+
+
+def test_get_text_embeddings_loops_per_text():
+    emb = ArkEmbedding(api_key="k")
+    fake_client = MagicMock()
+    fake_client.multimodal_embeddings.create.side_effect = [
+        _embedding_response([1.0]),
+        _embedding_response([2.0]),
+    ]
+
+    with patch.object(emb, "_get_client", return_value=fake_client):
+        result = emb.get_text_embeddings(["a", "b"])
+
+    assert result == [[1.0], [2.0]]
+    assert fake_client.multimodal_embeddings.create.call_count == 2
+
+
+def test_get_text_embeddings_empty_returns_empty_without_client_call():
+    emb = ArkEmbedding(api_key="k")
+    with patch.object(emb, "_get_client") as get_client:
+        assert emb.get_text_embeddings([]) == []
+    get_client.assert_not_called()
+
+
+def test_additional_kwargs_forwarded_to_create():
+    emb = ArkEmbedding(api_key="k", dimensions=64)
+    fake_client = MagicMock()
+    fake_client.multimodal_embeddings.create.return_value = _embedding_response([0.0])
+
+    with patch.object(emb, "_get_client", return_value=fake_client):
+        emb.get_text_embedding("x")
+
+    _, kwargs = fake_client.multimodal_embeddings.create.call_args
+    assert kwargs["dimensions"] == 64
+
+
+# --------------------------------------------------------------------------
+# async embedding calls
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_aget_text_embedding():
+    emb = ArkEmbedding(api_key="k")
+    fake_aclient = MagicMock()
+    fake_aclient.multimodal_embeddings.create = AsyncMock(
+        return_value=_embedding_response([0.5, 0.6])
+    )
+
+    with patch.object(emb, "_get_aclient", return_value=fake_aclient):
+        result = await emb.aget_text_embedding("hi")
+
+    assert result == [0.5, 0.6]
+    _, kwargs = fake_aclient.multimodal_embeddings.create.call_args
+    assert kwargs["input"] == [{"type": "text", "text": "hi"}]
+
+
+@pytest.mark.asyncio
+async def test_aget_query_embedding():
+    emb = ArkEmbedding(api_key="k")
+    fake_aclient = MagicMock()
+    fake_aclient.multimodal_embeddings.create = AsyncMock(
+        return_value=_embedding_response([9.0])
+    )
+
+    with patch.object(emb, "_get_aclient", return_value=fake_aclient):
+        result = await emb.aget_query_embedding("q")
+
+    assert result == [9.0]
+
+
+@pytest.mark.asyncio
+async def test_aget_text_embeddings_loops():
+    emb = ArkEmbedding(api_key="k")
+    fake_aclient = MagicMock()
+    fake_aclient.multimodal_embeddings.create = AsyncMock(
+        side_effect=[_embedding_response([1.0]), _embedding_response([2.0])]
+    )
+
+    with patch.object(emb, "_get_aclient", return_value=fake_aclient):
+        result = await emb.aget_text_embeddings(["a", "b"])
+
+    assert result == [[1.0], [2.0]]
+    assert fake_aclient.multimodal_embeddings.create.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_aget_text_embeddings_empty_returns_empty():
+    emb = ArkEmbedding(api_key="k")
+    with patch.object(emb, "_get_aclient") as get_aclient:
+        assert await emb.aget_text_embeddings([]) == []
+    get_aclient.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# factory
+# --------------------------------------------------------------------------
+def test_create_embedding_model_routes_to_ark_for_doubao():
+    model = create_embedding_model(
+        model_name="doubao-embedding-vision-250615", api_key="k"
+    )
+    assert isinstance(model, ArkEmbedding)
+    assert model.model_name == "doubao-embedding-vision-250615"
+
+
+def test_create_embedding_model_routes_to_openai_like_for_other():
+    fake_instance = object()
+    with patch(
+        "llama_index.embeddings.openai_like.OpenAILikeEmbedding",
+        return_value=fake_instance,
+    ) as ctor:
+        model = create_embedding_model(
+            model_name="text-embedding-3-small",
+            api_key="k",
+            api_base="https://api.openai.com/v1",
+        )
+    assert model is fake_instance
+    ctor.assert_called_once()
+    _, kwargs = ctor.call_args
+    assert kwargs["model_name"] == "text-embedding-3-small"
+
+
+def test_environ_default_does_not_leak(monkeypatch):
+    # Constructing with an explicit key must not depend on the env var.
+    monkeypatch.delenv("MODEL_EMBEDDING_API_KEY", raising=False)
+    emb = ArkEmbedding(api_key="explicit")
+    assert emb.api_key == "explicit"
+    assert os.getenv("MODEL_EMBEDDING_API_KEY") is None

--- a/tests/models/test_ark_llm.py
+++ b/tests/models/test_ark_llm.py
@@ -1,0 +1,733 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``veadk.models.ark_llm``.
+
+These exercise the pure request/response transform helpers (model-name
+normalization, input filtering, request reorganization, schema conversion)
+and the ``ArkLlm`` client glue with the Ark SDK fully mocked, so no network
+or live Volcengine/Ark access is required.
+"""
+
+import os
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+os.environ.setdefault("MODEL_AGENT_API_KEY", "mocked_api_key")
+os.environ.setdefault("MODEL_API_KEY", "mocked_api_key")
+
+from google.adk.models.llm_request import LlmRequest  # noqa: E402
+from google.adk.models.llm_response import LlmResponse  # noqa: E402
+from google.genai import types  # noqa: E402
+from volcenginesdkarkruntime.types.responses import (  # noqa: E402
+    ResponseFunctionToolCall,
+    ResponseOutputMessage,
+    ResponseOutputText,
+    ResponseReasoningItem,
+    ResponseTextDeltaEvent,
+)
+from volcenginesdkarkruntime.types.responses.response_reasoning_item import (  # noqa: E402
+    Summary,
+)
+
+from volcenginesdkarkruntime._exceptions import ArkBadRequestError  # noqa: E402
+
+from veadk.consts import DEFAULT_VIDEO_MODEL_API_BASE  # noqa: E402
+from veadk.models import ark_llm  # noqa: E402
+from veadk.models.ark_llm import (  # noqa: E402
+    ArkLlm,
+    ArkLlmClient,
+    _content_to_input_item,
+    _get_responses_inputs,
+    _is_caching_enabled,
+    _responses_schema_to_text,
+    _safe_json_serialize,
+    _schema_to_dict,
+    _to_ark_role,
+    ark_response_to_generate_content_response,
+    event_to_generate_content_response,
+    filtered_inputs,
+    get_model_without_provider,
+    request_reorganization_by_ark,
+)
+
+
+# --------------------------------------------------------------------------
+# small pure helpers
+# --------------------------------------------------------------------------
+def test_to_ark_role_maps_model_and_assistant_to_assistant():
+    assert _to_ark_role("model") == "assistant"
+    assert _to_ark_role("assistant") == "assistant"
+
+
+def test_to_ark_role_defaults_to_user():
+    assert _to_ark_role("user") == "user"
+    assert _to_ark_role(None) == "user"
+    assert _to_ark_role("anything-else") == "user"
+
+
+def test_safe_json_serialize_roundtrips_dict():
+    assert _safe_json_serialize({"a": 1}) == '{"a": 1}'
+
+
+def test_safe_json_serialize_preserves_non_ascii():
+    # ensure_ascii=False -> Chinese characters are kept verbatim.
+    assert _safe_json_serialize({"k": "中文"}) == '{"k": "中文"}'
+
+
+def test_safe_json_serialize_falls_back_to_str_for_unserializable():
+    obj = object()
+    assert _safe_json_serialize(obj) == str(obj)
+
+
+def test_schema_to_dict_lowercases_type_and_strips_none_enum():
+    schema = types.Schema(
+        type=types.Type.STRING,
+        enum=["a", "b"],
+    )
+    result = _schema_to_dict(schema)
+    assert result["type"] == "string"
+    assert result["enum"] == ["a", "b"]
+
+
+def test_schema_to_dict_recurses_into_properties_and_items():
+    schema = types.Schema(
+        type=types.Type.OBJECT,
+        properties={
+            "items": types.Schema(
+                type=types.Type.ARRAY,
+                items=types.Schema(type=types.Type.INTEGER),
+            ),
+        },
+    )
+    result = _schema_to_dict(schema)
+    assert result["type"] == "object"
+    nested = result["properties"]["items"]
+    assert nested["type"] == "array"
+    assert nested["items"]["type"] == "integer"
+
+
+# --------------------------------------------------------------------------
+# get_model_without_provider
+# --------------------------------------------------------------------------
+def test_get_model_without_provider_strips_openai_prefix():
+    out = get_model_without_provider({"model": "openai/gpt-4o"})
+    assert out["model"] == "gpt-4o"
+
+
+def test_get_model_without_provider_rejects_non_string():
+    with pytest.raises(ValueError):
+        get_model_without_provider({"model": 123})
+
+
+def test_get_model_without_provider_rejects_missing_slash():
+    with pytest.raises(ValueError):
+        get_model_without_provider({"model": "gpt-4o"})
+
+
+def test_get_model_without_provider_rejects_unsupported_provider():
+    with pytest.raises(ValueError):
+        get_model_without_provider({"model": "anthropic/claude"})
+
+
+# --------------------------------------------------------------------------
+# filtered_inputs
+# --------------------------------------------------------------------------
+def test_filtered_inputs_identity_when_no_previous_response_id():
+    inputs = cast(list, [{"role": "user"}, {"role": "assistant"}])
+    assert filtered_inputs(inputs, None) is inputs
+
+
+def test_filtered_inputs_keeps_trailing_user_and_tool_outputs():
+    inputs = cast(
+        list,
+        [
+            {"role": "user"},
+            {"role": "assistant"},
+            {"role": "user"},
+            {"type": "function_call_output"},
+        ],
+    )
+    result = filtered_inputs(inputs, previous_response_id="pid")
+    # Stops at the assistant message; keeps the trailing user + tool output.
+    assert result == [{"role": "user"}, {"type": "function_call_output"}]
+
+
+# --------------------------------------------------------------------------
+# _is_caching_enabled
+# --------------------------------------------------------------------------
+def test_is_caching_enabled_true():
+    data = {"extra_body": {"caching": {"type": "enabled"}}}
+    assert _is_caching_enabled(data) is True
+
+
+def test_is_caching_enabled_false_variants():
+    assert _is_caching_enabled({}) is False
+    assert _is_caching_enabled({"extra_body": "nope"}) is False
+    assert _is_caching_enabled({"extra_body": {"caching": "nope"}}) is False
+    assert (
+        _is_caching_enabled({"extra_body": {"caching": {"type": "disabled"}}}) is False
+    )
+
+
+# --------------------------------------------------------------------------
+# _get_responses_inputs
+# --------------------------------------------------------------------------
+def _build_request(**config_kwargs) -> LlmRequest:
+    content = types.Content(role="user", parts=[types.Part(text="hello")])
+    config = types.GenerateContentConfig(**config_kwargs)
+    return LlmRequest(model="openai/gpt-4o", contents=[content], config=config)
+
+
+def test_get_responses_inputs_extracts_instructions_and_input():
+    req = _build_request(system_instruction="be nice")
+    instructions, input_params, tools, text, gen = _get_responses_inputs(req)
+    assert instructions == "be nice"
+    assert input_params is not None and len(input_params) == 1
+    first = cast(dict, input_params[0])
+    assert first["role"] == "user"
+    assert first["content"][0]["text"] == "hello"
+    assert tools is None
+    assert text is None
+
+
+def test_get_responses_inputs_extracts_generation_params():
+    req = _build_request(temperature=0.5, top_p=0.9, max_output_tokens=128)
+    _, _, _, _, gen = _get_responses_inputs(req)
+    assert gen == {"temperature": 0.5, "max_output_tokens": 128, "top_p": 0.9}
+
+
+def test_get_responses_inputs_generation_params_none_when_absent():
+    req = _build_request(system_instruction="x")
+    _, _, _, _, gen = _get_responses_inputs(req)
+    assert gen is None
+
+
+def test_get_responses_inputs_converts_tools():
+    decl = types.FunctionDeclaration(
+        name="get_weather",
+        description="Get weather",
+        parameters=types.Schema(
+            type=types.Type.OBJECT,
+            properties={"city": types.Schema(type=types.Type.STRING)},
+        ),
+    )
+    tool = types.Tool(function_declarations=[decl])
+    req = _build_request()
+    req.config = types.GenerateContentConfig(tools=[tool])
+    _, _, tools, _, _ = _get_responses_inputs(req)
+    assert tools is not None and len(tools) == 1
+    tool0 = cast(dict, tools[0])
+    assert tool0["name"] == "get_weather"
+    assert tool0["type"] == "function"
+    assert tool0["parameters"]["properties"]["city"]["type"] == "string"
+
+
+# --------------------------------------------------------------------------
+# _responses_schema_to_text
+# --------------------------------------------------------------------------
+def test_responses_schema_to_text_passthrough_for_json_object_dict():
+    schema = {"type": "json_object"}
+    assert _responses_schema_to_text(schema) == schema
+
+
+def test_responses_schema_to_text_from_pydantic_model():
+    from pydantic import BaseModel
+
+    class Out(BaseModel):
+        answer: str
+
+    text = cast(dict, _responses_schema_to_text(Out))
+    fmt = text["format"]
+    assert fmt["type"] == "json_schema"
+    assert fmt["name"] == "Out"
+    assert fmt["strict"] is True
+    assert "answer" in fmt["schema"]["properties"]
+
+
+# --------------------------------------------------------------------------
+# request_reorganization_by_ark
+# --------------------------------------------------------------------------
+def _base_request_data(**overrides):
+    data = {
+        "model": "openai/gpt-4o",
+        "instructions": None,
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hi"}],
+            }
+        ],
+        "previous_response_id": None,
+    }
+    data.update(overrides)
+    return data
+
+
+def test_request_reorganization_strips_provider_and_sets_expire_at():
+    out = request_reorganization_by_ark(_base_request_data())
+    assert out["model"] == "gpt-4o"
+    assert "expire_at" in out["extra_body"]
+    assert out["extra_body"]["expire_at"] > 0
+
+
+def test_request_reorganization_moves_instructions_into_system_message():
+    out = request_reorganization_by_ark(
+        _base_request_data(instructions="system prompt")
+    )
+    assert "instructions" not in out
+    assert out["input"][0]["role"] == "system"
+    assert out["input"][0]["content"][0]["text"] == "system prompt"
+
+
+def test_request_reorganization_keeps_instructions_out_when_previous_response_id():
+    out = request_reorganization_by_ark(
+        _base_request_data(instructions="sys", previous_response_id="resp_1")
+    )
+    # With a previous_response_id, instructions are dropped, not re-injected.
+    assert out["input"][0]["role"] == "user"
+
+
+def test_request_reorganization_filters_unsupported_fields():
+    out = request_reorganization_by_ark(
+        _base_request_data(not_a_real_field="x", temperature=0.3)
+    )
+    assert "not_a_real_field" not in out
+    assert out["temperature"] == 0.3
+
+
+def test_request_reorganization_drops_cache_fields_when_disabled():
+    data = _base_request_data(
+        previous_response_id="resp_1",
+        store=True,
+        extra_body={"caching": {"type": "enabled"}},
+    )
+    out = request_reorganization_by_ark(data, enable_responses_cache=False)
+    assert "previous_response_id" not in out
+    assert "store" not in out
+    assert "caching" not in out.get("extra_body", {})
+
+
+def test_request_reorganization_removes_tools_on_subsequent_round():
+    data = _base_request_data(
+        previous_response_id="resp_1",
+        tools=[{"name": "f", "type": "function", "parameters": {}}],
+    )
+    out = request_reorganization_by_ark(data)
+    assert "tools" not in out
+
+
+def test_request_reorganization_disables_caching_when_text_present():
+    data = _base_request_data(
+        extra_body={"caching": {"type": "enabled"}},
+        text={"format": {"type": "json_schema"}},
+    )
+    out = request_reorganization_by_ark(data)
+    assert "caching" not in out.get("extra_body", {})
+
+
+def test_request_reorganization_forces_store_true_when_caching_enabled():
+    data = _base_request_data(
+        store=False,
+        extra_body={"caching": {"type": "enabled"}},
+    )
+    out = request_reorganization_by_ark(data)
+    assert out["store"] is True
+
+
+# --------------------------------------------------------------------------
+# response -> LlmResponse transforms
+# --------------------------------------------------------------------------
+class _FakeUsageDetails:
+    cached_tokens = 3
+
+
+class _FakeUsage:
+    input_tokens = 10
+    output_tokens = 5
+    total_tokens = 15
+    input_tokens_details = _FakeUsageDetails()
+
+
+class _FakeArkResponse:
+    """Duck-typed stand-in matching the attrs ark_llm reads off a response.
+
+    ``ark_response_to_generate_content_response`` only does an ``isinstance``
+    check inside ``record_logs`` (which is wrapped in try/except), so a plain
+    object is sufficient for the transform itself.
+    """
+
+    def __init__(self, output, status="completed", usage=None, model="gpt-4o"):
+        self.output = output
+        self.status = status
+        self.incomplete_details = None
+        self.usage = usage
+        self.model = model
+        self.id = "resp_abc"
+        self.error = None
+
+
+def _first_part(resp: LlmResponse) -> types.Part:
+    assert resp.content is not None
+    assert resp.content.parts is not None
+    return resp.content.parts[0]
+
+
+def test_ark_response_to_llm_response_parses_text_and_usage():
+    msg = ResponseOutputMessage(
+        id="m1",
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[
+            ResponseOutputText(type="output_text", text="hello world", annotations=[])
+        ],
+    )
+    raw = _FakeArkResponse(output=[msg], usage=_FakeUsage())
+    resp = ark_response_to_generate_content_response(cast(Any, raw))
+    assert isinstance(resp, LlmResponse)
+    assert _first_part(resp).text == "hello world"
+    assert resp.finish_reason == types.FinishReason.STOP
+    assert resp.usage_metadata is not None
+    assert resp.usage_metadata.prompt_token_count == 10
+    assert resp.usage_metadata.candidates_token_count == 5
+    assert resp.usage_metadata.cached_content_token_count == 3
+    assert resp.interaction_id == "resp_abc"
+
+
+def test_ark_response_to_llm_response_parses_function_call():
+    fc = ResponseFunctionToolCall(
+        type="function_call",
+        name="get_weather",
+        arguments='{"city": "SF"}',
+        call_id="call_1",
+    )
+    raw = _FakeArkResponse(output=[fc])
+    resp = ark_response_to_generate_content_response(cast(Any, raw))
+    part = _first_part(resp)
+    assert part.function_call is not None
+    assert part.function_call.name == "get_weather"
+    assert part.function_call.args == {"city": "SF"}
+    assert part.function_call.id == "call_1"
+
+
+def test_ark_response_to_llm_response_parses_reasoning_as_thought():
+    reasoning = ResponseReasoningItem(
+        id="r1",
+        type="reasoning",
+        summary=[Summary(type="summary_text", text="thinking...")],
+    )
+    raw = _FakeArkResponse(output=[reasoning])
+    resp = ark_response_to_generate_content_response(cast(Any, raw))
+    part = _first_part(resp)
+    assert part.thought is True
+    assert part.text == "thinking..."
+
+
+def test_ark_response_to_llm_response_raises_on_empty_output():
+    raw = _FakeArkResponse(output=[])
+    with pytest.raises(ValueError, match="No message in response"):
+        ark_response_to_generate_content_response(cast(Any, raw))
+
+
+def test_event_to_generate_content_response_partial_text_delta():
+    event = ResponseTextDeltaEvent(
+        content_index=0,
+        delta="chunk",
+        item_id="i1",
+        output_index=0,
+        type="response.output_text.delta",
+    )
+    resp = event_to_generate_content_response(
+        event, is_partial=True, model_version="gpt-4o"
+    )
+    assert resp is not None
+    assert resp.partial is True
+    assert _first_part(resp).text == "chunk"
+
+
+def test_event_to_generate_content_response_partial_unknown_returns_none():
+    # An unrelated event in the partial branch yields no LlmResponse.
+    event = ResponseTextDeltaEvent(
+        content_index=0,
+        delta="x",
+        item_id="i1",
+        output_index=0,
+        type="response.output_text.delta",
+    )
+    # Force the isinstance checks to miss by passing a bare object.
+    assert (
+        event_to_generate_content_response(cast(Any, object()), is_partial=True) is None
+    )
+    # sanity: the real delta event still works
+    assert event_to_generate_content_response(event, is_partial=True) is not None
+
+
+# --------------------------------------------------------------------------
+# ArkLlm / ArkLlmClient
+# --------------------------------------------------------------------------
+def test_arkllm_supported_models():
+    assert ArkLlm.supported_models() == [r"openai/.*"]
+
+
+def test_arkllm_init_stores_additional_args_and_strips_reserved_keys():
+    llm = ArkLlm(model="openai/gpt-4o", drop_params=True, foo="bar")
+    assert llm.model == "openai/gpt-4o"
+    assert llm._additional_args["foo"] == "bar"
+    assert llm._additional_args["drop_params"] is True
+    # reserved keys must not leak into _additional_args
+    for reserved in (
+        "llm_client",
+        "messages",
+        "tools",
+        "stream",
+        "enable_responses_cache",
+    ):
+        assert reserved not in llm._additional_args
+
+
+def test_arkllm_init_respects_enable_responses_cache_flag():
+    llm = ArkLlm(model="openai/gpt-4o", enable_responses_cache=False)
+    assert llm.enable_responses_cache is False
+
+
+def test_arkllm_init_raises_when_adk_lacks_field():
+    with patch.object(ark_llm, "llm_request_has_field", return_value=False):
+        with pytest.raises(ImportError, match="google-adk"):
+            ArkLlm(model="openai/gpt-4o")
+
+
+@pytest.mark.asyncio
+async def test_arkllmclient_aresponses_uses_default_api_base_and_settings_key():
+    client = ArkLlmClient()
+    fake_async_ark = AsyncMock()
+    fake_async_ark.responses.create = AsyncMock(return_value="RAW")
+
+    with patch.object(ark_llm, "AsyncArk", return_value=fake_async_ark) as ark_ctor:
+        with patch.object(ark_llm.settings.model, "api_key", "settings_key"):
+            result = await client.aresponses(model="gpt-4o", input=[])
+
+    assert result == "RAW"
+    ark_ctor.assert_called_once_with(
+        base_url=DEFAULT_VIDEO_MODEL_API_BASE,
+        api_key="settings_key",
+    )
+    # api_base/api_key must be popped before reaching responses.create
+    _, create_kwargs = fake_async_ark.responses.create.call_args
+    assert "api_base" not in create_kwargs
+    assert "api_key" not in create_kwargs
+    assert create_kwargs["model"] == "gpt-4o"
+
+
+@pytest.mark.asyncio
+async def test_arkllmclient_aresponses_honours_explicit_api_key_and_base():
+    client = ArkLlmClient()
+    fake_async_ark = AsyncMock()
+    fake_async_ark.responses.create = AsyncMock(return_value="RAW")
+
+    with patch.object(ark_llm, "AsyncArk", return_value=fake_async_ark) as ark_ctor:
+        await client.aresponses(
+            model="gpt-4o", input=[], api_key="explicit", api_base="https://custom/"
+        )
+
+    ark_ctor.assert_called_once_with(
+        base_url="https://custom/",
+        api_key="explicit",
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_content_via_responses_non_stream_yields_one_response():
+    llm = ArkLlm(model="openai/gpt-4o")
+    msg = ResponseOutputMessage(
+        id="m1",
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[ResponseOutputText(type="output_text", text="hi", annotations=[])],
+    )
+    raw = _FakeArkResponse(output=[msg])
+
+    llm.llm_client.aresponses = AsyncMock(return_value=raw)
+
+    args = {
+        "model": "openai/gpt-4o",
+        "instructions": None,
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hi"}],
+            }
+        ],
+        "previous_response_id": None,
+    }
+    responses = [
+        r async for r in llm.generate_content_via_responses(args, stream=False)
+    ]
+    assert len(responses) == 1
+    assert _first_part(responses[0]).text == "hi"
+    # request was reorganized: provider stripped before hitting the client
+    _, kwargs = llm.llm_client.aresponses.call_args
+    assert kwargs["model"] == "gpt-4o"
+
+
+@pytest.mark.asyncio
+async def test_generate_content_via_responses_stream_yields_partials():
+    llm = ArkLlm(model="openai/gpt-4o")
+
+    async def _fake_stream(**kwargs):
+        for delta in ("a", "b"):
+            yield ResponseTextDeltaEvent(
+                content_index=0,
+                delta=delta,
+                item_id="i1",
+                output_index=0,
+                type="response.output_text.delta",
+            )
+
+    # aresponses is awaited, and the awaited result is async-iterated.
+    llm.llm_client.aresponses = AsyncMock(return_value=_fake_stream())
+
+    args = {
+        "model": "openai/gpt-4o",
+        "instructions": None,
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hi"}],
+            }
+        ],
+        "previous_response_id": None,
+    }
+    responses = [r async for r in llm.generate_content_via_responses(args, stream=True)]
+    assert [_first_part(r).text for r in responses] == ["a", "b"]
+    assert all(r.partial for r in responses)
+    _, kwargs = llm.llm_client.aresponses.call_args
+    assert kwargs["stream"] is True
+
+
+# --------------------------------------------------------------------------
+# _content_to_input_item branches
+# --------------------------------------------------------------------------
+def test_content_to_input_item_function_response():
+    part = types.Part(
+        function_response=types.FunctionResponse(
+            id="call_1", name="f", response={"result": 1}
+        )
+    )
+    content = types.Content(role="user", parts=[part])
+    item = cast(dict, _content_to_input_item(content))
+    assert item["type"] == "function_call_output"
+    assert item["call_id"] == "call_1"
+    assert item["output"] == '{"result": 1}'
+
+
+def test_content_to_input_item_function_call_from_model():
+    part = types.Part.from_function_call(name="f", args={"a": 1})
+    assert part.function_call is not None
+    part.function_call.id = "call_1"
+    content = types.Content(role="model", parts=[part])
+    items = cast(list, _content_to_input_item(content))
+    assert items[0]["type"] == "function_call"
+    assert items[0]["name"] == "f"
+    assert items[0]["call_id"] == "call_1"
+
+
+def test_content_to_input_item_inline_image_becomes_input_image():
+    part = types.Part(inline_data=types.Blob(mime_type="image/png", data=b"abc"))
+    content = types.Content(role="user", parts=[part])
+    item = cast(dict, _content_to_input_item(content))
+    image = item["content"][0]
+    assert image["type"] == "input_image"
+    assert image["image_url"].startswith("data:image/png;base64,")
+
+
+def test_content_to_input_item_file_uri_becomes_input_file():
+    part = types.Part(
+        file_data=types.FileData(
+            file_uri="https://example.com/doc.pdf", mime_type="application/pdf"
+        )
+    )
+    content = types.Content(role="user", parts=[part])
+    item = cast(dict, _content_to_input_item(content))
+    file_param = item["content"][0]
+    assert file_param["type"] == "input_file"
+    assert file_param["file_url"] == "https://example.com/doc.pdf"
+
+
+# --------------------------------------------------------------------------
+# generate_content_async error handling
+# --------------------------------------------------------------------------
+def _bad_request_error(code: str) -> ArkBadRequestError:
+    request = httpx.Request("POST", "https://ark/")
+    response = httpx.Response(400, request=request)
+    return ArkBadRequestError(
+        "bad", response=response, body={"code": code}, request_id="r"
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_content_async_retries_on_previous_response_not_found():
+    llm = ArkLlm(model="openai/gpt-4o")
+
+    msg = ResponseOutputMessage(
+        id="m1",
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[ResponseOutputText(type="output_text", text="ok", annotations=[])],
+    )
+    recovered = _FakeArkResponse(output=[msg])
+
+    call_count = {"n": 0}
+
+    async def _maybe_fail(self, responses_args, stream=False):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # First attempt carries previous_response_id and fails as expired.
+            assert "previous_response_id" in responses_args
+            raise _bad_request_error("InvalidParameter.PreviousResponseNotFound")
+        # Retry must have dropped previous_response_id.
+        assert "previous_response_id" not in responses_args
+        yield ark_response_to_generate_content_response(cast(Any, recovered))
+
+    req = _build_request(system_instruction="hi")
+    with patch.object(ark_llm, "get_previous_interaction_id", return_value="resp_old"):
+        with patch.object(ArkLlm, "generate_content_via_responses", _maybe_fail):
+            responses = [r async for r in llm.generate_content_async(req)]
+
+    assert call_count["n"] == 2
+    assert _first_part(responses[0]).text == "ok"
+
+
+@pytest.mark.asyncio
+async def test_generate_content_async_reraises_other_bad_request():
+    llm = ArkLlm(model="openai/gpt-4o")
+
+    async def _always_fail(self, responses_args, stream=False):
+        raise _bad_request_error("InvalidParameter.SomethingElse")
+        yield  # pragma: no cover - makes this an async generator
+
+    req = _build_request(system_instruction="hi")
+    with patch.object(ark_llm, "get_previous_interaction_id", return_value=None):
+        with patch.object(ArkLlm, "generate_content_via_responses", _always_fail):
+            with pytest.raises(ArkBadRequestError):
+                async for _ in llm.generate_content_async(req):
+                    pass

--- a/tests/prompts/test_prompt_manager.py
+++ b/tests/prompts/test_prompt_manager.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``veadk.prompts.prompt_manager``.
+
+``CozeloopPromptManager`` imports the optional ``cozeloop`` SDK inside its
+constructor; we stub it in ``sys.modules`` and mock the client so no network
+access occurs.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from veadk.prompts.prompt_manager import BasePromptManager, CozeloopPromptManager
+from veadk.prompts.agent_default_prompt import DEFAULT_INSTRUCTION
+
+
+@pytest.fixture
+def fake_cozeloop(monkeypatch):
+    """Install a stub ``cozeloop`` module and return its ``new_client`` mock."""
+    module = MagicMock()
+    client = MagicMock()
+    module.new_client.return_value = client
+    monkeypatch.setitem(sys.modules, "cozeloop", module)
+    return module, client
+
+
+def _make_context(agent_name: str = "agent-x") -> MagicMock:
+    ctx = MagicMock()
+    ctx.agent_name = agent_name
+    return ctx
+
+
+def test_base_prompt_manager_is_abstract():
+    with pytest.raises(TypeError):
+        BasePromptManager()  # type: ignore[abstract]
+
+
+def test_init_creates_client_with_credentials(fake_cozeloop):
+    module, client = fake_cozeloop
+    manager = CozeloopPromptManager(
+        cozeloop_workspace_id="ws",
+        cozeloop_token="tok",
+        prompt_key="key",
+        version="v1",
+        label="prod",
+    )
+
+    module.new_client.assert_called_once_with(workspace_id="ws", api_token="tok")
+    assert manager.client is client
+    assert manager.prompt_key == "key"
+    assert manager.version == "v1"
+    assert manager.label == "prod"
+
+
+def test_get_prompt_returns_remote_content(fake_cozeloop):
+    _, client = fake_cozeloop
+
+    message = MagicMock()
+    message.content = "REMOTE_PROMPT"
+    prompt = MagicMock()
+    prompt.prompt_template.messages = [message]
+    client.get_prompt.return_value = prompt
+
+    manager = CozeloopPromptManager(
+        cozeloop_workspace_id="ws",
+        cozeloop_token="tok",
+        prompt_key="key",
+    )
+
+    result = manager.get_prompt(_make_context())
+
+    assert result == "REMOTE_PROMPT"
+    client.get_prompt.assert_called_once_with(prompt_key="key", version="", label="")
+
+
+def test_get_prompt_falls_back_to_default_when_missing(fake_cozeloop):
+    _, client = fake_cozeloop
+    client.get_prompt.return_value = None
+
+    manager = CozeloopPromptManager(
+        cozeloop_workspace_id="ws",
+        cozeloop_token="tok",
+        prompt_key="key",
+    )
+
+    result = manager.get_prompt(_make_context())
+    assert result == DEFAULT_INSTRUCTION
+
+
+def test_get_prompt_falls_back_when_no_messages(fake_cozeloop):
+    _, client = fake_cozeloop
+
+    prompt = MagicMock()
+    prompt.prompt_template.messages = []
+    client.get_prompt.return_value = prompt
+
+    manager = CozeloopPromptManager(
+        cozeloop_workspace_id="ws",
+        cozeloop_token="tok",
+        prompt_key="key",
+    )
+
+    result = manager.get_prompt(_make_context())
+    assert result == DEFAULT_INSTRUCTION

--- a/tests/prompts/test_prompt_optimization.py
+++ b/tests/prompts/test_prompt_optimization.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``veadk.prompts.prompt_optimization``.
+
+These verify the Jinja2 rendering helpers. The agent and its tools are mocked;
+no model calls are made (the rendering functions themselves perform none).
+"""
+
+from unittest.mock import MagicMock, patch
+
+from veadk.prompts import prompt_optimization as po
+
+
+def _make_agent(*, tools=None):
+    agent = MagicMock()
+    agent.name = "MyAgent"
+    agent.model_name = "doubao"
+    agent.description = "an agent"
+    agent.instruction = "ORIGINAL_INSTRUCTION"
+    agent.tools = tools if tools is not None else []
+    return agent
+
+
+def test_render_prompt_feedback_includes_instruction_and_feedback():
+    agent = _make_agent()
+    rendered = po.render_prompt_feedback_with_jinja2(agent, feedback="too verbose")
+
+    assert "ORIGINAL_INSTRUCTION" in rendered
+    assert "too verbose" in rendered
+
+
+def test_render_prompt_with_no_tools_embeds_agent_info():
+    agent = _make_agent(tools=[])
+    rendered = po.render_prompt_with_jinja2(agent)
+
+    assert "ORIGINAL_INSTRUCTION" in rendered
+    assert "MyAgent" in rendered
+    assert "doubao" in rendered
+    assert "an agent" in rendered
+    # With no tools the tools loop produces no <tool> blocks.
+    assert "<tool>" not in rendered
+
+
+def test_render_prompt_with_function_tool_renders_tool_block():
+    """A plain callable is treated as a function tool and wrapped in a
+    ``FunctionTool`` whose declaration is rendered into the prompt."""
+
+    def my_function(x: int) -> int:
+        """double it"""
+        return x * 2
+
+    agent = _make_agent(tools=[my_function])
+
+    declaration = MagicMock()
+    declaration.model_dump.return_value = {"parameters": {"type": "object"}}
+
+    fake_tool = MagicMock()
+    fake_tool.name = "my_function"
+    fake_tool.description = "double it"
+    fake_tool._get_declaration.return_value = declaration
+
+    with patch.object(po, "FunctionTool", return_value=fake_tool) as mock_ft:
+        rendered = po.render_prompt_with_jinja2(agent)
+
+    mock_ft.assert_called_once_with(my_function)
+    assert "<tool>" in rendered
+    assert "my_function" in rendered
+    assert "function" in rendered
+
+
+def test_render_prompt_skips_tool_without_declaration():
+    def my_function():
+        return None
+
+    agent = _make_agent(tools=[my_function])
+
+    fake_tool = MagicMock()
+    fake_tool._get_declaration.return_value = None
+
+    with patch.object(po, "FunctionTool", return_value=fake_tool):
+        rendered = po.render_prompt_with_jinja2(agent)
+
+    # Declaration is None -> tool is skipped, no tool block emitted.
+    assert "<tool>" not in rendered

--- a/tests/reflector/test_local_reflector.py
+++ b/tests/reflector/test_local_reflector.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``veadk.reflector.local_reflector`` (and ``base_reflector``).
+
+The reflector builds an ``Agent`` + ``Runner`` and calls the model; both are
+mocked so no model / network access happens.
+"""
+
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from veadk.reflector import local_reflector as lr
+from veadk.reflector.base_reflector import BaseReflector, ReflectorResult
+from veadk.reflector.local_reflector import LocalReflector
+
+
+def _make_agent(instruction: str = "SYSTEM_PROMPT") -> MagicMock:
+    agent = MagicMock()
+    agent.instruction = instruction
+    return agent
+
+
+# --- base_reflector ---------------------------------------------------------
+
+
+def test_reflector_result_model_fields():
+    result = ReflectorResult(optimized_prompt="opt", reason="because")
+    assert result.optimized_prompt == "opt"
+    assert result.reason == "because"
+
+
+def test_base_reflector_is_abstract():
+    with pytest.raises(TypeError):
+        BaseReflector(_make_agent())  # type: ignore[abstract]
+
+
+def test_local_reflector_stores_agent():
+    agent = _make_agent()
+    reflector = LocalReflector(agent)
+    assert reflector.agent is agent
+    assert isinstance(reflector, BaseReflector)
+
+
+# --- _read_traces_from_dir --------------------------------------------------
+
+
+def test_read_traces_from_dir_reads_only_json(tmp_path):
+    (tmp_path / "a.json").write_text(json.dumps({"step": 1}))
+    (tmp_path / "b.json").write_text(json.dumps({"step": 2}))
+    (tmp_path / "ignore.txt").write_text("not json")
+
+    reflector = LocalReflector(_make_agent())
+    traces = reflector._read_traces_from_dir(str(tmp_path))
+
+    assert len(traces) == 2
+    assert {"step": 1} in traces
+    assert {"step": 2} in traces
+
+
+# --- reflect ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reflect_parses_valid_json_response(tmp_path):
+    trace_file = tmp_path / "trace.json"
+    trace_file.write_text(json.dumps([{"event": "x"}]))
+
+    runner = MagicMock()
+    runner.run = AsyncMock(
+        return_value=json.dumps(
+            {"optimized_prompt": "better prompt", "reason": "clearer"}
+        )
+    )
+
+    with (
+        patch.object(lr, "Agent") as mock_agent_cls,
+        patch.object(lr, "Runner", return_value=runner) as mock_runner_cls,
+    ):
+        reflector = LocalReflector(_make_agent("OLD_PROMPT"))
+        result = await reflector.reflect(str(trace_file))
+
+    assert isinstance(result, ReflectorResult)
+    assert result.optimized_prompt == "better prompt"
+    assert result.reason == "clearer"
+
+    # An Agent + Runner are constructed and run is awaited with the prompt.
+    mock_agent_cls.assert_called_once()
+    mock_runner_cls.assert_called_once()
+    runner.run.assert_awaited_once()
+    sent = runner.run.await_args.kwargs["messages"]
+    assert "OLD_PROMPT" in sent
+
+
+@pytest.mark.asyncio
+async def test_reflect_handles_invalid_json_response(tmp_path):
+    trace_file = tmp_path / "trace.json"
+    trace_file.write_text(json.dumps([]))
+
+    runner = MagicMock()
+    runner.run = AsyncMock(return_value="this is not json")
+
+    with (
+        patch.object(lr, "Agent"),
+        patch.object(lr, "Runner", return_value=runner),
+    ):
+        reflector = LocalReflector(_make_agent())
+        result = await reflector.reflect(str(trace_file))
+
+    assert result.optimized_prompt == ""
+    assert "not valid json" in result.reason
+
+
+@pytest.mark.asyncio
+async def test_reflect_handles_empty_response(tmp_path):
+    trace_file = tmp_path / "trace.json"
+    trace_file.write_text(json.dumps([]))
+
+    runner = MagicMock()
+    runner.run = AsyncMock(return_value="")
+
+    with (
+        patch.object(lr, "Agent"),
+        patch.object(lr, "Runner", return_value=runner),
+    ):
+        reflector = LocalReflector(_make_agent())
+        result = await reflector.reflect(str(trace_file))
+
+    assert result.optimized_prompt == ""
+    assert result.reason == "response from optimizer is empty"
+
+
+@pytest.mark.asyncio
+async def test_reflect_asserts_on_non_json_file(tmp_path):
+    txt_file = tmp_path / "trace.txt"
+    txt_file.write_text("[]")
+
+    reflector = LocalReflector(_make_agent())
+    with pytest.raises(AssertionError, match="not a valid json file"):
+        await reflector.reflect(str(txt_file))
+
+
+@pytest.mark.asyncio
+async def test_reflect_asserts_on_missing_file(tmp_path):
+    missing = os.path.join(str(tmp_path), "does_not_exist.json")
+
+    reflector = LocalReflector(_make_agent())
+    with pytest.raises(AssertionError, match="is not a file"):
+        await reflector.reflect(missing)

--- a/tests/runner/test_runner_behavior.py
+++ b/tests/runner/test_runner_behavior.py
@@ -1,0 +1,483 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavior tests for ``veadk.runner.Runner`` and its module helpers.
+
+These cover the ``run()`` orchestration flow (message conversion, session
+auto-creation, event collection, llm-call-limit handling, tracing dump,
+trace-id logging and the temporary upload toggle), the standalone
+``_convert_messages`` media/error branches, ``_upload_image_to_tos``,
+``pre_run_process``, ``get_trace_id`` / ``_print_trace_id`` and
+``save_session_to_long_term_memory``.
+
+All model, network and storage dependencies are mocked; ``run_async`` is
+replaced with an in-memory async generator so no real LLM/agent loop executes.
+"""
+
+import os
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from google.adk.agents.invocation_context import LlmCallsLimitExceededError
+from google.adk.events.event import Event
+from google.genai import types
+
+from veadk.agent import Agent
+from veadk.memory.short_term_memory import ShortTermMemory
+from veadk.runner import (
+    Runner,
+    _convert_messages,
+    _upload_image_to_tos,
+    pre_run_process,
+)
+from veadk.types import MediaMessage
+
+_ENV = {"MODEL_AGENT_API_KEY": "mock_api_key"}
+
+
+def _make_runner(**kwargs) -> Runner:
+    """Build a Runner backed by a real in-memory ShortTermMemory and Agent."""
+    agent = Agent()
+    stm = ShortTermMemory()
+    return Runner(agent=agent, short_term_memory=stm, **kwargs)
+
+
+def _text_event(text: str, *, thought: bool = False) -> Event:
+    return Event(
+        author="model",
+        content=types.Content(
+            role="model", parts=[types.Part(text=text, thought=thought)]
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _convert_messages branches
+# ---------------------------------------------------------------------------
+
+
+def test_convert_messages_media_message():
+    msg = MediaMessage(text="describe", media="/tmp/pic.png")
+    kind = Mock()
+    kind.mime = "image/png"
+    with (
+        patch("veadk.runner.read_file_to_bytes", return_value=b"rawbytes"),
+        patch("filetype.guess", return_value=kind),
+    ):
+        result = _convert_messages(msg, app_name="app", user_id="u", session_id="s")
+    assert len(result) == 1
+    parts = result[0].parts
+    assert parts[0].text == "describe"
+    assert parts[1].inline_data.mime_type == "image/png"
+    assert parts[1].inline_data.data == b"rawbytes"
+
+
+def test_convert_messages_unknown_filetype_raises():
+    msg = MediaMessage(text="t", media="/tmp/x.bin")
+    with (
+        patch("veadk.runner.read_file_to_bytes", return_value=b"x"),
+        patch("filetype.guess", return_value=None),
+        pytest.raises(ValueError, match="Unsupported or unknown file type"),
+    ):
+        _convert_messages(msg, app_name="a", user_id="u", session_id="s")
+
+
+def test_convert_messages_unsupported_mime_asserts():
+    msg = MediaMessage(text="t", media="/tmp/x.pdf")
+    kind = Mock()
+    kind.mime = "application/pdf"
+    with (
+        patch("veadk.runner.read_file_to_bytes", return_value=b"x"),
+        patch("filetype.guess", return_value=kind),
+        pytest.raises(AssertionError, match="Unsupported media type"),
+    ):
+        _convert_messages(msg, app_name="a", user_id="u", session_id="s")
+
+
+def test_convert_messages_mixed_list():
+    media = MediaMessage(text="img", media="/tmp/v.mp4")
+    kind = Mock()
+    kind.mime = "video/mp4"
+    with (
+        patch("veadk.runner.read_file_to_bytes", return_value=b"vid"),
+        patch("filetype.guess", return_value=kind),
+    ):
+        result = _convert_messages(
+            ["hi", media], app_name="a", user_id="u", session_id="s"
+        )
+    assert len(result) == 2
+    assert result[0].parts[0].text == "hi"
+    assert result[1].parts[1].inline_data.mime_type == "video/mp4"
+
+
+def test_convert_messages_unknown_type_raises():
+    with pytest.raises(ValueError, match="Unknown message type"):
+        _convert_messages(12345, app_name="a", user_id="u", session_id="s")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _upload_image_to_tos
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upload_image_to_tos_success_rewrites_display_name():
+    part = types.Part(
+        inline_data=types.Blob(
+            display_name="orig.png", data=b"bytes", mime_type="image/png"
+        )
+    )
+    fake_tos = Mock()
+    fake_tos.build_tos_signed_url.return_value = "https://signed/url"
+    fake_tos.async_upload_bytes = AsyncMock()
+    with patch("veadk.integrations.ve_tos.ve_tos.VeTOS", return_value=fake_tos):
+        await _upload_image_to_tos(part, "app", "user", "sess")
+    assert part.inline_data is not None
+    assert part.inline_data.display_name == "https://signed/url"
+    fake_tos.async_upload_bytes.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_upload_image_to_tos_swallows_exceptions():
+    part = types.Part(
+        inline_data=types.Blob(
+            display_name="orig.png", data=b"bytes", mime_type="image/png"
+        )
+    )
+    with patch(
+        "veadk.integrations.ve_tos.ve_tos.VeTOS", side_effect=RuntimeError("boom")
+    ):
+        # Should not raise; exception is logged and swallowed.
+        await _upload_image_to_tos(part, "app", "user", "sess")
+
+
+# ---------------------------------------------------------------------------
+# pre_run_process
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pre_run_process_invokes_process_func_when_enabled():
+    self_mock = Mock()
+    self_mock.upload_inline_data_to_tos = True
+    self_mock.app_name = "app"
+    process_func = AsyncMock()
+
+    part = types.Part(
+        inline_data=types.Blob(display_name="f.png", data=b"d", mime_type="image/png")
+    )
+    new_message = types.Content(role="user", parts=[part])
+
+    await pre_run_process(self_mock, process_func, new_message, "u", "s")
+    process_func.assert_awaited_once_with(part, "app", "u", "s")
+
+
+@pytest.mark.asyncio
+async def test_pre_run_process_skips_when_upload_disabled():
+    self_mock = Mock()
+    self_mock.upload_inline_data_to_tos = False
+    process_func = AsyncMock()
+    part = types.Part(
+        inline_data=types.Blob(display_name="f.png", data=b"d", mime_type="image/png")
+    )
+    new_message = types.Content(role="user", parts=[part])
+    await pre_run_process(self_mock, process_func, new_message, "u", "s")
+    process_func.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Runner.__init__ branches
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, _ENV)
+def test_runner_creates_default_short_term_memory():
+    agent = Agent()
+    runner = Runner(agent=agent)
+    assert runner.short_term_memory is not None
+    assert runner.session_service is runner.short_term_memory.session_service
+    assert runner.app_name == "veadk_default_app"
+
+
+@patch.dict(os.environ, _ENV)
+def test_runner_run_processor_arg_takes_priority():
+    from veadk.processors import NoOpRunProcessor
+
+    custom = NoOpRunProcessor()
+    runner = _make_runner(run_processor=custom)
+    assert runner.run_processor is custom
+
+
+@patch.dict(os.environ, _ENV)
+def test_runner_inherits_run_processor_from_agent():
+    from veadk.processors import NoOpRunProcessor
+
+    agent = Agent()
+    agent_processor = NoOpRunProcessor()
+    agent.run_processor = agent_processor
+    runner = Runner(agent=agent, short_term_memory=ShortTermMemory())
+    assert runner.run_processor is agent_processor
+
+
+# ---------------------------------------------------------------------------
+# Runner.run flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch.dict(os.environ, _ENV)
+async def test_run_returns_last_text_and_auto_creates_session():
+    runner = _make_runner()
+
+    async def fake_run_async(**kwargs):
+        yield _text_event("thinking...", thought=True)
+        yield _text_event("final answer")
+
+    runner.run_async = fake_run_async  # type: ignore[assignment]
+
+    out = await runner.run("hello", session_id="sess-1")
+    assert out == "final answer"
+
+    # The run() flow auto-creates the session in the session service.
+    session = await runner.session_service.get_session(
+        app_name=runner.app_name,
+        user_id=runner.user_id,
+        session_id="sess-1",
+    )
+    assert session is not None
+
+
+@pytest.mark.asyncio
+@patch.dict(os.environ, _ENV)
+async def test_run_handles_llm_calls_limit_exceeded():
+    runner = _make_runner()
+
+    async def fake_run_async(**kwargs):
+        raise LlmCallsLimitExceededError("limit")
+        yield  # pragma: no cover - generator marker
+
+    runner.run_async = fake_run_async  # type: ignore[assignment]
+    out = await runner.run("hello", session_id="sess-limit")
+    assert out == ""
+
+
+@pytest.mark.asyncio
+@patch.dict(os.environ, _ENV)
+async def test_run_saves_tracing_when_requested():
+    runner = _make_runner()
+
+    async def fake_run_async(**kwargs):
+        yield _text_event("done")
+
+    runner.run_async = fake_run_async  # type: ignore[assignment]
+    with patch.object(runner, "save_tracing_file") as mock_save:
+        await runner.run("hi", session_id="sess-trace", save_tracing_data=True)
+    mock_save.assert_called_once_with("sess-trace")
+
+
+@pytest.mark.asyncio
+@patch.dict(os.environ, _ENV)
+async def test_run_temporarily_toggles_upload_flag():
+    runner = _make_runner()
+    assert runner.upload_inline_data_to_tos is False
+
+    captured = {}
+
+    async def fake_run_async(**kwargs):
+        captured["during"] = runner.upload_inline_data_to_tos
+        yield _text_event("ok")
+
+    runner.run_async = fake_run_async  # type: ignore[assignment]
+    await runner.run("hi", session_id="sess-upload", upload_inline_data_to_tos=True)
+    assert captured["during"] is True
+    # Flag restored after the run.
+    assert runner.upload_inline_data_to_tos is False
+
+
+@pytest.mark.asyncio
+@patch.dict(os.environ, _ENV)
+async def test_run_uses_run_processor_override():
+    runner = _make_runner()
+
+    async def fake_run_async(**kwargs):
+        yield _text_event("answer")
+
+    runner.run_async = fake_run_async  # type: ignore[assignment]
+
+    calls = {"count": 0}
+
+    class _Processor:
+        def process_run(self, runner, message, **kwargs):
+            calls["count"] += 1
+
+            def decorator(func):
+                return func
+
+            return decorator
+
+    out = await runner.run(
+        "hi",
+        session_id="sess-proc",
+        run_processor=_Processor(),  # type: ignore[arg-type]
+    )
+    assert out == "answer"
+    assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
+@patch.dict(os.environ, _ENV)
+async def test_run_initializes_session_path_when_agent_has_skills():
+    runner = _make_runner()
+    # Force the skills branch without loading real skills.
+    object.__setattr__(runner.agent, "skills", ["alpha"])
+
+    async def fake_run_async(**kwargs):
+        yield _text_event("ok")
+
+    runner.run_async = fake_run_async  # type: ignore[assignment]
+    with patch(
+        "veadk.tools.skills_tools.session_path.initialize_session_path"
+    ) as mock_init:
+        await runner.run("hi", session_id="sess-skills")
+    mock_init.assert_called_once_with("sess-skills")
+
+
+# ---------------------------------------------------------------------------
+# get_trace_id / _print_trace_id
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, _ENV)
+def test_get_trace_id_non_veadk_agent_returns_unknown():
+    from google.adk.agents import LlmAgent
+
+    runner = Runner(agent=LlmAgent(name="plain"), short_term_memory=ShortTermMemory())
+    assert runner.get_trace_id() == "<unknown_trace_id>"
+
+
+@patch.dict(os.environ, _ENV)
+def test_get_trace_id_no_tracer_returns_unknown():
+    runner = _make_runner()
+    assert runner.agent.tracers == []  # type: ignore[attr-defined]
+    assert runner.get_trace_id() == "<unknown_trace_id>"
+
+
+@patch.dict(os.environ, _ENV)
+def test_get_trace_id_returns_tracer_value():
+    runner = _make_runner()
+    tracer = Mock()
+    tracer.trace_id = "trace-xyz"
+    runner.agent.tracers = [tracer]  # type: ignore[attr-defined]
+    assert runner.get_trace_id() == "trace-xyz"
+
+
+@patch.dict(os.environ, _ENV)
+def test_print_trace_id_no_tracer_is_noop():
+    runner = _make_runner()
+    # Should not raise even with no tracer configured.
+    runner._print_trace_id()
+
+
+@patch.dict(os.environ, _ENV)
+def test_print_trace_id_logs_value():
+    runner = _make_runner()
+    tracer = Mock()
+    tracer.trace_id = "trace-abc"
+    runner.agent.tracers = [tracer]  # type: ignore[attr-defined]
+    runner._print_trace_id()  # exercises the success path
+
+
+# ---------------------------------------------------------------------------
+# save_tracing_file
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, _ENV)
+def test_save_tracing_file_wrong_agent_type_returns_empty():
+    from google.adk.agents import LlmAgent
+
+    runner = Runner(agent=LlmAgent(name="plain"), short_term_memory=ShortTermMemory())
+    assert runner.save_tracing_file("sess") == ""
+
+
+@patch.dict(os.environ, _ENV)
+def test_save_tracing_file_no_tracer_returns_empty():
+    runner = _make_runner()
+    assert runner.save_tracing_file("sess") == ""
+
+
+@patch.dict(os.environ, _ENV)
+def test_save_tracing_file_dumps_and_returns_path():
+    runner = _make_runner()
+    tracer = Mock()
+    tracer.dump.return_value = "/tmp/trace.json"
+    runner.agent.tracers = [tracer]  # type: ignore[attr-defined]
+    path = runner.save_tracing_file("sess-7")
+    assert path == "/tmp/trace.json"
+    tracer.dump.assert_called_once_with(user_id=runner.user_id, session_id="sess-7")
+
+
+@patch.dict(os.environ, _ENV)
+def test_save_tracing_file_returns_empty_on_dump_error():
+    runner = _make_runner()
+    tracer = Mock()
+    tracer.dump.side_effect = RuntimeError("disk full")
+    runner.agent.tracers = [tracer]  # type: ignore[attr-defined]
+    assert runner.save_tracing_file("sess-err") == ""
+
+
+# ---------------------------------------------------------------------------
+# save_session_to_long_term_memory
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch.dict(os.environ, _ENV)
+async def test_save_session_no_long_term_memory_returns_early():
+    runner = _make_runner()
+    assert runner.long_term_memory is None
+    # Should simply warn and return without raising.
+    await runner.save_session_to_long_term_memory(session_id="s")
+
+
+@pytest.mark.asyncio
+@patch.dict(os.environ, _ENV)
+async def test_save_session_session_not_found_returns_early():
+    runner = _make_runner()
+    runner.long_term_memory = Mock()
+    runner.long_term_memory.add_session_to_memory = AsyncMock()
+    runner.session_service.get_session = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+    await runner.save_session_to_long_term_memory(session_id="missing")
+    runner.long_term_memory.add_session_to_memory.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch.dict(os.environ, _ENV)
+async def test_save_session_persists_when_found():
+    runner = _make_runner()
+    runner.long_term_memory = Mock()
+    runner.long_term_memory.add_session_to_memory = AsyncMock()
+
+    session = Mock()
+    session.id = "sess-found"
+    runner.session_service.get_session = AsyncMock(return_value=session)  # type: ignore[method-assign]
+
+    await runner.save_session_to_long_term_memory(
+        session_id="sess-found", user_id="bob", app_name="myapp"
+    )
+    runner.session_service.get_session.assert_awaited_once_with(
+        app_name="myapp", user_id="bob", session_id="sess-found"
+    )
+    runner.long_term_memory.add_session_to_memory.assert_awaited_once()

--- a/tests/runtime/codex/conftest.py
+++ b/tests/runtime/codex/conftest.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test fixtures for the codex runtime tests.
+
+``veadk.runtime.codex.runtime`` hard-imports ``openai_codex`` (the optional
+codex extra). It is installed in dev environments but not in the base CI image,
+so stub the module here — before the codex test modules import — when it is
+absent. Tests mock ``AsyncCodex`` behaviour anyway; the stub only lets the
+import chain succeed so the runtime/translate/proxy logic can be exercised.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+try:
+    import openai_codex  # noqa: F401
+except ImportError:
+    _stub = types.ModuleType("openai_codex")
+    # Name imported by veadk.runtime.codex.runtime; tests patch its usage.
+    _stub.AsyncCodex = MagicMock()  # type: ignore[attr-defined]
+    sys.modules["openai_codex"] = _stub

--- a/tests/runtime/codex/test_proxy.py
+++ b/tests/runtime/codex/test_proxy.py
@@ -1,0 +1,367 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for veadk.runtime.codex.proxy (the Responses shim).
+
+All backend calls (``litellm.aresponses``) are mocked; no network is used.
+"""
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from litellm.exceptions import APIError
+
+from veadk.runtime.codex import proxy
+from veadk.runtime.codex.proxy import (
+    ResponsesShim,
+    _error_type,
+    _sse,
+    _synth_sse,
+    _to_dict,
+    get_shim_url,
+)
+
+
+def _parse_sse(raw: bytes) -> list[dict[str, Any]]:
+    """Parse an SSE byte stream into the list of decoded data dicts."""
+    events: list[dict[str, Any]] = []
+    for frame in raw.decode().split("\n\n"):
+        frame = frame.strip()
+        if not frame:
+            continue
+        for line in frame.splitlines():
+            if line.startswith("data: "):
+                events.append(json.loads(line[len("data: ") :]))
+    return events
+
+
+class TestErrorType:
+    def test_known_codes(self):
+        assert _error_type(400) == "invalid_request_error"
+        assert _error_type(401) == "authentication_error"
+        assert _error_type(403) == "permission_error"
+        assert _error_type(404) == "not_found_error"
+        assert _error_type(429) == "rate_limit_error"
+
+    def test_unknown_code_defaults_to_api_error(self):
+        assert _error_type(500) == "api_error"
+        assert _error_type(418) == "api_error"
+
+
+class TestToDict:
+    def test_dict_passthrough(self):
+        d = {"a": 1}
+        assert _to_dict(d) is d
+
+    def test_model_dump_object(self):
+        obj = SimpleNamespace(model_dump=lambda: {"x": 2})
+        assert _to_dict(obj) == {"x": 2}
+
+    def test_mapping_fallback(self):
+        # dict(obj) works on a mapping-like sequence of pairs.
+        assert _to_dict([("k", "v")]) == {"k": "v"}
+
+
+class TestSse:
+    def test_encodes_event_and_data_lines(self):
+        frame = _sse({"type": "response.created", "n": 1})
+        text = frame.decode()
+        assert text.startswith("event: response.created\n")
+        assert "data: " in text
+        assert text.endswith("\n\n")
+        data_line = [line for line in text.splitlines() if line.startswith("data: ")][0]
+        assert json.loads(data_line[len("data: ") :]) == {
+            "type": "response.created",
+            "n": 1,
+        }
+
+
+class TestSynthSse:
+    @pytest.mark.asyncio
+    async def _collect(self, resp: dict[str, Any]) -> list[dict[str, Any]]:
+        frames = [frame async for frame in _synth_sse(resp)]
+        events: list[dict[str, Any]] = []
+        for f in frames:
+            events.extend(_parse_sse(f))
+        return events
+
+    @pytest.mark.asyncio
+    async def test_wraps_with_created_and_completed(self):
+        resp = {"id": "r1", "status": "completed", "output": []}
+        events = await self._collect(resp)
+        assert events[0]["type"] == "response.created"
+        assert events[1]["type"] == "response.in_progress"
+        assert events[-1]["type"] == "response.completed"
+        # The created/in_progress snapshots are trimmed to in_progress + empty.
+        assert events[0]["response"]["status"] == "in_progress"
+        assert events[0]["response"]["output"] == []
+        assert events[-1]["response"]["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_sequence_numbers_are_monotonic(self):
+        resp = {"id": "r1", "output": []}
+        events = await self._collect(resp)
+        seqs = [e["sequence_number"] for e in events]
+        assert seqs == list(range(len(events)))
+
+    @pytest.mark.asyncio
+    async def test_function_call_item_streams_arguments(self):
+        resp = {
+            "id": "r1",
+            "output": [
+                {
+                    "id": "fc1",
+                    "type": "function_call",
+                    "name": "do",
+                    "arguments": '{"x":1}',
+                }
+            ],
+        }
+        events = await self._collect(resp)
+        types_seen = [e["type"] for e in events]
+        assert "response.output_item.added" in types_seen
+        assert "response.function_call_arguments.delta" in types_seen
+        assert "response.function_call_arguments.done" in types_seen
+        assert "response.output_item.done" in types_seen
+        delta = [
+            e for e in events if e["type"] == "response.function_call_arguments.delta"
+        ][0]
+        assert delta["delta"] == '{"x":1}'
+        assert delta["item_id"] == "fc1"
+
+    @pytest.mark.asyncio
+    async def test_message_item_streams_text(self):
+        resp = {
+            "id": "r1",
+            "output": [
+                {
+                    "id": "m1",
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "hi"}],
+                }
+            ],
+        }
+        events = await self._collect(resp)
+        types_seen = [e["type"] for e in events]
+        assert "response.content_part.added" in types_seen
+        assert "response.output_text.delta" in types_seen
+        assert "response.output_text.done" in types_seen
+        delta = [e for e in events if e["type"] == "response.output_text.delta"][0]
+        assert delta["delta"] == "hi"
+
+    @pytest.mark.asyncio
+    async def test_reasoning_item_streams_summary(self):
+        resp = {
+            "id": "r1",
+            "output": [
+                {
+                    "id": "rs1",
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "think"}],
+                }
+            ],
+        }
+        events = await self._collect(resp)
+        types_seen = [e["type"] for e in events]
+        assert "response.reasoning_summary_part.added" in types_seen
+        assert "response.reasoning_summary_text.delta" in types_seen
+        assert "response.reasoning_summary_text.done" in types_seen
+
+    @pytest.mark.asyncio
+    async def test_non_emitted_item_types_filtered_from_output(self):
+        resp = {
+            "id": "r1",
+            "output": [
+                {"id": "x", "type": "something_else"},
+                {"id": "m1", "type": "message", "content": []},
+            ],
+        }
+        events = await self._collect(resp)
+        completed = events[-1]
+        assert completed["type"] == "response.completed"
+        # Only the message item survives into the completed output.
+        kept_types = [it["type"] for it in completed["response"]["output"]]
+        assert kept_types == ["message"]
+
+
+def _make_app_client(shim: ResponsesShim) -> TestClient:
+    # The app is built in __init__; exercise its route via TestClient.
+    return TestClient(shim._app)
+
+
+class TestResponsesEndpoint:
+    def _shim(self) -> ResponsesShim:
+        return ResponsesShim(api_base="https://backend.example/v1", api_key="sk-test")
+
+    def test_non_streaming_returns_json_and_forwards_kwargs(self):
+        shim = self._shim()
+        fake = SimpleNamespace(model_dump=lambda: {"id": "r1", "output": []})
+        mock = AsyncMock(return_value=fake)
+        with patch.object(proxy.litellm, "aresponses", mock):
+            client = _make_app_client(shim)
+            resp = client.post(
+                "/v1/responses",
+                json={
+                    "model": "my-model",
+                    "input": "hi",
+                    "temperature": 0.5,
+                    "stream": False,
+                    "unsupported_field": "drop me",
+                },
+            )
+        assert resp.status_code == 200
+        assert resp.json() == {"id": "r1", "output": []}
+
+        _, kwargs = mock.call_args
+        # Model is prefixed and backend creds/provider injected.
+        assert kwargs["model"] == "openai/my-model"
+        assert kwargs["api_base"] == "https://backend.example/v1"
+        assert kwargs["api_key"] == "sk-test"
+        assert kwargs["custom_llm_provider"] == "openai"
+        assert kwargs["drop_params"] is True
+        assert kwargs["stream"] is False
+        # Passthrough kept; unsupported dropped.
+        assert kwargs["input"] == "hi"
+        assert kwargs["temperature"] == 0.5
+        assert "unsupported_field" not in kwargs
+
+    def test_streaming_returns_synthesized_sse(self):
+        shim = self._shim()
+        fake = SimpleNamespace(
+            model_dump=lambda: {
+                "id": "r1",
+                "output": [
+                    {"id": "m1", "type": "message", "content": [{"text": "hi"}]}
+                ],
+            }
+        )
+        with patch.object(proxy.litellm, "aresponses", AsyncMock(return_value=fake)):
+            client = _make_app_client(shim)
+            resp = client.post(
+                "/v1/responses",
+                json={"model": "m", "input": "hi", "stream": True},
+            )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        events = _parse_sse(resp.content)
+        assert events[0]["type"] == "response.created"
+        assert events[-1]["type"] == "response.completed"
+
+    def test_non_function_tools_are_filtered_out(self):
+        shim = self._shim()
+        mock = AsyncMock(
+            return_value=SimpleNamespace(model_dump=lambda: {"id": "r", "output": []})
+        )
+        with patch.object(proxy.litellm, "aresponses", mock):
+            client = _make_app_client(shim)
+            client.post(
+                "/v1/responses",
+                json={
+                    "model": "m",
+                    "tools": [
+                        {"type": "function", "name": "f"},
+                        {"type": "web_search", "external_web_access": True},
+                    ],
+                },
+            )
+        _, kwargs = mock.call_args
+        assert kwargs["tools"] == [{"type": "function", "name": "f"}]
+
+    def test_assistant_messages_get_status_backfilled(self):
+        shim = self._shim()
+        mock = AsyncMock(
+            return_value=SimpleNamespace(model_dump=lambda: {"id": "r", "output": []})
+        )
+        with patch.object(proxy.litellm, "aresponses", mock):
+            client = _make_app_client(shim)
+            client.post(
+                "/v1/responses",
+                json={
+                    "model": "m",
+                    "input": [
+                        {"type": "message", "role": "assistant", "content": []},
+                        {"type": "message", "role": "user", "content": []},
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "status": "completed",
+                            "content": [],
+                        },
+                    ],
+                },
+            )
+        _, kwargs = mock.call_args
+        sent = kwargs["input"]
+        assert sent[0]["status"] == "completed"  # backfilled
+        assert "status" not in sent[1]  # user untouched
+        assert sent[2]["status"] == "completed"  # already present, untouched
+
+    def test_api_error_is_translated_to_error_envelope(self):
+        shim = self._shim()
+        err = APIError(
+            status_code=429,
+            message="rate limited",
+            llm_provider="openai",
+            model="m",
+        )
+        with patch.object(proxy.litellm, "aresponses", AsyncMock(side_effect=err)):
+            # TestClient re-raises by default; disable so the handler runs.
+            client = TestClient(shim._app, raise_server_exceptions=False)
+            resp = client.post("/v1/responses", json={"model": "m"})
+        assert resp.status_code == 429
+        body = resp.json()
+        assert body["error"]["type"] == "rate_limit_error"
+        assert "rate limited" in body["error"]["message"]
+
+
+class TestStartStop:
+    @pytest.mark.asyncio
+    async def test_start_returns_url_and_is_idempotent(self):
+        shim = ResponsesShim(api_base="https://b/v1", api_key="k")
+        try:
+            url = await shim.start()
+            assert url.startswith("http://127.0.0.1:")
+            assert shim.url == url
+            # Second call returns the same URL without restarting.
+            assert await shim.start() == url
+        finally:
+            await shim.stop()
+        assert shim.url is None
+
+
+class TestGetShimUrl:
+    @pytest.mark.asyncio
+    async def test_caches_one_shim_per_backend(self):
+        proxy._SHIMS.clear()
+        started: list[ResponsesShim] = []
+
+        async def fake_start(self: ResponsesShim) -> str:
+            started.append(self)
+            self.url = "http://127.0.0.1:9999"
+            return self.url
+
+        with patch.object(ResponsesShim, "start", fake_start):
+            url1 = await get_shim_url("https://b/v1", "k1")
+            url2 = await get_shim_url("https://b/v1", "k1")
+            url3 = await get_shim_url("https://other/v1", "k1")
+
+        assert url1 == url2 == "http://127.0.0.1:9999"
+        # Same (base, key) reuses one shim; a different base makes a new one.
+        assert len(proxy._SHIMS) == 2
+        assert url3 == "http://127.0.0.1:9999"
+        proxy._SHIMS.clear()

--- a/tests/runtime/codex/test_runtime.py
+++ b/tests/runtime/codex/test_runtime.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for veadk.runtime.codex.runtime.
+
+The Codex SDK (``AsyncCodex``), the Responses shim and the filesystem-touching
+``_prepare_codex_home`` are all mocked; no subprocess, network or model is used.
+"""
+
+import os
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from veadk.runtime.base_runtime import BaseRuntime
+from veadk.runtime.codex import runtime as runtime_mod
+from veadk.runtime.codex.runtime import CodexRuntime
+
+
+def _agent(
+    model_name: Any = "my-model",
+    model_api_base: str = "https://backend/v1",
+    model_api_key: str = "sk-1",
+    name: str = "agent",
+    description: str = "",
+    instruction: Any = "",
+) -> Any:
+    return SimpleNamespace(
+        model_name=model_name,
+        model_api_base=model_api_base,
+        model_api_key=model_api_key,
+        name=name,
+        description=description,
+        instruction=instruction,
+    )
+
+
+def _ctx(invocation_id: str = "inv-1") -> Any:
+    return SimpleNamespace(
+        invocation_id=invocation_id,
+        session=SimpleNamespace(events=[]),
+    )
+
+
+class TestContract:
+    def test_is_base_runtime_subclass(self):
+        assert issubclass(CodexRuntime, BaseRuntime)
+
+    def test_name_is_codex(self):
+        assert CodexRuntime.name == "codex"
+
+    def test_instantiable(self):
+        assert isinstance(CodexRuntime(), CodexRuntime)
+
+
+class TestResolveModel:
+    def test_string_model_name(self):
+        assert CodexRuntime()._resolve_model(_agent(model_name="gpt-x")) == "gpt-x"
+
+    def test_list_model_name_uses_first(self):
+        agent = _agent(model_name=["primary", "fallback"])
+        assert CodexRuntime()._resolve_model(agent) == "primary"
+
+    def test_empty_list_falls_back_to_env(self):
+        agent = _agent(model_name=[])
+        with patch.dict(os.environ, {"OPENAI_MODEL": "env-model"}):
+            assert CodexRuntime()._resolve_model(agent) == "env-model"
+
+    def test_empty_name_falls_back_to_env(self):
+        agent = _agent(model_name="")
+        with patch.dict(os.environ, {"OPENAI_MODEL": "env-model"}):
+            assert CodexRuntime()._resolve_model(agent) == "env-model"
+
+    def test_no_model_anywhere_raises(self):
+        agent = _agent(model_name="")
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="codex runtime requires a model"):
+                CodexRuntime()._resolve_model(agent)
+
+
+class TestPrepareCodexHome:
+    def test_writes_config_toml_and_caches(self, tmp_path):
+        runtime_mod._CODEX_HOMES.clear()
+        with patch.object(
+            runtime_mod.tempfile, "mkdtemp", return_value=str(tmp_path)
+        ) as mkdtemp:
+            home = runtime_mod._prepare_codex_home("http://127.0.0.1:1234", "m-1")
+
+        assert home == str(tmp_path)
+        config_path = os.path.join(home, "config.toml")
+        assert os.path.exists(config_path)
+        with open(config_path, encoding="utf-8") as f:
+            config = f.read()
+        assert 'model = "m-1"' in config
+        assert 'model_provider = "veadk"' in config
+        assert "[model_providers.veadk]" in config
+        assert 'base_url = "http://127.0.0.1:1234/v1"' in config
+        assert 'env_key = "VEADK_CODEX_API_KEY"' in config
+        assert 'wire_api = "responses"' in config
+
+        # A second call with the same key is cached: no new mkdtemp.
+        mkdtemp.reset_mock()
+        with patch.object(runtime_mod.tempfile, "mkdtemp") as mkdtemp2:
+            again = runtime_mod._prepare_codex_home("http://127.0.0.1:1234", "m-1")
+        assert again == home
+        mkdtemp2.assert_not_called()
+        runtime_mod._CODEX_HOMES.clear()
+
+    def test_distinct_keys_get_distinct_homes(self, tmp_path):
+        runtime_mod._CODEX_HOMES.clear()
+        homes = [str(tmp_path / "a"), str(tmp_path / "b")]
+        for h in homes:
+            os.makedirs(h, exist_ok=True)
+        with patch.object(runtime_mod.tempfile, "mkdtemp", side_effect=homes):
+            h1 = runtime_mod._prepare_codex_home("http://s1/v1", "m")
+            h2 = runtime_mod._prepare_codex_home("http://s2/v1", "m")
+        assert h1 != h2
+        runtime_mod._CODEX_HOMES.clear()
+
+
+def _patch_codex(result):
+    """Return a patcher for AsyncCodex whose thread.run resolves to ``result``."""
+    thread = SimpleNamespace(run=AsyncMock(return_value=result))
+    codex = MagicMock()
+    codex.thread_start = AsyncMock(return_value=thread)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=codex)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return patch.object(runtime_mod, "AsyncCodex", MagicMock(return_value=cm)), codex
+
+
+class TestRunAsync:
+    @pytest.mark.asyncio
+    async def test_missing_api_base_or_key_raises(self):
+        agent = _agent(model_api_base="", model_api_key="")
+        with patch.dict(os.environ, {}, clear=True):
+            runtime = CodexRuntime()
+            with pytest.raises(ValueError, match="model_api_base and model_api_key"):
+                async for _ in runtime.run_async(agent, _ctx()):
+                    pass
+
+    @pytest.mark.asyncio
+    async def test_run_async_streams_translated_events(self):
+        agent = _agent(name="bot", instruction="Be nice.")
+        result = SimpleNamespace(
+            items=[{"type": "agentMessage", "text": "hello"}],
+            final_response="hello",
+        )
+        codex_patch, codex = _patch_codex(result)
+        with (
+            patch.object(
+                runtime_mod, "get_shim_url", AsyncMock(return_value="http://shim")
+            ),
+            patch.object(runtime_mod, "_prepare_codex_home", return_value="/tmp/home"),
+            codex_patch,
+        ):
+            runtime = CodexRuntime()
+            events = [e async for e in runtime.run_async(agent, _ctx("inv-9"))]
+
+        assert len(events) == 1
+        content = events[0].content
+        assert content is not None and content.parts is not None
+        assert content.parts[0].text == "hello"
+        assert events[0].author == "bot"
+        assert events[0].invocation_id == "inv-9"
+        # thread_start receives the resolved model.
+        codex.thread_start.assert_awaited_once_with(model="my-model")
+
+    @pytest.mark.asyncio
+    async def test_prompt_includes_system_append_block(self):
+        agent = _agent(name="bot", description="A bot.", instruction="Be brief.")
+        result = SimpleNamespace(items=[], final_response=None)
+        codex_patch, codex = _patch_codex(result)
+        ctx = _ctx()
+        ctx.session.events = [
+            SimpleNamespace(
+                author="user",
+                content=SimpleNamespace(
+                    parts=[SimpleNamespace(text="hi", thought=False)]
+                ),
+            )
+        ]
+        with (
+            patch.object(
+                runtime_mod, "get_shim_url", AsyncMock(return_value="http://shim")
+            ),
+            patch.object(runtime_mod, "_prepare_codex_home", return_value="/tmp/home"),
+            codex_patch,
+        ):
+            runtime = CodexRuntime()
+            _ = [e async for e in runtime.run_async(agent, ctx)]
+
+        prompt = codex.thread_start.return_value.run.call_args.args[0]
+        assert "# System instructions" in prompt
+        assert "Your name is bot." in prompt
+        assert "A bot." in prompt
+        assert "Be brief." in prompt
+        assert "# Conversation" in prompt
+        assert prompt.endswith("hi")
+
+    @pytest.mark.asyncio
+    async def test_env_isolation_restored_after_run(self):
+        agent = _agent()
+        result = SimpleNamespace(items=[], final_response=None)
+        codex_patch, _ = _patch_codex(result)
+        with patch.dict(
+            os.environ,
+            {"CODEX_HOME": "/orig/home", "VEADK_CODEX_API_KEY": "orig-key"},
+        ):
+            with (
+                patch.object(
+                    runtime_mod, "get_shim_url", AsyncMock(return_value="http://shim")
+                ),
+                patch.object(
+                    runtime_mod, "_prepare_codex_home", return_value="/tmp/home"
+                ),
+                codex_patch,
+            ):
+                runtime = CodexRuntime()
+                _ = [e async for e in runtime.run_async(agent, _ctx())]
+            # Pre-existing env vars are restored to their original values.
+            assert os.environ["CODEX_HOME"] == "/orig/home"
+            assert os.environ["VEADK_CODEX_API_KEY"] == "orig-key"
+
+    @pytest.mark.asyncio
+    async def test_env_isolation_pops_vars_that_did_not_exist(self):
+        agent = _agent()
+        result = SimpleNamespace(items=[], final_response=None)
+        codex_patch, _ = _patch_codex(result)
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ["OPENAI_BASE_URL"] = "x"  # keep run_async happy via agent
+            with (
+                patch.object(
+                    runtime_mod, "get_shim_url", AsyncMock(return_value="http://shim")
+                ),
+                patch.object(
+                    runtime_mod, "_prepare_codex_home", return_value="/tmp/home"
+                ),
+                codex_patch,
+            ):
+                runtime = CodexRuntime()
+                _ = [e async for e in runtime.run_async(agent, _ctx())]
+            # They were absent before the run, so they must be removed after.
+            assert "CODEX_HOME" not in os.environ
+            assert "VEADK_CODEX_API_KEY" not in os.environ
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_env_base_and_key(self):
+        agent = _agent(model_api_base="", model_api_key="")
+        result = SimpleNamespace(items=[], final_response=None)
+        codex_patch, _ = _patch_codex(result)
+        shim = AsyncMock(return_value="http://shim")
+        with patch.dict(
+            os.environ,
+            {"OPENAI_BASE_URL": "https://env-base/v1", "OPENAI_API_KEY": "env-key"},
+        ):
+            with (
+                patch.object(runtime_mod, "get_shim_url", shim),
+                patch.object(
+                    runtime_mod, "_prepare_codex_home", return_value="/tmp/home"
+                ),
+                codex_patch,
+            ):
+                runtime = CodexRuntime()
+                _ = [e async for e in runtime.run_async(agent, _ctx())]
+        shim.assert_awaited_once_with("https://env-base/v1", "env-key")

--- a/tests/runtime/codex/test_translate.py
+++ b/tests/runtime/codex/test_translate.py
@@ -1,0 +1,360 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for veadk.runtime.codex.translate."""
+
+from enum import Enum
+from types import SimpleNamespace
+from typing import Any
+
+from google.adk.events.event import Event
+from google.genai import types
+
+from veadk.runtime.codex import translate
+from veadk.runtime.codex.translate import (
+    _join,
+    _parse_args,
+    _scalar,
+    _tool_call,
+    build_prompt,
+    result_to_events,
+)
+
+
+def _part(text: Any = None, thought: bool = False) -> Any:
+    return SimpleNamespace(text=text, thought=thought)
+
+
+def _event(author: str, parts: Any) -> Any:
+    return SimpleNamespace(author=author, content=SimpleNamespace(parts=parts))
+
+
+def _ctx(events: Any) -> Any:
+    return SimpleNamespace(session=SimpleNamespace(events=events))
+
+
+def _content(event: Event) -> Any:
+    """Return an Event's content, asserting it is present (it always is here)."""
+    assert event.content is not None
+    assert event.content.parts is not None
+    return event.content
+
+
+class TestBuildPrompt:
+    def test_single_user_turn_returns_bare_message(self):
+        ctx = _ctx([_event("user", [_part(text="hello there")])])
+        assert build_prompt(ctx) == "hello there"
+
+    def test_multi_turn_renders_prefixed_transcript(self):
+        ctx = _ctx(
+            [
+                _event("user", [_part(text="hi")]),
+                _event("agent", [_part(text="hello")]),
+                _event("user", [_part(text="bye")]),
+            ]
+        )
+        assert build_prompt(ctx) == "User: hi\nAssistant: hello\nUser: bye"
+
+    def test_thought_parts_are_skipped(self):
+        ctx = _ctx(
+            [
+                _event(
+                    "agent",
+                    [_part(text="thinking...", thought=True), _part(text="answer")],
+                )
+            ]
+        )
+        # The single non-thought line is from a non-user author, so it stays
+        # prefixed (the bare-message shortcut only applies to a lone user turn).
+        assert build_prompt(ctx) == "Assistant: answer"
+
+    def test_events_without_content_or_parts_skipped(self):
+        empty_content = SimpleNamespace(author="user", content=None)
+        no_parts = _event("user", [])
+        ctx = _ctx([empty_content, no_parts, _event("user", [_part(text="x")])])
+        assert build_prompt(ctx) == "x"
+
+    def test_whitespace_only_text_skipped(self):
+        ctx = _ctx(
+            [
+                _event("user", [_part(text="   ")]),
+                _event("user", [_part(text="real")]),
+            ]
+        )
+        assert build_prompt(ctx) == "real"
+
+    def test_empty_session_returns_empty_string(self):
+        assert build_prompt(_ctx([])) == ""
+
+
+class TestScalar:
+    def test_enum_returns_value(self):
+        class Status(Enum):
+            DONE = "completed"
+
+        assert _scalar(Status.DONE) == "completed"
+
+    def test_object_with_value_attr(self):
+        assert _scalar(SimpleNamespace(value="v")) == "v"
+
+    def test_plain_scalar_passthrough(self):
+        assert _scalar("plain") == "plain"
+        assert _scalar(7) == 7
+
+
+class TestJoin:
+    def test_list_of_strings(self):
+        assert _join(["a", "b"]) == "a\nb"
+
+    def test_list_of_dicts_with_text(self):
+        assert _join([{"text": "one"}, {"text": "two"}]) == "one\ntwo"
+
+    def test_strips_and_drops_blanks(self):
+        assert _join(["  a  ", "", "   ", "b"]) == "a\nb"
+
+    def test_none_returns_empty(self):
+        assert _join(None) == ""
+
+
+class TestParseArgs:
+    def test_dict_passthrough(self):
+        assert _parse_args({"k": "v"}) == {"k": "v"}
+
+    def test_valid_json_object(self):
+        assert _parse_args('{"a": 1}') == {"a": 1}
+
+    def test_json_non_object_wrapped(self):
+        assert _parse_args("[1, 2]") == {"input": [1, 2]}
+
+    def test_invalid_json_wrapped_as_input(self):
+        assert _parse_args("not json") == {"input": "not json"}
+
+    def test_empty_and_other_types_return_empty(self):
+        assert _parse_args("") == {}
+        assert _parse_args("   ") == {}
+        assert _parse_args(None) == {}
+        assert _parse_args(123) == {}
+
+
+class TestToolCall:
+    def test_command_execution(self):
+        result = _tool_call(
+            {
+                "type": "commandExecution",
+                "command": "ls",
+                "cwd": "/tmp",
+                "aggregated_output": "out",
+                "exit_code": 0,
+                "status": "completed",
+            }
+        )
+        assert result is not None
+        name, args, response = result
+        assert name == "exec_command"
+        assert args == {"command": "ls", "cwd": "/tmp"}
+        assert response == {"output": "out", "exit_code": 0, "status": "completed"}
+
+    def test_mcp_tool_call_joins_server_and_tool(self):
+        result = _tool_call(
+            {
+                "type": "mcpToolCall",
+                "server": "fs",
+                "tool": "read",
+                "arguments": '{"path": "/a"}',
+                "result": "data",
+                "error": None,
+                "status": "completed",
+            }
+        )
+        assert result is not None
+        name, args, response = result
+        assert name == "fs.read"
+        assert args == {"path": "/a"}
+        assert response["result"] == "data"
+
+    def test_mcp_tool_call_falls_back_to_default_name(self):
+        result = _tool_call({"type": "mcpToolCall"})
+        assert result is not None
+        assert result[0] == "mcp_tool"
+
+    def test_dynamic_tool_call(self):
+        result = _tool_call(
+            {
+                "type": "dynamicToolCall",
+                "namespace": "ns",
+                "tool": "do",
+                "arguments": {"x": 1},
+                "content_items": ["c"],
+                "success": True,
+                "status": "completed",
+            }
+        )
+        assert result is not None
+        name, args, response = result
+        assert name == "ns.do"
+        assert args == {"x": 1}
+        assert response == {"content": ["c"], "success": True, "status": "completed"}
+
+    def test_file_change(self):
+        result = _tool_call(
+            {"type": "fileChange", "changes": [{"path": "a"}], "status": "completed"}
+        )
+        assert result is not None
+        name, args, response = result
+        assert name == "apply_patch"
+        assert args == {"changes": [{"path": "a"}]}
+        assert response == {"status": "completed"}
+
+    def test_web_search_status_always_completed(self):
+        result = _tool_call({"type": "webSearch", "query": "q", "action": "search"})
+        assert result is not None
+        name, args, response = result
+        assert name == "web_search"
+        assert args == {"query": "q", "action": "search"}
+        assert response == {"status": "completed"}
+
+    def test_non_tool_returns_none(self):
+        assert _tool_call({"type": "agentMessage", "text": "hi"}) is None
+        assert _tool_call({"type": "reasoning"}) is None
+
+
+class TestResultToEvents:
+    def test_user_message_is_skipped(self):
+        result = SimpleNamespace(items=[{"type": "userMessage", "text": "hi"}])
+        assert result_to_events(result, "agent", "inv-1") == []
+
+    def test_reasoning_becomes_thought_part(self):
+        result = SimpleNamespace(
+            items=[{"type": "reasoning", "summary": ["thinking hard"]}]
+        )
+        events = result_to_events(result, "agent", "inv-1")
+        assert len(events) == 1
+        part = _content(events[0]).parts[0]
+        assert part.thought is True
+        assert part.text == "thinking hard"
+        assert events[0].author == "agent"
+        assert events[0].invocation_id == "inv-1"
+        assert _content(events[0]).role == "model"
+
+    def test_reasoning_falls_back_to_content(self):
+        result = SimpleNamespace(
+            items=[{"type": "reasoning", "summary": [], "content": ["from content"]}]
+        )
+        events = result_to_events(result, "agent", "inv-1")
+        assert _content(events[0]).parts[0].text == "from content"
+
+    def test_empty_reasoning_emits_no_event(self):
+        result = SimpleNamespace(items=[{"type": "reasoning", "summary": []}])
+        assert result_to_events(result, "agent", "inv-1") == []
+
+    def test_agent_message_becomes_text_part(self):
+        result = SimpleNamespace(items=[{"type": "agentMessage", "text": "hello"}])
+        events = result_to_events(result, "agent", "inv-1")
+        assert len(events) == 1
+        assert _content(events[0]).parts[0].text == "hello"
+        assert _content(events[0]).parts[0].thought is not True
+
+    def test_tool_call_emits_call_and_response_pair(self):
+        result = SimpleNamespace(
+            items=[
+                {
+                    "type": "commandExecution",
+                    "id": "c-1",
+                    "command": "ls",
+                    "cwd": "/tmp",
+                    "aggregated_output": "out",
+                    "exit_code": 0,
+                    "status": "completed",
+                }
+            ]
+        )
+        events = result_to_events(result, "agent", "inv-1")
+        assert len(events) == 2
+
+        call_part = _content(events[0]).parts[0]
+        assert _content(events[0]).role == "model"
+        assert isinstance(call_part.function_call, types.FunctionCall)
+        assert call_part.function_call.name == "exec_command"
+        assert call_part.function_call.id == "c-1"
+        assert call_part.function_call.args == {"command": "ls", "cwd": "/tmp"}
+
+        resp_part = _content(events[1]).parts[0]
+        assert _content(events[1]).role == "user"
+        assert isinstance(resp_part.function_response, types.FunctionResponse)
+        assert resp_part.function_response.id == "c-1"
+        assert resp_part.function_response.name == "exec_command"
+        response = resp_part.function_response.response
+        assert response is not None
+        assert response["output"] == "out"
+
+    def test_tool_call_synthesizes_id_when_missing(self):
+        result = SimpleNamespace(
+            items=[{"type": "webSearch", "query": "q", "action": "search"}]
+        )
+        events = result_to_events(result, "agent", "inv-1")
+        # No "id" in the item -> synthesized as call_<len(events)>; at the point
+        # of synthesis no events exist yet, so it is call_0.
+        assert _content(events[0]).parts[0].function_call.id == "call_0"
+        assert _content(events[1]).parts[0].function_response.id == "call_0"
+
+    def test_multi_step_turn_order_preserved(self):
+        result = SimpleNamespace(
+            items=[
+                {"type": "reasoning", "summary": ["let me look"]},
+                {
+                    "type": "webSearch",
+                    "id": "w-1",
+                    "query": "q",
+                    "action": "search",
+                },
+                {"type": "agentMessage", "text": "done"},
+            ]
+        )
+        events = result_to_events(result, "agent", "inv-1")
+        # reasoning(1) + tool call/response(2) + agentMessage(1) = 4
+        assert len(events) == 4
+        assert _content(events[0]).parts[0].thought is True
+        assert _content(events[1]).parts[0].function_call.name == "web_search"
+        assert _content(events[2]).parts[0].function_response is not None
+        assert _content(events[3]).parts[0].text == "done"
+
+    def test_fallback_to_final_response_when_no_items_map(self):
+        result = SimpleNamespace(items=[], final_response="the answer")
+        events = result_to_events(result, "agent", "inv-1")
+        assert len(events) == 1
+        assert _content(events[0]).parts[0].text == "the answer"
+        assert _content(events[0]).role == "model"
+
+    def test_no_items_and_no_final_response_returns_empty(self):
+        result = SimpleNamespace(items=[], final_response=None)
+        assert result_to_events(result, "agent", "inv-1") == []
+
+    def test_items_attribute_absent(self):
+        result = SimpleNamespace(final_response="fallback")
+        events = result_to_events(result, "agent", "inv-1")
+        assert _content(events[0]).parts[0].text == "fallback"
+
+    def test_pydantic_item_via_model_dump(self):
+        class Item:
+            def model_dump(self) -> dict[str, Any]:
+                return {"type": "agentMessage", "text": "from pydantic"}
+
+        result = SimpleNamespace(items=[Item()])
+        events = result_to_events(result, "agent", "inv-1")
+        assert _content(events[0]).parts[0].text == "from pydantic"
+
+
+def test_item_dict_unknown_object_returns_empty():
+    # An object without model_dump and not a dict yields {}.
+    assert translate._item_dict(object()) == {}

--- a/tests/runtime/test_base_runtime.py
+++ b/tests/runtime/test_base_runtime.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for veadk.runtime.base_runtime."""
+
+import inspect
+from types import SimpleNamespace
+from typing import Any, AsyncGenerator
+
+import pytest
+
+from veadk.runtime.base_runtime import BaseRuntime, build_system_append
+
+
+def _agent(name: str = "", description: str = "", instruction: Any = "") -> Any:
+    """A minimal duck-typed stand-in for veadk.agent.Agent."""
+    return SimpleNamespace(name=name, description=description, instruction=instruction)
+
+
+class TestBuildSystemAppend:
+    def test_combines_name_description_instruction_in_order(self):
+        agent = _agent(
+            name="helper",
+            description="A helpful agent.",
+            instruction="Always be concise.",
+        )
+        result = build_system_append(agent)
+        assert result == (
+            "Your name is helper.\n\nA helpful agent.\n\nAlways be concise."
+        )
+
+    def test_empty_agent_returns_empty_string(self):
+        assert build_system_append(_agent()) == ""
+
+    def test_only_name(self):
+        assert build_system_append(_agent(name="bot")) == "Your name is bot."
+
+    def test_blank_instruction_is_skipped(self):
+        # Whitespace-only instruction must not produce a trailing block.
+        agent = _agent(name="bot", instruction="   ")
+        assert build_system_append(agent) == "Your name is bot."
+
+    def test_callable_instruction_is_skipped(self):
+        # An InstructionProvider (non-str) needs a context to resolve, so it is
+        # dropped rather than stringified.
+        def provider(_ctx):
+            return "resolved"
+
+        agent = _agent(name="bot", instruction=provider)
+        assert build_system_append(agent) == "Your name is bot."
+
+    def test_description_only(self):
+        assert build_system_append(_agent(description="Does things.")) == "Does things."
+
+
+class TestBaseRuntimeContract:
+    def test_is_abstract_cannot_instantiate(self):
+        with pytest.raises(TypeError):
+            BaseRuntime()  # type: ignore[abstract]
+
+    def test_default_name_is_base(self):
+        assert BaseRuntime.name == "base"
+
+    def test_run_async_is_abstract(self):
+        assert getattr(BaseRuntime.run_async, "__isabstractmethod__", False)
+
+    def test_run_async_signature(self):
+        sig = inspect.signature(BaseRuntime.run_async)
+        assert list(sig.parameters) == ["self", "agent", "ctx"]
+
+    def test_subclass_must_implement_run_async(self):
+        class Incomplete(BaseRuntime):
+            pass
+
+        with pytest.raises(TypeError):
+            Incomplete()  # type: ignore[abstract]
+
+    @pytest.mark.asyncio
+    async def test_concrete_subclass_streams_events(self):
+        sentinel = object()
+
+        class Concrete(BaseRuntime):
+            name = "concrete"
+
+            async def run_async(self, agent, ctx) -> AsyncGenerator:  # type: ignore[override]
+                yield sentinel
+
+        runtime = Concrete()
+        ctx: Any = object()
+        collected = [e async for e in runtime.run_async(_agent(), ctx)]
+        assert collected == [sentinel]
+        assert runtime.name == "concrete"

--- a/tests/test_agent_builder.py
+++ b/tests/test_agent_builder.py
@@ -1,0 +1,221 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for :mod:`veadk.agent_builder`.
+
+These exercise the YAML config reader and the recursive ``_build`` dispatch
+(type lookup, dotted-path tool import, and sub-agent recursion) using a fake
+agent class registered into ``AGENT_TYPES``. No real ``Agent`` is instantiated,
+so there is no model or network access.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import Any, cast
+
+import pytest
+
+from veadk import agent_builder
+from veadk.agent_builder import AGENT_TYPES, AgentBuilder
+
+# A module-level callable used to verify dotted-path tool resolution in ``_build``.
+SENTINEL_TOOL_CALLS = []
+
+
+def sample_tool() -> str:
+    """A trivial tool resolved by its dotted import path during tests."""
+    return "tool-result"
+
+
+class _FakeAgent:
+    """Records the kwargs ``_build`` passes to the resolved agent class."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs: dict[str, Any] = kwargs
+        # Mirror the fields the tests assert on for convenience.
+        self.sub_agents: list[Any] = kwargs.get("sub_agents", [])
+        self.tools: list[Any] = kwargs.get("tools", [])
+        self.name: Any = kwargs.get("name")
+
+
+@pytest.fixture
+def fake_agent_types(monkeypatch):
+    """Register ``FakeAgent`` so ``_build`` constructs it instead of a real Agent."""
+    monkeypatch.setitem(AGENT_TYPES, "FakeAgent", _FakeAgent)
+    return _FakeAgent
+
+
+def test_agent_types_registry_contents():
+    """The registry maps the documented type names to classes."""
+    assert set(AGENT_TYPES) == {
+        "Agent",
+        "SequentialAgent",
+        "ParallelAgent",
+        "LoopAgent",
+        "RemoteVeAgent",
+    }
+
+
+def test_read_config_rejects_non_yaml(tmp_path):
+    """Only ``.yaml`` config files are accepted."""
+    bad = tmp_path / "config.json"
+    bad.write_text("{}")
+
+    with pytest.raises(AssertionError, match="must be a `.yaml` file"):
+        AgentBuilder()._read_config(str(bad))
+
+
+def test_read_config_parses_yaml_to_dict(tmp_path):
+    """A well-formed YAML file parses into a plain dict."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            """
+            root_agent:
+              type: FakeAgent
+              name: root
+            """
+        )
+    )
+
+    result = AgentBuilder()._read_config(str(cfg))
+
+    assert isinstance(result, dict)
+    assert result["root_agent"]["type"] == "FakeAgent"
+    assert result["root_agent"]["name"] == "root"
+
+
+def test_build_constructs_registered_type(fake_agent_types):
+    """``_build`` looks up the class by ``type`` and forwards remaining config."""
+    agent = AgentBuilder()._build({"type": "FakeAgent", "name": "leaf"})
+
+    assert isinstance(agent, _FakeAgent)
+    assert agent.name == "leaf"
+    # ``_build`` always supplies sub_agents and tools, defaulting to empty lists.
+    assert agent.sub_agents == []
+    assert agent.tools == []
+
+
+def test_build_unknown_type_raises_keyerror(fake_agent_types):
+    """An unregistered ``type`` surfaces a KeyError from the registry lookup."""
+    with pytest.raises(KeyError):
+        AgentBuilder()._build({"type": "DoesNotExist"})
+
+
+def test_build_resolves_tools_by_dotted_path(fake_agent_types):
+    """Tool entries are imported by ``module.func`` and passed as callables."""
+    config = {
+        "type": "FakeAgent",
+        "name": "with_tools",
+        "tools": [{"name": "tests.test_agent_builder.sample_tool"}],
+    }
+
+    agent = cast(_FakeAgent, AgentBuilder()._build(config))
+
+    assert len(agent.tools) == 1
+    resolved = agent.tools[0]
+    assert callable(resolved)
+    assert resolved.__name__ == "sample_tool"
+    # The resolved callable is a genuine, invokable function.
+    assert resolved() == "tool-result"
+
+
+def test_build_recurses_into_sub_agents(fake_agent_types):
+    """Nested ``sub_agents`` are built recursively and attached to the parent."""
+    config = {
+        "type": "FakeAgent",
+        "name": "parent",
+        "sub_agents": [
+            {"type": "FakeAgent", "name": "child_a"},
+            {"type": "FakeAgent", "name": "child_b"},
+        ],
+    }
+
+    agent = AgentBuilder()._build(config)
+
+    assert [c.name for c in agent.sub_agents] == ["child_a", "child_b"]
+    assert all(isinstance(c, _FakeAgent) for c in agent.sub_agents)
+
+
+def test_build_pops_sub_agents_and_tools_from_config(fake_agent_types):
+    """``_build`` consumes ``sub_agents``/``tools`` so they are not re-passed."""
+    config = {
+        "type": "FakeAgent",
+        "name": "p",
+        "sub_agents": [{"type": "FakeAgent", "name": "c"}],
+        "tools": [{"name": "tests.test_agent_builder.sample_tool"}],
+    }
+
+    agent = cast(_FakeAgent, AgentBuilder()._build(config))
+
+    # The raw config dict had its consumed keys removed in place.
+    assert "sub_agents" not in config
+    assert "tools" not in config
+    # And they were re-supplied to the constructor as kwargs.
+    assert "sub_agents" in agent.kwargs
+    assert "tools" in agent.kwargs
+    assert len(agent.sub_agents) == 1
+    assert len(agent.tools) == 1
+
+
+def test_build_entrypoint_reads_config_and_dispatches(tmp_path, fake_agent_types):
+    """``build`` reads the file then builds the agent under ``root_agent_identifier``."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            """
+            root_agent:
+              type: FakeAgent
+              name: top
+            """
+        )
+    )
+
+    agent = AgentBuilder().build(str(cfg))
+
+    assert isinstance(agent, _FakeAgent)
+    assert agent.name == "top"
+
+
+def test_build_entrypoint_honours_custom_identifier(tmp_path, fake_agent_types):
+    """A non-default ``root_agent_identifier`` selects a different top-level key."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            """
+            my_root:
+              type: FakeAgent
+              name: custom
+            """
+        )
+    )
+
+    agent = AgentBuilder().build(str(cfg), root_agent_identifier="my_root")
+
+    assert agent.name == "custom"
+
+
+def test_build_entrypoint_missing_identifier_raises(tmp_path, fake_agent_types):
+    """A missing root identifier surfaces a KeyError."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("other_agent:\n  type: FakeAgent\n")
+
+    with pytest.raises(KeyError):
+        AgentBuilder().build(str(cfg))
+
+
+def test_module_logger_present():
+    """The module exposes a configured logger (contract check)."""
+    assert agent_builder.logger is not None


### PR DESCRIPTION
> Stacked on #600 (contract tests). Base will retarget to `main` once #600 merges.

## What

Expands the unit-test suite to cover the framework's **core paths** and **this-cycle features** that previously had **0% coverage**, in addition to the contract tests from #600. All external dependencies are mocked (HTTP, model/Ark SDK, RocketMQ, Nacos, codex subprocess) — no network, no live services.

## Modules covered (before → after coverage)

| Area | Module | Before | After |
|---|---|---:|---:|
| models | `models/ark_llm.py` | 0%* | 83% |
| models | `models/ark_embedding.py` | 0%* | 99% |
| runtime | `runtime/base_runtime.py` | 47% | 94% |
| runtime | `runtime/codex/proxy.py` | 0% | 100% |
| runtime | `runtime/codex/runtime.py` | 0% | 100% |
| runtime | `runtime/codex/translate.py` | 0% | 100% |
| a2ui | `a2ui/toolset.py` | 0% | 94% |
| a2ui | `a2ui/catalog.py` | 0% | 100% |
| builder | `agent_builder.py` | 0% | 100% |
| config | `configs/dynamic_config_manager.py` | 0% | 100% |
| memory | `memory/save_session_callback.py` | 0% | 97% |
| memory | `memory/short_term_memory_processor.py` | 0% | 100% |
| prompts | `prompts/prompt_optimization.py` | 0% | 91% |
| prompts | `prompts/prompt_manager.py` | 44% | 100% |
| reflector | `reflector/local_reflector.py` | 0% | 100% |
| core | `agent.py` | 44% | 84% |
| core | `runner.py` | 33% | 83% |
| a2a | `a2a/remote_ve_agent.py` | 0% | 98% |
| a2a | `a2a/hub/a2a_hub_server.py` | 0% | 100% |
| a2a | `a2a/hub/models.py` | 0% | 100% |
| a2a | `a2a/hub/rocketmq_middleware.py` | 0% | 100% |

\* baseline showed 0% because the existing suite never imported these modules.

## Layout

Tests mirror the package tree (google-adk style): `tests/models/`, `tests/runtime/codex/`, `tests/a2ui/`, `tests/configs/`, `tests/memory/`, `tests/prompts/`, `tests/reflector/`, `tests/a2a/hub/`, plus `tests/agent/test_agent_behavior.py` and `tests/runner/test_runner_behavior.py`.

## Verification

- `pytest`: **641 passed** (281 prior + 360 new), no regressions
- `ruff check` / `ruff format --check`: clean on all new files
- `pyright`: 0 errors on all new files (pre-existing test files' pyright errors are untouched / out of scope)
- No source files under `veadk/` were modified.

## Notes on what's intentionally left uncovered

A few branches need live services and were skipped deliberately: `prompt_optimization` MCPToolset path (needs a live async MCP toolset), `save_session_callback` broad `except` fallback, and a handful of niche media-transform branches in `ark_llm`. External-dependency backends (vikingdb/redis/opensearch/mem0/tos), `integrations/*`, `toolkits/audio`, and `cli_*` shells were out of scope for this batch.