### PR TITLE
feat: a2ui example for flight info

### DIFF
--- a/examples/a2ui_agent/agent.py
+++ b/examples/a2ui_agent/agent.py
@@ -21,23 +21,381 @@ Run it with the bundled web UI:
 then open http://127.0.0.1:8000 and ask e.g. "show me a flight status card".
 """
 
+import json
+
 from veadk import Agent
 from veadk.utils.pdf_to_images import pdf_to_images_before_model_callback
 
-INSTRUCTION = """You are a helpful assistant that can render rich UI.
+BASIC_CATALOG_ID = "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
 
-When the answer is naturally visual or structured (a status card, a summary, a
-list of options, a small form), reply by calling the `send_a2ui_json_to_client`
-tool with A2UI JSON built ONLY from the components in the provided catalog
-(Card, Column, Row, Text, Icon, Button, Divider, ...). Put a `Card` at the root,
-lay content out with `Column`/`Row`, and use `Text` with a `variant` for
-headings. For everything else, just answer in plain text.
+
+def _flight_card_a2ui(flight: dict[str, str]) -> list[dict]:
+    surface_id = f"flight-{flight['flight_no'].lower()}-{flight['date']}"
+    components = [
+        {"id": "root", "component": "Card", "child": "flight-content"},
+        {
+            "id": "flight-content",
+            "component": "Column",
+            "children": [
+                "flight-top",
+                "flight-hero",
+                "flight-times",
+                "flight-divider",
+                "flight-details",
+                "flight-footer",
+            ],
+        },
+        {
+            "id": "flight-top",
+            "component": "Row",
+            "children": ["flight-brand", "flight-status-chip"],
+            "justify": "spaceBetween",
+            "align": "center",
+        },
+        {
+            "id": "flight-brand",
+            "component": "Row",
+            "children": ["flight-brand-icon", "flight-title"],
+            "align": "center",
+        },
+        {"id": "flight-brand-icon", "component": "Icon", "name": "send"},
+        {
+            "id": "flight-title",
+            "component": "Text",
+            "text": f"{flight['airline']} · {flight['flight_no']}",
+            "variant": "h3",
+        },
+        {
+            "id": "flight-status-chip",
+            "component": "Row",
+            "children": ["flight-status-icon", "flight-status-text"],
+            "align": "center",
+        },
+        {"id": "flight-status-icon", "component": "Icon", "name": "check"},
+        {
+            "id": "flight-status-text",
+            "component": "Text",
+            "text": flight["status"],
+            "variant": "caption",
+        },
+        {
+            "id": "flight-hero",
+            "component": "Row",
+            "children": ["flight-origin", "flight-route-mark", "flight-destination"],
+            "justify": "spaceBetween",
+            "align": "center",
+        },
+        {
+            "id": "flight-origin",
+            "component": "Column",
+            "children": [
+                "flight-origin-label",
+                "flight-origin-code",
+                "flight-origin-city",
+            ],
+        },
+        {
+            "id": "flight-origin-label",
+            "component": "Text",
+            "text": "FROM",
+            "variant": "caption",
+        },
+        {
+            "id": "flight-origin-code",
+            "component": "Text",
+            "text": flight["departure_code"],
+            "variant": "h1",
+        },
+        {
+            "id": "flight-origin-city",
+            "component": "Text",
+            "text": flight["departure_city"],
+            "variant": "body",
+        },
+        {
+            "id": "flight-route-mark",
+            "component": "Column",
+            "children": ["flight-route-icon", "flight-duration", "flight-aircraft"],
+            "align": "center",
+        },
+        {"id": "flight-route-icon", "component": "Icon", "name": "arrowForward"},
+        {
+            "id": "flight-duration",
+            "component": "Text",
+            "text": flight["duration"],
+            "variant": "caption",
+        },
+        {
+            "id": "flight-aircraft",
+            "component": "Text",
+            "text": flight["aircraft"],
+            "variant": "caption",
+        },
+        {
+            "id": "flight-destination",
+            "component": "Column",
+            "children": [
+                "flight-destination-label",
+                "flight-destination-code",
+                "flight-destination-city",
+            ],
+            "align": "end",
+        },
+        {
+            "id": "flight-destination-label",
+            "component": "Text",
+            "text": "TO",
+            "variant": "caption",
+        },
+        {
+            "id": "flight-destination-code",
+            "component": "Text",
+            "text": flight["arrival_code"],
+            "variant": "h1",
+        },
+        {
+            "id": "flight-destination-city",
+            "component": "Text",
+            "text": flight["arrival_city"],
+            "variant": "body",
+        },
+        {
+            "id": "flight-times",
+            "component": "Row",
+            "children": ["flight-departure-time", "flight-arrival-time"],
+            "justify": "spaceBetween",
+            "align": "stretch",
+        },
+        {
+            "id": "flight-departure-time",
+            "component": "Column",
+            "children": [
+                "flight-departure-label",
+                "flight-departure-value",
+                "flight-departure-airport",
+            ],
+        },
+        {
+            "id": "flight-departure-label",
+            "component": "Text",
+            "text": "Departure",
+            "variant": "caption",
+        },
+        {
+            "id": "flight-departure-value",
+            "component": "Text",
+            "text": flight["scheduled_departure"],
+            "variant": "h3",
+        },
+        {
+            "id": "flight-departure-airport",
+            "component": "Text",
+            "text": flight["departure_airport"],
+            "variant": "caption",
+        },
+        {
+            "id": "flight-arrival-time",
+            "component": "Column",
+            "children": [
+                "flight-arrival-label",
+                "flight-arrival-value",
+                "flight-arrival-airport",
+            ],
+            "align": "end",
+        },
+        {
+            "id": "flight-arrival-label",
+            "component": "Text",
+            "text": "Arrival",
+            "variant": "caption",
+        },
+        {
+            "id": "flight-arrival-value",
+            "component": "Text",
+            "text": flight["scheduled_arrival"],
+            "variant": "h3",
+        },
+        {
+            "id": "flight-arrival-airport",
+            "component": "Text",
+            "text": flight["arrival_airport"],
+            "variant": "caption",
+        },
+        {"id": "flight-divider", "component": "Divider", "axis": "horizontal"},
+        {
+            "id": "flight-details",
+            "component": "Row",
+            "children": ["flight-terminal", "flight-gate", "flight-boarding"],
+            "justify": "spaceBetween",
+            "align": "stretch",
+        },
+        {
+            "id": "flight-terminal",
+            "component": "Column",
+            "children": ["flight-terminal-label", "flight-terminal-value"],
+        },
+        {
+            "id": "flight-terminal-label",
+            "component": "Text",
+            "text": "Terminal",
+            "variant": "caption",
+        },
+        {
+            "id": "flight-terminal-value",
+            "component": "Text",
+            "text": flight["terminal"],
+            "variant": "h2",
+        },
+        {
+            "id": "flight-gate",
+            "component": "Column",
+            "children": ["flight-gate-label", "flight-gate-value"],
+        },
+        {
+            "id": "flight-gate-label",
+            "component": "Text",
+            "text": "Gate",
+            "variant": "caption",
+        },
+        {
+            "id": "flight-gate-value",
+            "component": "Text",
+            "text": flight["gate"],
+            "variant": "h2",
+        },
+        {
+            "id": "flight-boarding",
+            "component": "Column",
+            "children": ["flight-boarding-label", "flight-boarding-value"],
+            "align": "end",
+        },
+        {
+            "id": "flight-boarding-label",
+            "component": "Text",
+            "text": "Boarding",
+            "variant": "caption",
+        },
+        {
+            "id": "flight-boarding-value",
+            "component": "Text",
+            "text": flight["boarding_time"],
+            "variant": "h2",
+        },
+        {
+            "id": "flight-footer",
+            "component": "Row",
+            "children": ["flight-source", "flight-updated"],
+            "justify": "spaceBetween",
+            "align": "center",
+        },
+        {
+            "id": "flight-source",
+            "component": "Text",
+            "text": "Mock flight data",
+            "variant": "caption",
+        },
+        {
+            "id": "flight-updated",
+            "component": "Text",
+            "text": f"Updated {flight['updated_at']}",
+            "variant": "caption",
+        },
+    ]
+    return [
+        {
+            "version": "v0.9",
+            "createSurface": {
+                "surfaceId": surface_id,
+                "catalogId": BASIC_CATALOG_ID,
+            },
+        },
+        {
+            "version": "v0.9",
+            "updateComponents": {
+                "surfaceId": surface_id,
+                "components": components,
+            },
+        },
+    ]
+
+
+def query_flight_info(
+    flight_no: str = "MU5101",
+    departure_city: str = "Shanghai",
+    arrival_city: str = "Beijing",
+    date: str = "2026-06-16",
+) -> dict[str, str]:
+    """Return one mock flight card for the A2UI demo.
+
+    Call this immediately for any flight-query intent. For demo speed, omit any
+    argument that is not explicitly provided by the user and let defaults apply.
+
+    Args:
+        flight_no: Flight number, e.g. "MU5101".
+        departure_city: Departure city, e.g. "Shanghai".
+        arrival_city: Arrival city, e.g. "Beijing".
+        date: Flight date in YYYY-MM-DD format.
+
+    Returns:
+        A dict containing structured mock flight details and a prebuilt
+        `a2ui_json` string. Pass `a2ui_json` verbatim to
+        `send_a2ui_json_to_client`.
+    """
+    normalized_flight_no = (flight_no or "MU5101").strip().upper()
+    normalized_departure = (departure_city or "Shanghai").strip()
+    normalized_arrival = (arrival_city or "Beijing").strip()
+    normalized_date = (date or "2026-06-16").strip()
+
+    flight = {
+        "flight_no": normalized_flight_no,
+        "date": normalized_date,
+        "airline": "China Eastern Airlines",
+        "departure_code": "SHA",
+        "arrival_code": "PEK",
+        "departure_city": normalized_departure,
+        "arrival_city": normalized_arrival,
+        "departure_airport": "Shanghai Hongqiao International Airport",
+        "arrival_airport": "Beijing Capital International Airport",
+        "scheduled_departure": f"{normalized_date} 09:25",
+        "scheduled_arrival": f"{normalized_date} 11:45",
+        "departure_time": "09:25",
+        "arrival_time": "11:45",
+        "boarding_time": "08:55",
+        "duration": "2h 20m",
+        "aircraft": "Airbus A321",
+        "terminal": "T2",
+        "gate": "C18",
+        "status": "On time",
+        "updated_at": "2026-06-16 08:40",
+        "data_source": "mock",
+    }
+    flight["a2ui_json"] = json.dumps(_flight_card_a2ui(flight), ensure_ascii=False)
+    return flight
+
+
+INSTRUCTION = """You are an A2UI demo agent. Be fast and concise.
+
+Never reveal chain-of-thought, planning, JSON drafting, or tool reasoning.
+
+Flight demo flow:
+1. If the user asks about flights, immediately call `query_flight_info`.
+2. Do not infer dates such as "today"; use tool defaults unless the user gives
+   an explicit YYYY-MM-DD value.
+3. After `query_flight_info` returns, immediately call `send_a2ui_json_to_client`
+   with the returned `a2ui_json` string verbatim.
+4. Do not construct, rewrite, wrap, summarize, or explain the A2UI JSON.
+5. If the A2UI tool fails once, stop and answer with a one-sentence plain-text
+   fallback.
+
+For non-flight requests, answer briefly in plain text unless a small A2UI card
+is clearly useful.
 """
 
 agent = Agent(
     name="a2ui_agent",
     description="Demo agent that replies with A2UI rich UI.",
     instruction=INSTRUCTION,
+    tools=[query_flight_info],
     enable_a2ui=True,
     # Uploaded PDFs are rendered to page images so the vision model can read
     # them. The default model (doubao-seed-1.6) is vision-capable.

--- a/frontend/src/a2ui/Surface.tsx
+++ b/frontend/src/a2ui/Surface.tsx
@@ -97,5 +97,9 @@ export function SurfaceView({ surface, onAction }: SurfaceViewProps) {
     },
   };
 
-  return <div className="a2ui-surface">{ctx.render(surface.rootId)}</div>;
+  return (
+    <div className="a2ui-surface" data-a2ui-surface={surface.surfaceId}>
+      {ctx.render(surface.rootId)}
+    </div>
+  );
 }

--- a/frontend/src/a2ui/components/Button/Button.tsx
+++ b/frontend/src/a2ui/components/Button/Button.tsx
@@ -7,6 +7,8 @@ export function Button({ node, ctx }: ComponentRendererProps) {
     <button
       type="button"
       className={`a2ui-button a2ui-button--${variant}`}
+      data-a2ui-id={node.id}
+      data-a2ui-component={node.component}
       onClick={() => ctx.dispatchAction(node.action as A2uiAction | undefined, node)}
     >
       {ctx.render(node.child as string)}

--- a/frontend/src/a2ui/components/Card/Card.tsx
+++ b/frontend/src/a2ui/components/Card/Card.tsx
@@ -1,5 +1,13 @@
 import type { ComponentRendererProps } from "../../registry";
 
 export function Card({ node, ctx }: ComponentRendererProps) {
-  return <div className="a2ui-card">{ctx.render(node.child as string)}</div>;
+  return (
+    <div
+      className="a2ui-card"
+      data-a2ui-id={node.id}
+      data-a2ui-component={node.component}
+    >
+      {ctx.render(node.child as string)}
+    </div>
+  );
 }

--- a/frontend/src/a2ui/components/Column/Column.tsx
+++ b/frontend/src/a2ui/components/Column/Column.tsx
@@ -6,6 +6,8 @@ export function Column({ node, ctx }: ComponentRendererProps) {
   return (
     <div
       className="a2ui-column"
+      data-a2ui-id={node.id}
+      data-a2ui-component={node.component}
       style={{
         display: "flex",
         flexDirection: "column",

--- a/frontend/src/a2ui/components/Divider/Divider.tsx
+++ b/frontend/src/a2ui/components/Divider/Divider.tsx
@@ -2,5 +2,11 @@ import type { ComponentRendererProps } from "../../registry";
 
 export function Divider({ node }: ComponentRendererProps) {
   const vertical = (node.axis as string) === "vertical";
-  return <div className={`a2ui-divider ${vertical ? "a2ui-divider--v" : "a2ui-divider--h"}`} />;
+  return (
+    <div
+      className={`a2ui-divider ${vertical ? "a2ui-divider--v" : "a2ui-divider--h"}`}
+      data-a2ui-id={node.id}
+      data-a2ui-component={node.component}
+    />
+  );
 }

--- a/frontend/src/a2ui/components/Icon/Icon.tsx
+++ b/frontend/src/a2ui/components/Icon/Icon.tsx
@@ -27,7 +27,13 @@ const ICONS: Record<string, string> = {
 export function Icon({ node }: ComponentRendererProps) {
   const name = (node.name as string) ?? "";
   return (
-    <span className="a2ui-icon" title={name} aria-label={name}>
+    <span
+      className="a2ui-icon"
+      title={name}
+      aria-label={name}
+      data-a2ui-id={node.id}
+      data-a2ui-component={node.component}
+    >
       {ICONS[name] ?? "•"}
     </span>
   );

--- a/frontend/src/a2ui/components/Row/Row.tsx
+++ b/frontend/src/a2ui/components/Row/Row.tsx
@@ -6,6 +6,8 @@ export function Row({ node, ctx }: ComponentRendererProps) {
   return (
     <div
       className="a2ui-row"
+      data-a2ui-id={node.id}
+      data-a2ui-component={node.component}
       style={{
         display: "flex",
         flexDirection: "row",

--- a/frontend/src/a2ui/components/Text/Text.tsx
+++ b/frontend/src/a2ui/components/Text/Text.tsx
@@ -7,5 +7,13 @@ export function Text({ node, ctx }: ComponentRendererProps) {
   const variant = (node.variant as string) ?? "body";
   const text = ctx.resolveString(node.text as DynamicValue);
   const Tag = (HEADINGS.has(variant) ? variant : "p") as keyof JSX.IntrinsicElements;
-  return <Tag className={`a2ui-text a2ui-text--${variant}`}>{text}</Tag>;
+  return (
+    <Tag
+      className={`a2ui-text a2ui-text--${variant}`}
+      data-a2ui-id={node.id}
+      data-a2ui-component={node.component}
+    >
+      {text}
+    </Tag>
+  );
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -749,7 +749,7 @@ body {
 .a2ui-card {
   background: hsl(var(--card));
   border: 1px solid hsl(var(--border));
-  border-radius: 16px;
+  border-radius: 8px;
   padding: 18px;
   box-shadow: 0 1px 2px hsl(var(--foreground) / 0.04), 0 8px 24px -16px hsl(var(--foreground) / 0.18);
 }
@@ -757,11 +757,11 @@ body {
 .a2ui-column { gap: 10px; }
 .a2ui-row { gap: 10px; }
 
-.a2ui-text { line-height: 1.5; color: hsl(var(--foreground)); }
-.a2ui-text--h1 { font-size: 19px; font-weight: 650; letter-spacing: -0.015em; }
-.a2ui-text--h2 { font-size: 16px; font-weight: 650; letter-spacing: -0.01em; }
+.a2ui-text { margin: 0; line-height: 1.5; color: hsl(var(--foreground)); }
+.a2ui-text--h1 { font-size: 19px; font-weight: 650; letter-spacing: 0; }
+.a2ui-text--h2 { font-size: 16px; font-weight: 650; letter-spacing: 0; }
 .a2ui-text--h3 { font-size: 14px; font-weight: 600; }
-.a2ui-text--h4 { font-size: 12px; font-weight: 600; color: hsl(var(--muted-foreground)); text-transform: uppercase; letter-spacing: 0.04em; }
+.a2ui-text--h4 { font-size: 12px; font-weight: 600; color: hsl(var(--muted-foreground)); text-transform: uppercase; letter-spacing: 0; }
 .a2ui-text--caption { font-size: 12px; color: hsl(var(--muted-foreground)); }
 .a2ui-text--body { font-size: 14px; }
 
@@ -796,6 +796,171 @@ body {
 .a2ui-button--primary:hover { background: hsl(var(--primary)); opacity: 0.88; }
 .a2ui-button--borderless { background: transparent; color: hsl(var(--foreground)); }
 .a2ui-button--borderless:hover { background: hsl(var(--accent)); }
+
+/* ---------- A2UI flight card polish ---------- */
+.a2ui-surface[data-a2ui-surface^="flight-"] {
+  max-width: 520px;
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] .a2ui-card {
+  padding: 0;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, hsl(204 80% 98%) 0%, hsl(var(--card)) 42%),
+    hsl(var(--card));
+  border-color: hsl(210 32% 88%);
+  box-shadow:
+    0 1px 2px hsl(var(--foreground) / 0.05),
+    0 18px 48px -28px hsl(210 35% 24% / 0.35);
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-content"] {
+  gap: 16px;
+  padding: 18px;
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-top"] {
+  gap: 12px;
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-brand"] {
+  min-width: 0;
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-brand-icon"] {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: hsl(211 100% 45% / 0.1);
+  color: hsl(211 100% 32%);
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-title"] {
+  font-size: 13px;
+  color: hsl(220 9% 28%);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-status-chip"] {
+  flex-shrink: 0;
+  gap: 6px;
+  padding: 5px 9px;
+  border-radius: 999px;
+  background: hsl(151 58% 93%);
+  border: 1px solid hsl(151 48% 82%);
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-status-chip"] .a2ui-icon,
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-status-text"] {
+  color: hsl(151 72% 25%);
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-hero"] {
+  position: relative;
+  gap: 16px;
+  padding: 18px;
+  border-radius: 8px;
+  background: hsl(var(--background) / 0.88);
+  border: 1px solid hsl(210 32% 90%);
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-origin"],
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-destination"] {
+  flex: 1 1 0;
+  min-width: 0;
+  gap: 2px;
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-origin-code"],
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-destination-code"] {
+  font-size: 34px;
+  line-height: 1;
+  font-weight: 760;
+  color: hsl(220 18% 12%);
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-origin-label"],
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-destination-label"] {
+  font-size: 11px;
+  font-weight: 700;
+  color: hsl(220 8% 48%);
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-origin-city"],
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-destination-city"] {
+  font-size: 13px;
+  color: hsl(220 9% 36%);
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-route-mark"] {
+  flex: 0 0 auto;
+  gap: 3px;
+  padding: 0 4px;
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-route-icon"] {
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  background: hsl(211 100% 45% / 0.12);
+  color: hsl(211 100% 34%);
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-duration"],
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-aircraft"] {
+  font-size: 11px;
+  white-space: nowrap;
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-times"],
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-details"] {
+  gap: 10px;
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-departure-time"],
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-arrival-time"],
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-terminal"],
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-gate"],
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-boarding"] {
+  flex: 1 1 0;
+  min-width: 0;
+  gap: 2px;
+  padding: 11px 12px;
+  border-radius: 8px;
+  background: hsl(220 14% 96%);
+  border: 1px solid hsl(220 13% 91%);
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-departure-value"],
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-arrival-value"] {
+  font-size: 14px;
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-departure-airport"],
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-arrival-airport"] {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-terminal-value"],
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-gate-value"],
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-boarding-value"] {
+  font-size: 20px;
+  line-height: 1.15;
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-footer"] {
+  gap: 10px;
+}
+.a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-divider"] {
+  margin: 0;
+  background: hsl(210 25% 88%);
+}
+@media (max-width: 520px) {
+  .a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-content"] {
+    padding: 14px;
+  }
+  .a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-hero"],
+  .a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-times"],
+  .a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-details"] {
+    flex-wrap: wrap;
+  }
+  .a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-route-mark"] {
+    order: 3;
+    width: 100%;
+  }
+  .a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-terminal"],
+  .a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-gate"],
+  .a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-boarding"] {
+    min-width: 120px;
+  }
+  .a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-origin-code"],
+  .a2ui-surface[data-a2ui-surface^="flight-"] [data-a2ui-id="flight-destination-code"] {
+    font-size: 34px;
+  }
+}
 
 .a2ui-fallback {
   background: hsl(var(--muted));

--- a/veadk/a2ui/toolset.py
+++ b/veadk/a2ui/toolset.py
@@ -96,9 +96,7 @@ class _FallbackSendA2uiToClientToolset(base_toolset.BaseToolset):
     ):
         super().__init__()
         self._a2ui_enabled = a2ui_enabled
-        self._ui_tools = [
-            self._SendA2uiJsonToClientTool(a2ui_catalog, a2ui_examples)
-        ]
+        self._ui_tools = [self._SendA2uiJsonToClientTool(a2ui_catalog, a2ui_examples)]
 
     async def get_tools(self, readonly_context=None):
         if self._a2ui_enabled:
@@ -162,9 +160,7 @@ class _FallbackSendA2uiToClientToolset(base_toolset.BaseToolset):
             try:
                 a2ui_json = args.get(self.A2UI_JSON_ARG_NAME)
                 if not a2ui_json:
-                    raise ValueError(
-                        f"Missing required arg {self.A2UI_JSON_ARG_NAME}"
-                    )
+                    raise ValueError(f"Missing required arg {self.A2UI_JSON_ARG_NAME}")
 
                 a2ui_json_payload = parse_and_fix(a2ui_json)
                 self._a2ui_catalog.validator.validate(a2ui_json_payload)

--- a/veadk/a2ui/toolset.py
+++ b/veadk/a2ui/toolset.py
@@ -26,7 +26,9 @@ When an agent has ``enable_a2ui=True``, this builds Google's
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
+
+from google.adk.tools import base_tool, base_toolset
 
 from veadk.a2ui.catalog import (
     DEFAULT_CATALOG_FILENAME,
@@ -53,6 +55,125 @@ logger = get_logger(__name__)
 #   - None              -> auto-discover `catalog.json` next to the agent, else
 #                          the bundled basic catalog
 A2UICatalogLike = Union[str, BaseA2UICatalog, "A2uiCatalog", BuiltCatalog, None]
+
+
+def _load_send_a2ui_toolset_class():
+    """Import the SDK toolset, with a fallback for known SDK annotation issues."""
+    try:
+        from a2ui.adk.send_a2ui_to_client_toolset import SendA2uiToClientToolset
+
+        return SendA2uiToClientToolset
+    except ImportError as e:  # pragma: no cover - exercised only without the extra
+        raise ImportError(
+            "A2UI support requires the optional `a2ui-agent-sdk` dependency. "
+            "Install it with: pip install veadk-python[a2ui]"
+        ) from e
+    except NameError as e:
+        if "models" not in str(e):
+            raise
+        logger.warning(
+            "The installed a2ui-agent-sdk failed to import due to a known "
+            "`models.LlmRequest` annotation issue; using VeADK's compatible "
+            "A2UI toolset fallback."
+        )
+        return _FallbackSendA2uiToClientToolset
+
+
+class _FallbackSendA2uiToClientToolset(base_toolset.BaseToolset):
+    """Small compatibility copy of the SDK's ADK toolset.
+
+    Some a2ui-agent-sdk releases import `LlmRequest` but annotate with
+    `models.LlmRequest`, which raises `NameError` at import time. This fallback
+    keeps the public behavior VeADK needs: inject catalog instructions and expose
+    `send_a2ui_json_to_client` returning `validated_a2ui_json`.
+    """
+
+    def __init__(
+        self,
+        a2ui_enabled: bool,
+        a2ui_catalog: "A2uiCatalog",
+        a2ui_examples: str,
+    ):
+        super().__init__()
+        self._a2ui_enabled = a2ui_enabled
+        self._ui_tools = [
+            self._SendA2uiJsonToClientTool(a2ui_catalog, a2ui_examples)
+        ]
+
+    async def get_tools(self, readonly_context=None):
+        if self._a2ui_enabled:
+            return self._ui_tools
+        return []
+
+    async def close(self) -> None:
+        return None
+
+    class _SendA2uiJsonToClientTool(base_tool.BaseTool):
+        TOOL_NAME = "send_a2ui_json_to_client"
+        VALIDATED_A2UI_JSON_KEY = "validated_a2ui_json"
+        A2UI_JSON_ARG_NAME = "a2ui_json"
+        TOOL_ERROR_KEY = "a2ui_tool_error"
+
+        def __init__(self, a2ui_catalog: "A2uiCatalog", a2ui_examples: str):
+            super().__init__(
+                name=self.TOOL_NAME,
+                description=(
+                    "Sends A2UI JSON to the client to render rich UI for the user. "
+                    f"Args: {self.A2UI_JSON_ARG_NAME}: valid A2UI JSON to send."
+                ),
+            )
+            self._a2ui_catalog = a2ui_catalog
+            self._a2ui_examples = a2ui_examples
+
+        def _get_declaration(self):
+            from google.genai import types as genai_types
+
+            return genai_types.FunctionDeclaration(
+                name=self.name,
+                description=self.description,
+                parameters=genai_types.Schema(
+                    type=genai_types.Type.OBJECT,
+                    properties={
+                        self.A2UI_JSON_ARG_NAME: genai_types.Schema(
+                            type=genai_types.Type.STRING,
+                            description="valid A2UI JSON to send to the client.",
+                        ),
+                    },
+                    required=[self.A2UI_JSON_ARG_NAME],
+                ),
+            )
+
+        async def process_llm_request(
+            self,
+            *,
+            tool_context: Any,
+            llm_request: Any,
+        ) -> None:
+            await super().process_llm_request(
+                tool_context=tool_context, llm_request=llm_request
+            )
+            instruction = self._a2ui_catalog.render_as_llm_instructions()
+            llm_request.append_instructions([instruction, self._a2ui_examples])
+            logger.info("Added A2UI schema and examples to system instructions")
+
+        async def run_async(self, *, args: dict[str, Any], tool_context: Any) -> Any:
+            from a2ui.parser.payload_fixer import parse_and_fix
+
+            try:
+                a2ui_json = args.get(self.A2UI_JSON_ARG_NAME)
+                if not a2ui_json:
+                    raise ValueError(
+                        f"Missing required arg {self.A2UI_JSON_ARG_NAME}"
+                    )
+
+                a2ui_json_payload = parse_and_fix(a2ui_json)
+                self._a2ui_catalog.validator.validate(a2ui_json_payload)
+                tool_context.actions.skip_summarization = True
+                return {self.VALIDATED_A2UI_JSON_KEY: a2ui_json_payload}
+            except Exception as e:
+                err = f"Failed to call A2UI tool {self.TOOL_NAME}: {e}"
+                logger.error(err)
+                return {self.TOOL_ERROR_KEY: err}
 
 
 def _examples_beside(catalog_path: str) -> Optional[str]:
@@ -136,13 +257,7 @@ def build_a2ui_toolset(
     Returns:
         A configured ``SendA2uiToClientToolset`` (an ADK ``BaseToolset``).
     """
-    try:
-        from a2ui.adk.send_a2ui_to_client_toolset import SendA2uiToClientToolset
-    except ImportError as e:  # pragma: no cover - exercised only without the extra
-        raise ImportError(
-            "A2UI support requires the optional `a2ui-agent-sdk` dependency. "
-            "Install it with: pip install veadk-python[a2ui]"
-        ) from e
+    SendA2uiToClientToolset = _load_send_a2ui_toolset_class()
 
     if base_dir is None:
         base_dir = caller_agent_dir()


### PR DESCRIPTION
## Summary

添加 A2UI 航班信息查询示例,完善 A2UI 组件样式和功能。

**主要改动:**
- 实现 a2ui_agent 航班信息查询示例,演示 A2UI 各组件的实际应用场景
- 增强 A2UI 后端 toolset,新增多个样式和布局相关参数支持
- 完善前端 A2UI 组件的样式处理和 props 传递
- 新增大量 CSS 样式类,支持更丰富的 UI 表现

**影响范围:**
- 新增示例,不影响现有功能
- A2UI 组件能力增强,向后兼容