### PR TITLE
feat(harness): tag the AgentKit runtime with agentkit:agenttype=harness

### DIFF
--- a/veadk/cli/cli_harness.py
+++ b/veadk/cli/cli_harness.py
@@ -718,9 +718,27 @@ def deploy(
     resolved_region = region or os.getenv("VOLCENGINE_REGION") or "cn-beijing"
     cfg = _build_agentkit_config(runtime_name, resolved_region, runtime_envs, auth)
 
+    # AgentKit's launch path exposes no hook for runtime tags, so tag the runtime
+    # at creation by wrapping the SDK's create_runtime: every harness runtime is
+    # tagged `agentkit:agenttype=harness`. Scoped to this deploy and restored after.
+    from agentkit.sdk.runtime import types as _rt_types
+    from agentkit.sdk.runtime.client import AgentkitRuntimeClient as _RtClient
+
+    _orig_create_runtime = _RtClient.create_runtime
+
+    def _create_runtime_with_harness_tag(self, request):
+        request.tags = [
+            *(request.tags or []),
+            _rt_types.TagsItemForCreateRuntime.model_validate(
+                {"Key": "agentkit:agenttype", "Value": "harness"}
+            ),
+        ]
+        return _orig_create_runtime(self, request)
+
     logger.info(f"Deploying harness runtime '{runtime_name}' from {proj_dir}")
     cwd = os.getcwd()
     os.chdir(proj_dir)
+    _RtClient.create_runtime = _create_runtime_with_harness_tag
     try:
         result = sdk.launch(
             config_dict=cfg,
@@ -728,6 +746,7 @@ def deploy(
             reporter=LoggingReporter(),
         )
     finally:
+        _RtClient.create_runtime = _orig_create_runtime
         os.chdir(cwd)
 
     if not result.success:


### PR DESCRIPTION
## What

`veadk harness deploy` now tags the created AgentKit runtime with
**key `agentkit:agenttype`, value `harness`**.

## Why / how

AgentKit's launch/deploy path exposes no hook for runtime **resource tags** —
the config and `sdk.launch` only carry `image_tag` (the Docker tag), and the
runner builds `CreateRuntimeRequest` without ever setting its `tags` field
(which the model does support). So `deploy` wraps the SDK's
`AgentkitRuntimeClient.create_runtime` for the duration of the launch and
appends the tag onto the request, then restores the original method in
`finally`. The tag is set atomically at create time (no extra API call, no race
with the runtime release).

## Verification (real deploy)

- `veadk harness create → add → deploy` → runtime `r-yeoh0lauwwo2eybtivpq` (Ready).
- `veadk agentkit runtime get` →
  `Tags: [{"Key": "agentkit:agenttype", "Value": "harness"}]`.
- `veadk harness invoke` → model responds normally.
- ruff + pyright clean.

> Note: this is a workaround for the current agentkit-sdk-python (no native
> runtime-tags option). If a future SDK version exposes tags via the launch
> config, this wrap can be replaced with the native field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)