### PR TITLE
feat(harness): surface unsupported-tool and runtime errors via an error field

### DIFF
--- a/tests/cloud/test_harness_app_contract.py
+++ b/tests/cloud/test_harness_app_contract.py
@@ -127,8 +127,10 @@ class TestRequestResponseSchemas:
 
     def test_invoke_response_fields_and_defaults(self):
         fields = _fields(InvokeHarnessResponse)
-        assert set(fields) == {"harness_name", "overwrite", "output"}
+        assert set(fields) == {"harness_name", "overwrite", "output", "error"}
         assert fields["overwrite"].default is False
+        # `error` is unset on success and carries the message verbatim on failure.
+        assert fields["error"].default is None
 
 
 class TestSplitCsv:

--- a/veadk/cloud/harness_app/app.py
+++ b/veadk/cloud/harness_app/app.py
@@ -37,7 +37,11 @@ from veadk.cloud.harness_app.types import (
     InvokeHarnessRequest,
     InvokeHarnessResponse,
 )
-from veadk.cloud.harness_app.utils import SkillLoadError, spawn_harness_agent
+from veadk.cloud.harness_app.utils import (
+    SkillLoadError,
+    ToolLoadError,
+    spawn_harness_agent,
+)
 from veadk.memory.short_term_memory import ShortTermMemory
 from veadk.runner import Runner
 from veadk.utils.logger import get_logger
@@ -89,43 +93,58 @@ class HarnessApp:
                 else RunConfig()
             )
 
-            if request.harness is not None:
-                logger.info(f"Applying once-time harness override: {request.harness}")
-                # The override clones the base agent and may download incremental
-                # skills into a temp dir; the skill files are read from disk while
-                # the agent runs, so the dir is removed (and the one-off agent +
-                # runner dropped) only after the run finishes.
-                with tempfile.TemporaryDirectory(prefix="harness_invoke_") as work_dir:
-                    try:
+            try:
+                if request.harness is not None:
+                    logger.info(
+                        f"Applying once-time harness override: {request.harness}"
+                    )
+                    # The override clones the base agent and may download incremental
+                    # skills into a temp dir; the skill files are read from disk while
+                    # the agent runs, so the dir is removed (and the one-off agent +
+                    # runner dropped) only after the run finishes.
+                    with tempfile.TemporaryDirectory(
+                        prefix="harness_invoke_"
+                    ) as work_dir:
                         agent = spawn_harness_agent(
                             self.agent, request.harness, download_dir=Path(work_dir)
                         )
-                    except SkillLoadError as e:
-                        # A once-time skill failed to load; return the reason to
-                        # the caller instead of running with a wrong skill set.
-                        logger.error(f"Once-time skill load failed: {e}")
-                        return InvokeHarnessResponse(
-                            harness_name=self.harness_name,
-                            overwrite=True,
-                            output=str(e),
+                        runner = Runner(
+                            agent=agent,
+                            short_term_memory=self.short_term_memory,
+                            app_name=self.harness_name,
                         )
-                    runner = Runner(
-                        agent=agent,
-                        short_term_memory=self.short_term_memory,
-                        app_name=self.harness_name,
-                    )
-                    output = await runner.run(
+                        output = await runner.run(
+                            messages=[request.prompt],
+                            user_id=request.run_agent_request.user_id,
+                            session_id=request.run_agent_request.session_id,
+                            run_config=run_config,
+                        )
+                else:
+                    output = await self.runner.run(
                         messages=[request.prompt],
                         user_id=request.run_agent_request.user_id,
                         session_id=request.run_agent_request.session_id,
                         run_config=run_config,
                     )
-            else:
-                output = await self.runner.run(
-                    messages=[request.prompt],
-                    user_id=request.run_agent_request.user_id,
-                    session_id=request.run_agent_request.session_id,
-                    run_config=run_config,
+            except (SkillLoadError, ToolLoadError) as e:
+                # A once-time tool/skill failed to load; return the reason to the
+                # caller instead of running with a wrong tool/skill set.
+                logger.error(f"Once-time override failed to load: {e}")
+                return InvokeHarnessResponse(
+                    harness_name=self.harness_name,
+                    overwrite=request.harness is not None,
+                    output="",
+                    error=str(e),
+                )
+            except Exception as e:
+                # Runtime (e.g. ADK) errors take many shapes; pass the message
+                # through verbatim so the caller can surface it for debugging.
+                logger.exception("Harness invocation failed")
+                return InvokeHarnessResponse(
+                    harness_name=self.harness_name,
+                    overwrite=request.harness is not None,
+                    output="",
+                    error=str(e),
                 )
 
             return InvokeHarnessResponse(

--- a/veadk/cloud/harness_app/types.py
+++ b/veadk/cloud/harness_app/types.py
@@ -103,3 +103,11 @@ class InvokeHarnessResponse(BaseModel):
     harness_name: str
     overwrite: bool = Field(default=False)
     output: str
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Error message when the invocation fails (unsupported tool, skill "
+            "load failure, or a runtime error). Passed through verbatim; `output` "
+            "is empty when set."
+        ),
+    )

--- a/veadk/cloud/harness_app/utils.py
+++ b/veadk/cloud/harness_app/utils.py
@@ -41,7 +41,7 @@ from veadk.cloud.harness_app.types import HarnessConfig, HarnessOverrides
 from veadk.knowledgebase import KnowledgeBase
 from veadk.memory.long_term_memory import LongTermMemory
 from veadk.memory.short_term_memory import ShortTermMemory
-from veadk.tools import get_builtin_tool
+from veadk.tools import get_builtin_tool, list_builtin_tools
 from veadk.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -52,10 +52,32 @@ __all__ = [
     "split_csv",
     "build_skill_toolset",
     "SkillLoadError",
+    "ToolLoadError",
     "config_from_env",
     "init_harness_agent",
     "spawn_harness_agent",
 ]
+
+
+class ToolLoadError(RuntimeError):
+    """A requested built-in tool is not supported.
+
+    Raised instead of failing with an opaque ``KeyError`` so the unsupported
+    tool name surfaces — at server startup for a base tool, or in the invoke
+    response for a per-call override.
+    """
+
+
+def _load_builtin_tool(name: str) -> Any:
+    """Resolve a built-in tool by name, raising :class:`ToolLoadError` if unknown."""
+    try:
+        return get_builtin_tool(name)
+    except KeyError as e:
+        raise ToolLoadError(
+            f"Tool '{name}' is not a supported built-in tool. "
+            f"Available: {', '.join(list_builtin_tools())}"
+        ) from e
+
 
 # Skill hub download endpoint. A skill name in a harness is the path after
 # `/download/`, e.g. "clawhub/lgwventrue/system-file-handler".
@@ -205,7 +227,7 @@ def _assemble_agent(config: HarnessConfig) -> tuple[Agent, ShortTermMemory]:
     base / long-term memory. Backend values are validated by each component's
     pydantic model (fast-fail on an unknown value).
     """
-    tools = [get_builtin_tool(name) for name in split_csv(config.tools)]
+    tools = [_load_builtin_tool(name) for name in split_csv(config.tools)]
 
     skills = split_csv(config.skills)
     if skills:
@@ -278,7 +300,7 @@ def _add_incremental_tools(agent: Agent, tool_names: list[str]) -> None:
         if name in existing:
             logger.info(f"Tool '{name}' already on the agent; skipping.")
             continue
-        agent.tools.append(get_builtin_tool(name))
+        agent.tools.append(_load_builtin_tool(name))
         existing.add(name)
 
 


### PR DESCRIPTION
## Summary

The harness `/harness/invoke` endpoint previously had two rough edges:
- An **unsupported built-in tool name** (per-call `--tools`) failed with an opaque **HTTP 500** (a bare `KeyError` from `get_builtin_tool`).
- A **failed skill load** was returned only inside `output`, indistinguishable from a normal answer.

This makes invocation errors **structured and pass-through**:

- Add **`ToolLoadError`** (`utils.py`), raised for an unsupported built-in tool name with the list of available tools. Used in both base-agent assembly and per-call incremental tool loading.
- Add an **`error` field** to `InvokeHarnessResponse` (`types.py`).
- In `/harness/invoke` (`app.py`), wrap the override/run in a `try/except`: tool/skill load failures **and** runtime (ADK) errors are caught and returned **verbatim** in `error` (`output` empty), instead of a 500. Runtime errors take many shapes, so the message is passed through unchanged for debugging.

## Behaviour

| case | before | after |
| :--- | :--- | :--- |
| unknown tool | HTTP 500 (opaque) | `200` with `error: "Tool 'x' is not a supported built-in tool. Available: …"` |
| skill load fail | error string in `output` | `error: "Skill 'x' failed to load: …"`, `output: ""` |
| runtime error | 500 | `error: "<message>"`, `output: ""` |

Backward compatible: successful runs still return `output` with `error: null`.

The AgentKit CLI (`agentkit invoke harness`) reads this `error` field and surfaces it in red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)