### PR TITLE
fix(cli): `veadk agentkit` shows no subcommands on Typer ≥ 0.26

### DIFF
--- a/veadk/cli/cli_agentkit.py
+++ b/veadk/cli/cli_agentkit.py
@@ -25,6 +25,9 @@ def agentkit():
 
 agentkit_commands = get_command(agentkit_typer_app)
 
-if isinstance(agentkit_commands, click.Group):
-    for cmd_name, cmd in agentkit_commands.commands.items():
-        agentkit.add_command(cmd, name=cmd_name)
+# Re-export the AgentKit CLI's subcommands under `veadk agentkit`. Iterate by
+# duck-typing on `.commands` rather than gating on `isinstance(..., click.Group)`:
+# since Typer 0.26 a TyperGroup is no longer a click.Group subclass, so the
+# isinstance check silently evaluates False and drops every command.
+for cmd_name, cmd in getattr(agentkit_commands, "commands", {}).items():
+    agentkit.add_command(cmd, name=cmd_name)


### PR DESCRIPTION
## Symptom

`veadk agentkit --help` lists **no commands** (only `--help`) in environments with a newer Typer — every re-exported AgentKit subcommand (build/config/deploy/runtime/…) disappears.

## Root cause

`cli_agentkit.py` re-exports the AgentKit CLI's subcommands behind an `isinstance` gate:

```python
agentkit_commands = get_command(agentkit_typer_app)
if isinstance(agentkit_commands, click.Group):   # ← False on Typer ≥ 0.26
    for cmd_name, cmd in agentkit_commands.commands.items():
        agentkit.add_command(cmd, name=cmd_name)
```

Since **Typer 0.26** a `TyperGroup` is no longer a `click.Group` subclass, so the guard silently evaluates `False` and the loop never runs — the `agentkit` group ends up empty. It worked on Typer 0.21 (where the isinstance held) but breaks on 0.26.7. Unrelated to the recent harness changes; this was a latent bug the version bump exposed.

## Fix

Drop the `isinstance` gate and iterate by duck-typing on `.commands` (always present on a TyperGroup):

```python
for cmd_name, cmd in getattr(agentkit_commands, "commands", {}).items():
    agentkit.add_command(cmd, name=cmd_name)
```

## Verification

- Typer **0.21.1**: `veadk agentkit` lists all 13 commands (unchanged).
- Typer **0.26.7**: the fixed logic now yields all 14 commands (was 0).
- `ruff` + `pyright` clean; full suite green (272 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)