### PR TITLE
fix(examples): allow_origins so browsers can call the deployed codex agent

### DIFF
--- a/examples/codex_runtime_on_agentkit/app.py
+++ b/examples/codex_runtime_on_agentkit/app.py
@@ -34,7 +34,7 @@ PORT = int(os.getenv("PORT", "8000"))
 
 
 def build_app():
-    app = get_fast_api_app(agents_dir=AGENTS_DIR, web=False)
+    app = get_fast_api_app(agents_dir=AGENTS_DIR, allow_origins=["*"], web=False)
 
     # A simple health endpoint for the runtime's liveness checks.
     @app.get("/ping")


### PR DESCRIPTION
The `codex_runtime_on_agentkit` deploy entry called `get_fast_api_app(agents_dir=..., web=False)` **without `allow_origins`**, so ADK's web server rejected browser requests.

## Why

ADK's web server has a CSRF-style **Origin guard** (`adk_web_server.py`):

- Safe methods (GET/HEAD/OPTIONS) pass through.
- State-changing methods (POST `/run_sse`, create-session) whose `Origin` header isn't allow-listed get **403 `Forbidden: origin not allowed`**.
- Requests with **no `Origin` header** (curl, server-to-server) pass.

So the deployed agent worked from `curl` (no Origin) but the bundled web UI / any browser hit 403 on every turn (the POST carries `Origin: http://...`). The allow-list was empty because `allow_origins` wasn't passed.

## Fix

```python
app = get_fast_api_app(agents_dir=AGENTS_DIR, allow_origins=["*"], web=False)
```

`_is_origin_allowed` honors `"*"`. The API is already protected by the AgentKit gateway's Bearer key auth, so opening Origin in this demo is acceptable (tighten to specific origins for stricter setups).

## Verified on the live runtime

Redeployed to the same runtime and re-tested **with an `Origin` header** (browser simulation):

- create-session `POST .../sessions` → **200** (was 403)
- `POST /run_sse` → **200**, real answer streamed back

(One-line change to `examples/codex_runtime_on_agentkit/app.py`.)