### PR TITLE
feat(harness): add agent harness sdk and runtime plugins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ eval = [
     "deepeval>=3.2.6",              # For DeepEval-based evaluation
     "google-adk[eval]",             # For Google ADK-based evaluation
 ]
+harness = [
+    "headroom",
+]
 cli = []
 dev = [
     "pre-commit>=4.2.0",            # Format checking

--- a/tests/cli/test_cli_agentkit_harness_invoke.py
+++ b/tests/cli/test_cli_agentkit_harness_invoke.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from click.testing import CliRunner
+
+from veadk.cli.cli_agentkit import agentkit
+
+
+class _FakeResponse:
+    status_code = 200
+    text = "{}"
+
+    def json(self) -> dict[str, str]:
+        return {"output": "ok"}
+
+
+def test_agentkit_invoke_maps_harness_enhance_flags(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    def fake_post(
+        url: str,
+        *,
+        json: dict[str, object],
+        headers: dict[str, str],
+        timeout: int,
+    ) -> _FakeResponse:
+        calls.append(
+            {
+                "url": url,
+                "json": json,
+                "headers": headers,
+                "timeout": timeout,
+            }
+        )
+        return _FakeResponse()
+
+    monkeypatch.setattr("httpx.post", fake_post)
+
+    result = CliRunner().invoke(
+        agentkit,
+        [
+            "invoke",
+            "--endpoint",
+            "http://127.0.0.1:8000",
+            "--apikey",
+            "test-key",
+            "--harness",
+            "paper-researcher",
+            "--user-id",
+            "u1",
+            "--session-id",
+            "s1",
+            "--model-id",
+            "model-a",
+            "--tools",
+            "run_code",
+            "--enable-harness-enhance",
+            "--harness-components",
+            "context_engine,compressor",
+            "--harness-profile",
+            "research",
+            "--harness-compression-provider",
+            "headroom",
+            "find best model",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert result.output.strip() == "ok"
+    assert calls[0]["url"] == "http://127.0.0.1:8000/harness/invoke"
+    body = calls[0]["json"]
+    headers = calls[0]["headers"]
+    assert body["prompt"] == "find best model"
+    assert body["harness_name"] == "paper-researcher"
+    assert body["run_agent_request"] == {"user_id": "u1", "session_id": "s1"}
+    assert body["harness"] == {"model_name": "model-a", "tools": "run_code"}
+    assert body["harness_enhance"] == {
+        "enabled": True,
+        "components": "context_engine,compressor",
+        "profile": "research",
+        "compression_provider": "headroom",
+    }
+    assert headers["Authorization"] == "Bearer test-key"
+    assert headers["X-Harness-Enhance"] == "true"
+    assert headers["X-Harness-Components"] == "context_engine,compressor"
+    assert headers["X-Harness-Profile"] == "research"
+    assert headers["X-Harness-Compression-Provider"] == "headroom"
+    assert "X-Harness-Compression-Base-Url" not in headers
+    assert "X-Harness-Max-Tool-Result-Chars" not in headers
+    assert "X-Harness-Verifier-Mode" not in headers

--- a/tests/cli/test_cli_harness_open_source_defaults.py
+++ b/tests/cli/test_cli_harness_open_source_defaults.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from click.testing import CliRunner
+
+from veadk.cli import cli_harness
+
+
+def test_harness_create_writes_gitignore_for_local_credentials() -> None:
+    runner = CliRunner()
+
+    with runner.isolated_filesystem() as temp_dir:
+        result = runner.invoke(cli_harness.harness, ["create", "my-harness"])
+
+        assert result.exit_code == 0
+        harness_dir = Path(temp_dir) / "my-harness"
+        gitignore = harness_dir / ".gitignore"
+        assert gitignore.is_file()
+        content = gitignore.read_text()
+        assert ".env" in content
+        assert "!.env.example" in content
+        assert "harness.json" in content
+        assert "agentkit*.yaml" in content
+
+
+def test_harness_dockerfile_uses_accelerated_source_with_official_fallback() -> None:
+    assert (
+        "https://ghfast.top/https://github.com/volcengine/veadk-python.git"
+        in cli_harness._DOCKERFILE
+    )
+    assert "https://github.com/volcengine/veadk-python.git" in cli_harness._DOCKERFILE
+    assert '"./src[harness]"' in cli_harness._DOCKERFILE
+    old_package_path = "packages/" + "agentkit" + "-harness-python"
+    assert old_package_path not in cli_harness._DOCKERFILE
+
+
+def test_harness_deploy_does_not_print_runtime_api_key(monkeypatch) -> None:
+    runtime_key = "placeholder-runtime-key"
+
+    def fake_launch(**_: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            success=True,
+            error=None,
+            deploy_result=SimpleNamespace(
+                endpoint_url="https://example.invalid/runtime",
+                metadata={
+                    "runtime_id": "runtime-id",
+                    "runtime_apikey": runtime_key,
+                },
+            ),
+        )
+
+    monkeypatch.setattr("agentkit.toolkit.sdk.launch", fake_launch)
+    monkeypatch.setenv("VOLC_ACCESSKEY", "test-access-key")
+    monkeypatch.setenv("VOLC_SECRETKEY", "placeholder-credential")
+
+    runner = CliRunner()
+    with runner.isolated_filesystem() as temp_dir:
+        harness_dir = Path(temp_dir)
+        (harness_dir / "harness.yaml").write_text("harness_name: test-harness\n")
+
+        result = runner.invoke(
+            cli_harness.harness,
+            ["deploy", "--path", str(harness_dir)],
+        )
+
+        assert result.exit_code == 0
+        assert runtime_key not in result.output
+        assert "saved in local harness.json (not printed)" in result.output
+
+        record = cli_harness._load_harness_json(str(harness_dir))
+        assert record["test-harness"]["key"] == runtime_key

--- a/tests/cloud/test_harness_app_contract.py
+++ b/tests/cloud/test_harness_app_contract.py
@@ -25,10 +25,15 @@ import time, so it is intentionally left out to keep these tests offline.
 """
 
 from veadk.cloud.harness_app.types import (
+    HarnessCompactionMetric,
     HarnessConfig,
+    HarnessEnhanceOverrides,
     HarnessOverrides,
+    HarnessPluginMetrics,
+    HarnessResponseMetrics,
     InvokeHarnessRequest,
     InvokeHarnessResponse,
+    LlmUsageMetrics,
     RunAgentRequest,
 )
 from veadk.cloud.harness_app.utils import split_csv
@@ -110,11 +115,20 @@ class TestRequestResponseSchemas:
             "max_llm_calls",
         }
 
+    def test_enhance_override_defaults(self):
+        assert HarnessEnhanceOverrides().model_dump() == {
+            "enabled": False,
+            "components": "invocation_context,compactor,response_verification",
+            "profile": "default",
+            "compression_provider": None,
+        }
+
     def test_invoke_request_fields(self):
         assert set(_fields(InvokeHarnessRequest)) == {
             "prompt",
             "harness_name",
             "harness",
+            "harness_enhance",
             "run_agent_request",
         }
 
@@ -127,10 +141,68 @@ class TestRequestResponseSchemas:
 
     def test_invoke_response_fields_and_defaults(self):
         fields = _fields(InvokeHarnessResponse)
-        assert set(fields) == {"harness_name", "overwrite", "output", "error"}
+        assert set(fields) == {
+            "harness_name",
+            "overwrite",
+            "output",
+            "metrics",
+            "error",
+        }
         assert fields["overwrite"].default is False
+        assert fields["metrics"].default is None
         # `error` is unset on success and carries the message verbatim on failure.
         assert fields["error"].default is None
+
+    def test_usage_metrics_accumulate(self):
+        usage = LlmUsageMetrics(prompt_tokens=10, total_tokens=12, usage_event_count=1)
+        usage.add(
+            LlmUsageMetrics(
+                prompt_tokens=20,
+                completion_tokens=5,
+                total_tokens=25,
+                cached_tokens=3,
+                usage_event_count=1,
+            )
+        )
+
+        assert HarnessResponseMetrics(llm_usage=usage).model_dump() == {
+            "llm_usage": {
+                "prompt_tokens": 30,
+                "completion_tokens": 5,
+                "total_tokens": 37,
+                "cached_tokens": 3,
+                "usage_event_count": 2,
+            },
+            "harness_plugins": {
+                "names": [],
+                "compaction_reports": [],
+            },
+        }
+
+    def test_harness_plugin_metrics_are_structured(self):
+        metrics = HarnessResponseMetrics(
+            harness_plugins=HarnessPluginMetrics(
+                names=["harness_compress_plugin"],
+                compaction_reports=[
+                    HarnessCompactionMetric(
+                        provider="builtin",
+                        original_chars=8000,
+                        compressed_chars=400,
+                        changed=True,
+                        tokens_before=2000,
+                        tokens_after=100,
+                        tokens_saved=1900,
+                        compression_ratio=0.05,
+                        transforms_applied=["builtin_tool_fact_compaction"],
+                    )
+                ],
+            )
+        )
+
+        report = metrics.harness_plugins.compaction_reports[0]
+        assert metrics.harness_plugins.names == ["harness_compress_plugin"]
+        assert report.changed is True
+        assert report.compressed_chars < report.original_chars
 
 
 class TestSplitCsv:

--- a/tests/cloud/test_harness_enhance_env.py
+++ b/tests/cloud/test_harness_enhance_env.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from veadk.cloud.harness_app.env_mapping import to_runtime_env
+
+
+def test_harness_enhance_config_flattens_to_runtime_env():
+    env = to_runtime_env(
+        {
+            "harness_enhance": {
+                "enabled": True,
+                "components": ["invocation_context", "compactor"],
+                "profile": "analysis",
+                "compression_provider": "heuristic",
+                "max_context_chars": 12000,
+                "max_tool_result_chars": 3000,
+                "verifier_mode": "observe",
+            }
+        }
+    )
+
+    assert env["HARNESS_ENHANCE_ENABLED"] == "true"
+    assert env["HARNESS_ENHANCE_COMPONENTS"] == "invocation_context,compactor"
+    assert env["HARNESS_ENHANCE_PROFILE"] == "analysis"
+    assert env["HARNESS_ENHANCE_COMPRESSION_PROVIDER"] == "heuristic"
+    assert env["HARNESS_ENHANCE_MAX_CONTEXT_CHARS"] == "12000"
+    assert env["HARNESS_ENHANCE_MAX_TOOL_RESULT_CHARS"] == "3000"
+    assert env["HARNESS_ENHANCE_VERIFIER_MODE"] == "observe"
+    assert env["HARNESS_COMPONENTS"] == "invocation_context,compactor"
+    assert env["HARNESS_PROFILE"] == "analysis"
+    assert env["HARNESS_COMPRESSION_PROVIDER"] == "heuristic"
+    assert env["HARNESS_MAX_CONTEXT_CHARS"] == "12000"
+    assert env["HARNESS_MAX_TOOL_RESULT_CHARS"] == "3000"
+    assert env["HARNESS_VERIFIER_MODE"] == "observe"

--- a/tests/cloud/test_harness_plugins.py
+++ b/tests/cloud/test_harness_plugins.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from veadk.cloud.harness_app.harness_plugins import (
+    build_harness_plugins_from_enhance,
+    build_harness_plugins_from_headers,
+    harness_env_from_enhance,
+    harness_env_from_headers,
+)
+from veadk.cloud.harness_app.types import HarnessEnhanceOverrides
+
+
+def test_harness_env_from_headers_maps_agentkit_headers():
+    env = harness_env_from_headers(
+        {
+            "X-Harness-Enable-Context": "true",
+            "X-Harness-Components": "invocation_context,response_verification",
+            "X-Harness-Profile": "analysis",
+            "X-Harness-Compression-Provider": "headroom",
+        }
+    )
+
+    assert env == {
+        "HARNESS_ENHANCE_ENABLED": "true",
+        "HARNESS_COMPONENTS": "invocation_context,response_verification",
+        "HARNESS_ENHANCE_COMPONENTS": "invocation_context,response_verification",
+        "HARNESS_PROFILE": "analysis",
+        "HARNESS_ENHANCE_PROFILE": "analysis",
+        "HARNESS_COMPRESSION_PROVIDER": "headroom",
+        "HARNESS_ENHANCE_COMPRESSION_PROVIDER": "headroom",
+    }
+
+
+def test_build_harness_plugins_from_headers_returns_empty_when_disabled():
+    assert build_harness_plugins_from_headers({}) == []
+
+
+def test_harness_env_from_enhance_maps_request_body_config():
+    env = harness_env_from_enhance(
+        HarnessEnhanceOverrides(
+            enabled=True,
+            components="invocation_context,compactor",
+            profile="analysis",
+            compression_provider="builtin",
+        )
+    )
+
+    assert env == {
+        "HARNESS_ENHANCE_ENABLED": "true",
+        "HARNESS_COMPONENTS": "invocation_context,compactor",
+        "HARNESS_ENHANCE_COMPONENTS": "invocation_context,compactor",
+        "HARNESS_PROFILE": "analysis",
+        "HARNESS_ENHANCE_PROFILE": "analysis",
+        "HARNESS_COMPRESSION_PROVIDER": "builtin",
+        "HARNESS_ENHANCE_COMPRESSION_PROVIDER": "builtin",
+    }
+
+
+def test_build_harness_plugins_from_enhance_returns_empty_when_disabled():
+    assert build_harness_plugins_from_enhance(HarnessEnhanceOverrides()) == []

--- a/tests/extensions/harness/golden/compressor_cases.jsonl
+++ b/tests/extensions/harness/golden/compressor_cases.jsonl
@@ -1,0 +1,1 @@
+{"name":"large_tool_result_saving","input":{"old_tool_chars":5000,"latest_tool":"latest status: complete"},"expected":{"min_saving_ratio":0.5,"latest_tool_retained":true}}

--- a/tests/extensions/harness/golden/context_engine_cases.jsonl
+++ b/tests/extensions/harness/golden/context_engine_cases.jsonl
@@ -1,0 +1,1 @@
+{"name":"chart_task_anchor","input":{"goal":"Create a chart from the CSV data","user_input":"Please plot this CSV file."},"expected":{"contains":["[Harness Context]","task_goal: Create a chart from the CSV data","[Harness Artifact Mode]"]}}

--- a/tests/extensions/harness/golden/plugin_lifecycle_cases.jsonl
+++ b/tests/extensions/harness/golden/plugin_lifecycle_cases.jsonl
@@ -1,0 +1,1 @@
+{"name":"default_plugin_order","input":{"components":"invocation_context,compactor,response_verification"},"expected":{"plugins":["harness_invocation_context_plugin","harness_compress_plugin","harness_response_verification_plugin"]}}

--- a/tests/extensions/harness/golden/verifier_cases.jsonl
+++ b/tests/extensions/harness/golden/verifier_cases.jsonl
@@ -1,0 +1,1 @@
+{"name":"unsupported_completion_claim","input":{"answer":"Done, I created the report.","receipts":[]},"expected":{"status":"fail"}}

--- a/tests/extensions/harness/test_adk_plugins.py
+++ b/tests/extensions/harness/test_adk_plugins.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from types import SimpleNamespace
+
+from google.adk.models import LlmRequest, LlmResponse
+from google.genai import types
+
+from veadk.extensions.harness.adk import (
+    HarnessCompressPlugin,
+    HarnessInvocationContextPlugin,
+    HarnessResponseVerificationPlugin,
+    build_harness_plugins,
+)
+from veadk.extensions.harness.modules.final_response_verifier import (
+    FinalResponseVerifier,
+    FinalResponseVerifierConfig,
+)
+from veadk.extensions.harness.modules.tool_result_compactor import (
+    ToolResultCompactor,
+    ToolResultCompactorConfig,
+)
+from veadk.extensions.harness.stores import InMemoryHarnessStore
+
+
+def _callback_context():
+    return SimpleNamespace(
+        session=SimpleNamespace(id="s1", app_name="app", user_id="u1"),
+        user_id="u1",
+        invocation_id="r1",
+        user_content=types.Content(
+            role="user", parts=[types.Part(text="Create a report")]
+        ),
+    )
+
+
+def _tool_context():
+    return SimpleNamespace(
+        session=SimpleNamespace(id="s1", app_name="app", user_id="u1"),
+        user_id="u1",
+        invocation_id="r1",
+    )
+
+
+def test_context_plugin_appends_system_instruction():
+    plugin = HarnessInvocationContextPlugin(store=InMemoryHarnessStore())
+    request = LlmRequest(
+        contents=[
+            types.Content(role="user", parts=[types.Part(text="Create a report")])
+        ]
+    )
+
+    asyncio.run(
+        plugin.before_model_callback(
+            callback_context=_callback_context(),
+            llm_request=request,
+        )
+    )
+
+    assert "[Harness Context]" in str(request.config.system_instruction)
+
+
+def test_compress_plugin_replaces_large_tool_result():
+    plugin = HarnessCompressPlugin(
+        compressor=ToolResultCompactor(
+            ToolResultCompactorConfig(max_tool_result_chars=1000)
+        ),
+        store=InMemoryHarnessStore(),
+    )
+
+    result = asyncio.run(
+        plugin.after_tool_callback(
+            tool=SimpleNamespace(name="query_data"),
+            tool_args={},
+            tool_context=_tool_context(),
+            result={"rows": "x" * 8000},
+        )
+    )
+
+    assert result is not None
+    assert result["harness_compressed"] is True
+    assert plugin.compaction_reports
+    assert plugin.compaction_reports[0].compressed_chars < 8000
+
+
+def test_compress_plugin_compacts_model_context_function_responses():
+    plugin = HarnessCompressPlugin(
+        compactor=ToolResultCompactor(
+            ToolResultCompactorConfig(max_tool_result_chars=1000)
+        ),
+        store=InMemoryHarnessStore(),
+    )
+    request = LlmRequest(
+        contents=[
+            types.Content(
+                role="user",
+                parts=[
+                    types.Part.from_function_response(
+                        name="run_code",
+                        response={
+                            "result": (
+                                '[{"kind":"metric","model":"T5","accuracy":88},'
+                                '{"kind":"debug","payload":"' + ("x" * 8000) + '"}]'
+                            )
+                        },
+                    )
+                ],
+            )
+        ]
+    )
+
+    asyncio.run(
+        plugin.before_model_callback(
+            callback_context=_callback_context(),
+            llm_request=request,
+        )
+    )
+
+    response = request.contents[0].parts[0].function_response.response
+    assert response["harness_compressed"] is True
+    assert "model=T5" in str(response["summary"])
+    assert "payload" not in str(response["summary"])
+    assert plugin.compaction_reports
+
+
+def test_compress_plugin_resets_diagnostics():
+    plugin = HarnessCompressPlugin(
+        compactor=ToolResultCompactor(
+            ToolResultCompactorConfig(max_tool_result_chars=1000)
+        ),
+        store=InMemoryHarnessStore(),
+    )
+
+    asyncio.run(
+        plugin.after_tool_callback(
+            tool=SimpleNamespace(name="query_data"),
+            tool_args={},
+            tool_context=_tool_context(),
+            result={"rows": "x" * 8000},
+        )
+    )
+    plugin.reset_diagnostics()
+
+    assert plugin.compaction_reports == []
+
+
+def test_response_verification_plugin_blocks_unsupported_completion_claim():
+    store = InMemoryHarnessStore()
+    plugin = HarnessResponseVerificationPlugin(
+        verifier=FinalResponseVerifier(FinalResponseVerifierConfig(mode="block")),
+        store=store,
+    )
+    response = LlmResponse(
+        content=types.Content(
+            role="model", parts=[types.Part(text="Done, I created it.")]
+        )
+    )
+
+    blocked = asyncio.run(
+        plugin.after_model_callback(
+            callback_context=_callback_context(),
+            llm_response=response,
+        )
+    )
+
+    assert blocked is not None
+    assert "cannot verify" in blocked.content.parts[0].text
+
+
+def test_response_verification_plugin_accepts_string_tool_result():
+    plugin = HarnessResponseVerificationPlugin(store=InMemoryHarnessStore())
+
+    result = asyncio.run(
+        plugin.after_tool_callback(
+            tool=SimpleNamespace(name="run_code"),
+            tool_args={},
+            tool_context=_tool_context(),
+            result="chain_1=abc123",
+        )
+    )
+
+    assert result is None
+
+
+def test_build_harness_plugins_uses_shared_store_and_aliases():
+    plugins = build_harness_plugins(components="context,compress,verifier")
+
+    assert [plugin.name for plugin in plugins] == [
+        "harness_invocation_context_plugin",
+        "harness_compress_plugin",
+        "harness_response_verification_plugin",
+    ]

--- a/tests/extensions/harness/test_backward_compat.py
+++ b/tests/extensions/harness/test_backward_compat.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from veadk.extensions.harness import (
+    CapabilityReceipt,
+    CompactionReport,
+    CompactionResult,
+    CompressionReport,
+    CompressionResult,
+    ContextBundle,
+    HarnessIntervention,
+    HarnessInvocationRef,
+    HarnessRunContext,
+    InvocationContextBlock,
+    ToolReceipt,
+    ToolResultCompactor,
+    ToolResultCompressor,
+    VerificationDecision,
+)
+from veadk.extensions.harness.adk import (
+    HarnessContextPlugin,
+    HarnessHallucinationPlugin,
+    HarnessInvocationContextPlugin,
+    HarnessResponseVerificationPlugin,
+)
+from veadk.extensions.harness.modules.final_response_verifier import (
+    FinalResponseVerifier,
+    ResultVerifier,
+)
+from veadk.extensions.harness.modules.tool_result_compactor import (
+    ContextCompactionPolicy,
+    ContextCompressionPolicy,
+)
+
+
+def test_renamed_public_objects_keep_backward_compatible_aliases():
+    assert HarnessRunContext is HarnessInvocationRef
+    assert ContextBundle is InvocationContextBlock
+    assert CompressionReport is CompactionReport
+    assert CompressionResult is CompactionResult
+    assert CapabilityReceipt is ToolReceipt
+    assert HarnessIntervention is VerificationDecision
+    assert ToolResultCompressor is ToolResultCompactor
+    assert ResultVerifier is FinalResponseVerifier
+    assert ContextCompressionPolicy is ContextCompactionPolicy
+    assert HarnessContextPlugin is HarnessInvocationContextPlugin
+    assert HarnessHallucinationPlugin is HarnessResponseVerificationPlugin

--- a/tests/extensions/harness/test_context_engine.py
+++ b/tests/extensions/harness/test_context_engine.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from veadk.extensions.harness import (
+    ContextEngine,
+    HarnessInvocationContextBuilder,
+    HarnessInvocationRef,
+    TaskContract,
+)
+from veadk.extensions.harness.schemas import ToolReceipt, ConversationMessage
+
+
+def test_invocation_context_builder_builds_task_anchor_and_receipts():
+    builder = HarnessInvocationContextBuilder()
+    context = HarnessInvocationRef(
+        session_id="s1",
+        invocation_id="r1",
+        profile="research",
+        task=TaskContract(goal="Create a chart", acceptance_criteria=["save a PNG"]),
+    )
+    bundle = builder.prepare_context(
+        context,
+        user_input="Create a chart from this CSV file.",
+        history=[ConversationMessage(role="user", content="Use the latest CSV.")],
+        receipts=[
+            ToolReceipt(name="read_csv", status="success", summary="10 rows loaded")
+        ],
+        has_tools=True,
+    )
+
+    assert bundle.injected is True
+    assert "task_goal: Create a chart" in bundle.header
+    assert "read_csv [success]" in bundle.header
+    assert "[Harness Tool Protocol]" in bundle.header
+
+
+def test_invocation_context_builder_injects_after_system_messages():
+    builder = HarnessInvocationContextBuilder()
+    context = HarnessInvocationRef(session_id="s1", invocation_id="r1")
+    messages = [
+        ConversationMessage(role="system", content="base system"),
+        ConversationMessage(role="user", content="hello"),
+    ]
+
+    enhanced, bundle = builder.enhance_messages(messages, context, user_input="hello")
+
+    assert bundle.injected is True
+    assert enhanced[0].content == "base system"
+    assert enhanced[1].name == "veadk_harness_context"
+
+
+def test_context_engine_alias_remains_available():
+    assert ContextEngine is HarnessInvocationContextBuilder

--- a/tests/extensions/harness/test_env.py
+++ b/tests/extensions/harness/test_env.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from veadk.extensions.harness.env import (
+    build_harness_plugins_from_env,
+    harness_enabled_from_env,
+)
+
+
+def test_harness_enabled_from_env():
+    assert harness_enabled_from_env({"HARNESS_ENHANCE_ENABLED": "true"}) is True
+    assert harness_enabled_from_env({"HARNESS_ENHANCE_ENABLED": "false"}) is False
+
+
+def test_build_harness_plugins_from_env_respects_components():
+    plugins = build_harness_plugins_from_env(
+        {
+            "HARNESS_ENHANCE_ENABLED": "true",
+            "HARNESS_ENHANCE_COMPONENTS": "context_engine,hallucination",
+            "HARNESS_ENHANCE_PROFILE": "analysis",
+        }
+    )
+
+    assert [plugin.name for plugin in plugins] == [
+        "harness_invocation_context_plugin",
+        "harness_response_verification_plugin",
+    ]
+
+
+def test_build_harness_plugins_from_env_defaults_to_builtin_compression():
+    plugins = build_harness_plugins_from_env(
+        {
+            "HARNESS_ENHANCE_ENABLED": "true",
+            "HARNESS_ENHANCE_COMPONENTS": "compressor",
+        }
+    )
+
+    assert plugins[0].name == "harness_compress_plugin"
+    assert plugins[0].compressor.config.provider == "builtin"

--- a/tests/extensions/harness/test_extension.py
+++ b/tests/extensions/harness/test_extension.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from veadk.extensions.harness import HarnessExtension
+
+
+def test_harness_extension_builds_runner_plugins() -> None:
+    plugins = HarnessExtension(
+        components=["invocation_context", "compactor", "response_verification"],
+        profile="test",
+    ).plugins()
+
+    assert [plugin.name for plugin in plugins] == [
+        "harness_invocation_context_plugin",
+        "harness_compress_plugin",
+        "harness_response_verification_plugin",
+    ]
+
+
+def test_harness_extension_from_env_respects_disabled_default() -> None:
+    assert HarnessExtension.from_env({}).plugins() == []
+
+
+def test_harness_extension_from_env_builds_configured_plugins() -> None:
+    plugins = HarnessExtension.from_env(
+        {
+            "HARNESS_ENHANCE_ENABLED": "true",
+            "HARNESS_ENHANCE_COMPONENTS": "invocation_context",
+        }
+    ).plugins()
+
+    assert [plugin.name for plugin in plugins] == ["harness_invocation_context_plugin"]

--- a/tests/extensions/harness/test_golden.py
+++ b/tests/extensions/harness/test_golden.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from veadk.extensions.harness.testing import GoldenCase, run_golden_cases
+
+
+def test_run_golden_cases_exact_match():
+    cases = [
+        GoldenCase(name="case-1", input={"value": "a"}, expected={"value": "a"}),
+        GoldenCase(name="case-2", input={"value": "b"}, expected={"value": "c"}),
+    ]
+
+    results = run_golden_cases(cases, lambda case: case.input)
+
+    assert [result.passed for result in results] == [True, False]

--- a/tests/extensions/harness/test_golden_fixtures.py
+++ b/tests/extensions/harness/test_golden_fixtures.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+
+from veadk.extensions.harness.adk import build_harness_plugins
+from veadk.extensions.harness.eval import run_deterministic_eval
+from veadk.extensions.harness.modules.invocation_context import (
+    HarnessInvocationContextBuilder,
+)
+from veadk.extensions.harness.modules.final_response_verifier import (
+    FinalResponseVerifier,
+)
+from veadk.extensions.harness.modules.tool_result_compactor import (
+    ToolResultCompactor,
+    ToolResultCompactorConfig,
+)
+from veadk.extensions.harness.schemas import (
+    CompressionRequest,
+    ConversationMessage,
+    HarnessInvocationRef,
+    TaskContract,
+)
+
+GOLDEN_DIR = Path(__file__).parent / "golden"
+
+
+def _load_case(filename: str) -> dict[str, object]:
+    return json.loads((GOLDEN_DIR / filename).read_text().splitlines()[0])
+
+
+def test_context_engine_golden_case():
+    case = _load_case("context_engine_cases.jsonl")
+    input_data = case["input"]
+    expected = case["expected"]
+    assert isinstance(input_data, dict)
+    assert isinstance(expected, dict)
+    context = HarnessInvocationRef(
+        session_id="s1",
+        invocation_id="r1",
+        task=TaskContract(goal=str(input_data["goal"])),
+    )
+
+    bundle = HarnessInvocationContextBuilder().prepare_context(
+        context,
+        user_input=str(input_data["user_input"]),
+    )
+
+    for text in expected["contains"]:
+        assert text in bundle.header
+
+
+def test_compactor_golden_case():
+    case = _load_case("compressor_cases.jsonl")
+    input_data = case["input"]
+    expected = case["expected"]
+    assert isinstance(input_data, dict)
+    assert isinstance(expected, dict)
+    old_tool_chars = int(input_data["old_tool_chars"])
+    latest_tool = str(input_data["latest_tool"])
+    messages = [
+        ConversationMessage(role="user", content="Summarize."),
+        ConversationMessage(role="tool", content="x" * old_tool_chars),
+        ConversationMessage(role="assistant", content="I will inspect the data."),
+        ConversationMessage(role="tool", content=latest_tool),
+    ]
+    compactor = ToolResultCompactor(
+        ToolResultCompactorConfig(max_context_chars=1000, min_candidate_chars=200)
+    )
+
+    result = compactor.compress_messages(
+        CompressionRequest(messages=messages, max_context_chars=1000)
+    )
+    before = sum(len(message.content) for message in messages)
+    after = sum(len(message.content) for message in result.messages)
+
+    assert 1 - after / before >= expected["min_saving_ratio"]
+    assert result.messages[-1].content == latest_tool
+
+
+def test_verifier_golden_case():
+    case = _load_case("verifier_cases.jsonl")
+    input_data = case["input"]
+    expected = case["expected"]
+    assert isinstance(input_data, dict)
+    assert isinstance(expected, dict)
+
+    report = FinalResponseVerifier().verify_text(str(input_data["answer"]))
+
+    assert report.status == expected["status"]
+
+
+def test_plugin_lifecycle_golden_case():
+    case = _load_case("plugin_lifecycle_cases.jsonl")
+    input_data = case["input"]
+    expected = case["expected"]
+    assert isinstance(input_data, dict)
+    assert isinstance(expected, dict)
+
+    plugins = build_harness_plugins(components=str(input_data["components"]))
+
+    assert [plugin.name for plugin in plugins] == expected["plugins"]
+
+
+def test_deterministic_eval_reports_effect_direction():
+    results = run_deterministic_eval()
+
+    assert results[0].char_saving_ratio > 0
+    assert results[1].baseline_false_accept is True
+    assert results[1].enhanced_false_accept is False

--- a/tests/extensions/harness/test_headroom_provider.py
+++ b/tests/extensions/harness/test_headroom_provider.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+
+from pytest import MonkeyPatch
+
+from veadk.extensions.harness.adk import HarnessCompressPlugin
+from veadk.extensions.harness.modules.headroom_provider import (
+    HeadroomCompressionProvider,
+)
+from veadk.extensions.harness.modules.tool_result_compactor import (
+    ToolResultCompactor,
+    ToolResultCompactorConfig,
+)
+from veadk.extensions.harness.schemas import CompressionRequest, ConversationMessage
+from veadk.extensions.harness.stores import InMemoryHarnessStore
+
+
+_HEADROOM_CALLS: list[dict[str, object]] = []
+
+
+def _install_fake_headroom(monkeypatch: MonkeyPatch) -> None:
+    package = ModuleType("headroom")
+    package.__path__ = []
+    compress_module = ModuleType("headroom.compress")
+
+    def compress(
+        messages: list[dict[str, object]],
+        *,
+        model: str,
+        optimize: bool,
+    ) -> object:
+        _HEADROOM_CALLS.append(
+            {"messages": messages, "model": model, "optimize": optimize}
+        )
+        return SimpleNamespace(
+            messages=[
+                {
+                    "role": "tool",
+                    "content": "HEADROOM_SUMMARY: preserved key facts only.",
+                    "metadata": {"source": "test"},
+                }
+            ],
+            tokens_before=2000,
+            tokens_after=40,
+            tokens_saved=1960,
+            compression_ratio=0.02,
+            transforms_applied=["headroom_test_compaction"],
+        )
+
+    compress_module.compress = compress
+    _HEADROOM_CALLS.clear()
+    monkeypatch.setitem(sys.modules, "headroom", package)
+    monkeypatch.setitem(sys.modules, "headroom.compress", compress_module)
+
+
+def test_headroom_sdk_provider_compresses_tool_result(monkeypatch: MonkeyPatch) -> None:
+    _install_fake_headroom(monkeypatch)
+    compactor = ToolResultCompactor(
+        ToolResultCompactorConfig(
+            provider="headroom",
+            max_tool_result_chars=200,
+        )
+    )
+
+    compressed, report = compactor.compress_tool_result({"rows": "x" * 8000})
+
+    assert compressed["harness_compressed"] is True
+    assert compressed["provider"] == "headroom"
+    assert "HEADROOM_SUMMARY" in str(compressed["summary"])
+    assert report.provider == "headroom"
+    assert report.tokens_saved == 1960
+    assert report.compressed_chars < report.original_chars
+    assert _HEADROOM_CALLS[0]["model"] == "gpt-4o"
+    assert _HEADROOM_CALLS[0]["optimize"] is True
+
+
+def test_compress_plugin_after_tool_callback_uses_headroom(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _install_fake_headroom(monkeypatch)
+    plugin = HarnessCompressPlugin(
+        compressor=ToolResultCompactor(
+            ToolResultCompactorConfig(
+                provider="headroom",
+                max_tool_result_chars=200,
+            )
+        ),
+        store=InMemoryHarnessStore(),
+    )
+
+    compressed = asyncio.run(
+        plugin.after_tool_callback(
+            tool=SimpleNamespace(name="query_data"),
+            tool_args={},
+            tool_context=SimpleNamespace(
+                session=SimpleNamespace(id="s1", app_name="app", user_id="u1"),
+                user_id="u1",
+                invocation_id="r1",
+            ),
+            result={"rows": "x" * 8000},
+        )
+    )
+
+    assert compressed is not None
+    assert compressed["provider"] == "headroom"
+    assert "HEADROOM_SUMMARY" in str(compressed["summary"])
+
+
+def test_headroom_sdk_provider_compresses_candidate_context(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _install_fake_headroom(monkeypatch)
+    compactor = ToolResultCompactor(
+        ToolResultCompactorConfig(
+            provider="headroom",
+            max_context_chars=1500,
+            min_candidate_chars=100,
+            protect_recent_messages=1,
+        )
+    )
+    messages = [
+        ConversationMessage(role="user", content="summarize"),
+        ConversationMessage(role="tool", content="a" * 1000),
+        ConversationMessage(role="tool", content="b" * 1000),
+    ]
+
+    result = compactor.compress_messages(
+        CompressionRequest(messages=messages, max_context_chars=1500)
+    )
+
+    assert result.report.provider == "headroom"
+    assert result.report.changed is True
+    assert result.report.policy["candidate_count"] == 1
+    assert "HEADROOM_SUMMARY" in result.messages[1].content
+    assert result.messages[-1].content == "b" * 1000
+
+
+def test_headroom_provider_does_not_install_when_unavailable(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name: str, package: str | None = None) -> ModuleType:
+        if name == "headroom.compress":
+            raise ImportError(name)
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+    provider = HeadroomCompressionProvider(auto_install=True)
+
+    result = provider.compress(
+        CompressionRequest(
+            messages=[ConversationMessage(role="tool", content="x" * 8000)],
+            max_context_chars=200,
+        )
+    )
+
+    assert result is None
+
+
+def test_headroom_provider_falls_back_when_unavailable(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name: str, package: str | None = None) -> ModuleType:
+        if name == "headroom.compress":
+            raise ImportError(name)
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+    compactor = ToolResultCompactor(
+        ToolResultCompactorConfig(provider="headroom", max_tool_result_chars=200)
+    )
+
+    compressed, report = compactor.compress_tool_result({"rows": "x" * 1000})
+
+    assert compressed["harness_compressed"] is True
+    assert report.provider == "heuristic"
+    assert "headroom provider unavailable" in report.warnings[0]
+    assert report.compressed_chars < report.original_chars

--- a/tests/extensions/harness/test_package_metadata.py
+++ b/tests/extensions/harness/test_package_metadata.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+
+def test_harness_extra_installs_headroom_provider() -> None:
+    pyproject = Path(__file__).parents[3] / "pyproject.toml"
+    text = pyproject.read_text(encoding="utf-8")
+
+    assert "[project.optional-dependencies]" in text
+    assert "harness = [" in text
+    assert '"headroom"' in text
+    old_package_name = "agentkit" + "-harness-python"
+    assert old_package_name not in text

--- a/tests/extensions/harness/test_result_verifier.py
+++ b/tests/extensions/harness/test_result_verifier.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from veadk.extensions.harness.modules.final_response_verifier import (
+    FinalResponseVerifier,
+    FinalResponseVerifierConfig,
+)
+from veadk.extensions.harness.schemas import ToolReceipt
+
+
+def test_verifier_fails_completion_claim_without_receipt():
+    verifier = FinalResponseVerifier()
+
+    report = verifier.verify_text("Done, I created the report.")
+
+    assert report.status == "fail"
+    assert report.unsupported_claims
+
+
+def test_verifier_allows_completion_claim_with_success_receipt():
+    verifier = FinalResponseVerifier()
+
+    report = verifier.verify_text(
+        "Done, I created the report.",
+        receipts=[
+            ToolReceipt(name="write_file", status="success", summary="report.md saved")
+        ],
+    )
+
+    assert report.status == "pass"
+    assert report.supported_claims
+
+
+def test_verifier_block_intervention():
+    verifier = FinalResponseVerifier(FinalResponseVerifierConfig(mode="block"))
+
+    report = verifier.verify_text("The file was saved successfully.")
+    intervention = verifier.decide(report)
+
+    assert intervention.action == "block"

--- a/tests/extensions/harness/test_tool_compressor.py
+++ b/tests/extensions/harness/test_tool_compressor.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from veadk.extensions.harness.modules.tool_result_compactor import (
+    ToolResultCompactor,
+    ToolResultCompactorConfig,
+)
+from veadk.extensions.harness.schemas import CompressionRequest, ConversationMessage
+
+
+def test_tool_result_compactor_compacts_large_tool_result():
+    compactor = ToolResultCompactor(
+        ToolResultCompactorConfig(max_tool_result_chars=200, summary_chars=80)
+    )
+
+    compressed, report = compactor.compress_tool_result({"rows": "x" * 1000})
+
+    assert report.changed is True
+    assert compressed["harness_compressed"] is True
+    assert report.compressed_chars < report.original_chars
+
+
+def test_builtin_provider_preserves_metric_rows_and_drops_noise():
+    compactor = ToolResultCompactor(ToolResultCompactorConfig())
+    payload = {
+        "metric_rows": [
+            {"kind": "metric", "model": "T4", "accuracy": 82, "rank": 2},
+            {"kind": "metric", "model": "T5", "accuracy": 88, "rank": 1},
+        ],
+        "debug_rows": [
+            {"kind": "debug", "row": index, "trace": "x" * 80} for index in range(200)
+        ],
+    }
+
+    compressed, report = compactor.compress_tool_result(payload)
+
+    assert compressed["provider"] == "builtin"
+    assert report.provider == "builtin"
+    assert report.compression_ratio < 0.1
+    assert "model=T5" in str(compressed["summary"])
+    assert "debug_rows" not in str(compressed["summary"])
+
+
+def test_builtin_provider_reads_run_code_result_string():
+    compactor = ToolResultCompactor(ToolResultCompactorConfig())
+    payload = {
+        "result": (
+            '[{"kind":"metric","model":"T5","accuracy":88},'
+            '{"kind":"debug","payload":"' + ("x" * 12000) + '"}]'
+        )
+    }
+
+    compressed, report = compactor.compress_tool_result(payload)
+
+    assert compressed["provider"] == "builtin"
+    assert report.provider == "builtin"
+    assert "model=T5" in str(compressed["summary"])
+    assert "payload" not in str(compressed["summary"])
+
+
+def test_builtin_provider_ignores_debug_rows_with_metric_shaped_fields():
+    compactor = ToolResultCompactor(ToolResultCompactorConfig())
+    rows = [
+        {"kind": "metric", "model": "T5", "accuracy": 88, "rank": 0},
+        {
+            "kind": "debug",
+            "model": "noise-1",
+            "accuracy": 0,
+            "payload": "x" * 12000,
+        },
+    ]
+
+    compressed, report = compactor.compress_tool_result({"result": json.dumps(rows)})
+
+    assert report.changed is True
+    assert "model=T5" in str(compressed["summary"])
+    assert "noise-1" not in str(compressed["summary"])
+    assert "payload" not in str(compressed["summary"])
+
+
+def test_policy_preserves_recent_tool_feedback():
+    compactor = ToolResultCompactor(
+        ToolResultCompactorConfig(
+            max_context_chars=500,
+            min_candidate_chars=100,
+            protect_recent_messages=1,
+        )
+    )
+    messages = [
+        ConversationMessage(role="user", content="summarize"),
+        ConversationMessage(role="tool", content="a" * 1000),
+        ConversationMessage(role="tool", content="b" * 1000),
+    ]
+
+    result = compactor.compress_messages(
+        CompressionRequest(messages=messages, max_context_chars=500)
+    )
+
+    assert result.report.changed is True
+    assert result.messages[-1].content == "b" * 1000
+    assert result.report.policy["candidate_count"] == 1

--- a/veadk/cli/cli_agentkit.py
+++ b/veadk/cli/cli_agentkit.py
@@ -14,6 +14,7 @@
 
 import click
 from agentkit.toolkit.cli.cli import app as agentkit_typer_app
+from agentkit.toolkit.cli.cli import invoke_command as agentkit_invoke_command
 from typer.main import get_command
 
 
@@ -30,4 +31,296 @@ agentkit_commands = get_command(agentkit_typer_app)
 # since Typer 0.26 a TyperGroup is no longer a click.Group subclass, so the
 # isinstance check silently evaluates False and drops every command.
 for cmd_name, cmd in getattr(agentkit_commands, "commands", {}).items():
+    if cmd_name == "invoke":
+        continue
     agentkit.add_command(cmd, name=cmd_name)
+
+
+@agentkit.command("invoke")
+@click.argument("message", required=False)
+@click.option("--config-file", type=click.Path(), default=None)
+@click.option("--payload", "-p", default=None, help="JSON payload to send.")
+@click.option("--headers", "-h", default=None, help="JSON headers to send.")
+@click.option("--runtime-id", "-r", default=None)
+@click.option("--endpoint", "-e", default=None)
+@click.option("--region", default=None)
+@click.option("--a2a", is_flag=True, default=False)
+@click.option("--show-reasoning", is_flag=True, default=False)
+@click.option("--raw", is_flag=True, default=False)
+@click.option("--apikey", "-ak", default=None)
+@click.option("--harness", default=None, help="Harness name for HarnessApp Runtime.")
+@click.option("--model-id", default=None, help="One-shot model override.")
+@click.option("--tools", default=None, help="Comma-separated one-shot tool override.")
+@click.option("--skills", default=None, help="Comma-separated one-shot skill override.")
+@click.option("--system-prompt", default=None, help="One-shot system prompt override.")
+@click.option("--runtime", default=None, help="One-shot runtime override.")
+@click.option("--user-id", default="agentkit_user")
+@click.option("--session-id", default="agentkit_sample_session")
+@click.option("--max-llm-calls", type=int, default=None)
+@click.option(
+    "--enable-harness-enhance",
+    is_flag=True,
+    default=False,
+    help="Enable Harness enhancement headers for this invocation.",
+)
+@click.option(
+    "--harness-components",
+    default=None,
+    help="Comma-separated Harness components.",
+)
+@click.option("--harness-profile", default=None)
+@click.option("--harness-compression-provider", default=None)
+def invoke(
+    message: str | None,
+    config_file: str | None,
+    payload: str | None,
+    headers: str | None,
+    runtime_id: str | None,
+    endpoint: str | None,
+    region: str | None,
+    a2a: bool,
+    show_reasoning: bool,
+    raw: bool,
+    apikey: str | None,
+    harness: str | None,
+    model_id: str | None,
+    tools: str | None,
+    skills: str | None,
+    system_prompt: str | None,
+    runtime: str | None,
+    user_id: str,
+    session_id: str,
+    max_llm_calls: int | None,
+    enable_harness_enhance: bool,
+    harness_components: str | None,
+    harness_profile: str | None,
+    harness_compression_provider: str | None,
+) -> None:
+    """Invoke AgentKit or HarnessApp Runtime.
+
+    When Harness-specific flags are present, the command sends a HarnessApp
+    request to `/harness/invoke` and maps enhancement options to HTTP headers.
+    Without those flags it delegates to the upstream AgentKit CLI unchanged.
+    """
+
+    if not _is_harness_invoke(
+        harness=harness,
+        model_id=model_id,
+        tools=tools,
+        skills=skills,
+        system_prompt=system_prompt,
+        runtime=runtime,
+        enable_harness_enhance=enable_harness_enhance,
+        harness_components=harness_components,
+        harness_profile=harness_profile,
+        harness_compression_provider=harness_compression_provider,
+        max_llm_calls=max_llm_calls,
+    ):
+        from pathlib import Path
+
+        agentkit_invoke_command(
+            config_file=Path(config_file) if config_file else None,
+            message=message,
+            payload=payload,
+            headers=headers,
+            runtime_id=runtime_id,
+            endpoint=endpoint,
+            region=region,
+            a2a=a2a,
+            show_reasoning=show_reasoning,
+            raw=raw,
+            apikey=apikey,
+        )
+        return
+
+    if config_file or runtime_id or region or a2a or show_reasoning:
+        raise click.ClickException(
+            "HarnessApp invoke supports --endpoint and Harness-specific flags; "
+            "do not combine it with --config-file, --runtime-id, --region, --a2a, "
+            "or --show-reasoning."
+        )
+    if not endpoint:
+        raise click.ClickException("HarnessApp invoke requires --endpoint.")
+
+    request_body = _build_harness_body(
+        message=message,
+        payload=payload,
+        harness=harness,
+        user_id=user_id,
+        session_id=session_id,
+        max_llm_calls=max_llm_calls,
+        model_id=model_id,
+        tools=tools,
+        skills=skills,
+        system_prompt=system_prompt,
+        runtime=runtime,
+        enable_harness_enhance=enable_harness_enhance,
+        harness_components=harness_components,
+        harness_profile=harness_profile,
+        harness_compression_provider=harness_compression_provider,
+    )
+    request_headers = _build_harness_headers(
+        headers=headers,
+        apikey=apikey,
+        enable_harness_enhance=enable_harness_enhance,
+        harness_components=harness_components,
+        harness_profile=harness_profile,
+        harness_compression_provider=harness_compression_provider,
+    )
+    response = _post_harness_invoke(endpoint, request_body, request_headers)
+    if raw:
+        click.echo(_json_dumps(response))
+        return
+    output = response.get("output")
+    click.echo(output if output is not None else _json_dumps(response))
+
+
+def _is_harness_invoke(**values: object) -> bool:
+    return any(value is not None and value is not False for value in values.values())
+
+
+def _build_harness_body(
+    *,
+    message: str | None,
+    payload: str | None,
+    harness: str | None,
+    user_id: str,
+    session_id: str,
+    max_llm_calls: int | None,
+    model_id: str | None,
+    tools: str | None,
+    skills: str | None,
+    system_prompt: str | None,
+    runtime: str | None,
+    enable_harness_enhance: bool,
+    harness_components: str | None,
+    harness_profile: str | None,
+    harness_compression_provider: str | None,
+) -> dict[str, object]:
+    payload_data = _json_loads_object(payload) if payload else {}
+    prompt = (
+        message
+        or _string_value(payload_data, "prompt")
+        or _string_value(payload_data, "message")
+    )
+    if not prompt:
+        raise click.ClickException(
+            "Provide a prompt as MESSAGE, --payload.prompt, or --payload.message."
+        )
+    run_request: dict[str, object] = {
+        "user_id": _string_value(payload_data, "user_id") or user_id,
+        "session_id": _string_value(payload_data, "session_id") or session_id,
+    }
+    if max_llm_calls is not None:
+        run_request["max_llm_calls"] = max_llm_calls
+    body: dict[str, object] = {
+        "prompt": prompt,
+        "harness_name": harness
+        or _string_value(payload_data, "harness_name")
+        or "default",
+        "run_agent_request": run_request,
+    }
+    override = {}
+    if model_id is not None:
+        override["model_name"] = model_id
+    if tools is not None:
+        override["tools"] = tools
+    if skills is not None:
+        override["skills"] = skills
+    if system_prompt is not None:
+        override["system_prompt"] = system_prompt
+    if runtime is not None:
+        override["runtime"] = runtime
+    if override:
+        body["harness"] = override
+    enhance = _json_object_value(payload_data, "harness_enhance")
+    if enable_harness_enhance:
+        enhance["enabled"] = True
+    if harness_components is not None:
+        enhance["components"] = harness_components
+    if harness_profile is not None:
+        enhance["profile"] = harness_profile
+    if harness_compression_provider is not None:
+        enhance["compression_provider"] = harness_compression_provider
+    if enhance:
+        body["harness_enhance"] = enhance
+    return body
+
+
+def _build_harness_headers(
+    *,
+    headers: str | None,
+    apikey: str | None,
+    enable_harness_enhance: bool,
+    harness_components: str | None,
+    harness_profile: str | None,
+    harness_compression_provider: str | None,
+) -> dict[str, str]:
+    request_headers = {"Content-Type": "application/json"}
+    request_headers.update(
+        {key: str(value) for key, value in _json_loads_object(headers).items()}
+        if headers
+        else {}
+    )
+    if apikey and "Authorization" not in request_headers:
+        request_headers["Authorization"] = f"Bearer {apikey}"
+    if enable_harness_enhance:
+        request_headers["X-Harness-Enhance"] = "true"
+    if harness_components:
+        request_headers["X-Harness-Components"] = harness_components
+    if harness_profile:
+        request_headers["X-Harness-Profile"] = harness_profile
+    if harness_compression_provider:
+        request_headers["X-Harness-Compression-Provider"] = harness_compression_provider
+    return request_headers
+
+
+def _post_harness_invoke(
+    endpoint: str, body: dict[str, object], headers: dict[str, str]
+) -> dict[str, object]:
+    import httpx
+
+    response = httpx.post(
+        endpoint.rstrip("/") + "/harness/invoke",
+        json=body,
+        headers=headers,
+        timeout=600,
+    )
+    if response.status_code != 200:
+        raise click.ClickException(
+            f"/harness/invoke failed: HTTP {response.status_code} - {response.text}"
+        )
+    data = response.json()
+    if not isinstance(data, dict):
+        raise click.ClickException("HarnessApp returned a non-object JSON response.")
+    return data
+
+
+def _json_loads_object(value: str | None) -> dict[str, object]:
+    import json
+
+    if not value:
+        return {}
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(f"Invalid JSON object: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise click.ClickException("Expected a JSON object.")
+    return parsed
+
+
+def _json_dumps(value: object) -> str:
+    import json
+
+    return json.dumps(value, ensure_ascii=False, indent=2)
+
+
+def _string_value(data: dict[str, object], key: str) -> str:
+    value = data.get(key)
+    return value if isinstance(value, str) else ""
+
+
+def _json_object_value(data: dict[str, object], key: str) -> dict[str, object]:
+    value = data.get(key)
+    return dict(value) if isinstance(value, dict) else {}

--- a/veadk/cli/cli_harness.py
+++ b/veadk/cli/cli_harness.py
@@ -19,7 +19,7 @@ Subcommands scaffold, configure, and deploy the harness server
 
 * ``veadk harness create <dir>`` writes a deployable directory: a blank
   ``harness.yaml`` template, a ``.env.example`` (deploy credentials only), a
-  ``Dockerfile``, and a short ``README.md``.
+  ``Dockerfile``, a ``.gitignore``, and a short ``README.md``.
 * ``veadk harness add`` writes agent parameters into ``harness.yaml``.
 * ``veadk harness deploy`` flattens ``harness.yaml`` into runtime env vars and
   performs a cloud AgentKit build + runtime create (no local Docker).
@@ -88,6 +88,18 @@ system_prompt: ""
 # Agent runtime backend: adk (default) | codex.
 #   env: RUNTIME               flag: --runtime
 runtime: adk
+
+# --- Harness enhance (optional) ---------------------------------------------
+# Enables composable ADK plugins for context engineering, tool-result
+# compression, and answer verification inside the runtime.
+#   env: HARNESS_ENHANCE_ENABLED       flag: --enable-harness-enhance
+#   env: HARNESS_ENHANCE_COMPONENTS    flag: --harness-components
+#   env: HARNESS_ENHANCE_PROFILE       flag: --harness-profile
+harness_enhance:
+  enabled: false
+  components: [invocation_context, compactor, response_verification]
+  profile: default
+  compression_provider: builtin
 
 # --- Knowledge base ----------------------------------------------------------
 #   type -> env: KNOWLEDGEBASE_TYPE   flag: --knowledgebase-type
@@ -174,12 +186,25 @@ VOLCENGINE_SECRET_KEY=
 # VOLCENGINE_REGION=cn-beijing
 """
 
-# Container image for the harness server. The base image's apt mirror is an
-# unreachable internal host, so apt is repointed at aliyun; the source branch is
-# cloned via the ghfast proxy with a github fallback; uv installs from aliyun.
+_GITIGNORE = """\
+# Local deploy credentials and generated runtime metadata.
+.env
+.env.*
+!.env.example
+harness.json
+agentkit.yaml
+agentkit*.yaml
+.agentkit/
+"""
+
+# Container image for the harness server. The base image's default apt source
+# can be unreachable in some environments, so apt is repointed at a public
+# mirror. The source branch is cloned through an acceleration URL with an
+# official GitHub fallback, and uv installs from a public Python mirror.
 _DOCKERFILE = """\
 FROM agentkit-cn-beijing.cr.volces.com/base/py-simple:python3.12-bookworm-slim-latest
 ENV PYTHONUNBUFFERED=1
+ENV PYTHONPATH=/app/src
 RUN set -eux; \\
     rm -f /etc/apt/sources.list.d/*; \\
     printf 'deb http://mirrors.aliyun.com/debian bookworm main contrib non-free non-free-firmware\\n\\
@@ -190,17 +215,18 @@ deb http://mirrors.aliyun.com/debian-security bookworm-security main contrib non
     apt-get install -y --no-install-recommends git ca-certificates; \\
     rm -rf /var/lib/apt/lists/*
 WORKDIR /app
+ARG VEADK_REF=main
 RUN set -eux; \\
     for url in \\
         https://ghfast.top/https://github.com/volcengine/veadk-python.git \\
         https://github.com/volcengine/veadk-python.git ; do \\
       for i in 1 2 3; do \\
-        git clone --depth 1 -b feat/harness-runtime "$url" src && break 2 || sleep 8; \\
+        git clone --depth 1 -b "$VEADK_REF" "$url" src && break 2 || sleep 8; \\
       done; \\
     done; \\
     test -d src/veadk
 RUN uv pip install --system --index-url https://mirrors.aliyun.com/pypi/simple/ \\
-        ./src fastapi "uvicorn[standard]"
+        "./src[harness]" fastapi "uvicorn[standard]"
 EXPOSE 8000
 CMD ["python", "-m", "uvicorn", "veadk.cloud.harness_app.app:app", "--host", "0.0.0.0", "--port", "8000"]
 """
@@ -215,6 +241,7 @@ Volcengine **AgentKit runtime** (cloud build, no local Docker).
 
 - `harness.yaml` — agent configuration; flattened into runtime env vars.
 - `.env.example` — Volcengine deploy credentials; copy to `.env` and fill in.
+- `.gitignore` — keeps local credentials and generated deploy metadata out of git.
 - `Dockerfile` — builds the harness server image.
 - `README.md` — this file.
 
@@ -244,6 +271,7 @@ _CREATE_SUCCESS = """\
 Harness deployment directory created at {target}:
 - harness.yaml   (agent configuration)
 - .env.example   (copy to .env and set VOLCENGINE_ACCESS_KEY / SECRET_KEY)
+- .gitignore     (ignores local credentials and generated deploy metadata)
 - Dockerfile     (builds the harness image)
 - README.md
 
@@ -280,6 +308,7 @@ def create(dir_name: str) -> None:
     target.mkdir(parents=True, exist_ok=True)
     (target / "harness.yaml").write_text(_HARNESS_YAML)
     (target / ".env.example").write_text(_ENV_EXAMPLE)
+    (target / ".gitignore").write_text(_GITIGNORE)
     (target / "Dockerfile").write_text(_DOCKERFILE)
     (target / "README.md").write_text(_README)
 
@@ -375,6 +404,22 @@ def _override_options(func):
 )
 @_override_options
 @click.option(
+    "--enable-harness-enhance/--disable-harness-enhance",
+    default=None,
+    help="Enable or disable Harness ADK plugins in the runtime.",
+)
+@click.option(
+    "--harness-components",
+    default=None,
+    help="Comma-separated Harness components: invocation_context,compactor,response_verification.",
+)
+@click.option("--harness-profile", default=None, help="Harness enhancement profile.")
+@click.option(
+    "--harness-compression-provider",
+    default=None,
+    help="Compression provider name. Defaults to built-in compression.",
+)
+@click.option(
     "--knowledgebase-type",
     "knowledgebase_type",
     default=None,
@@ -409,6 +454,10 @@ def add(
     skills: str | None,
     system_prompt: str | None,
     runtime: str | None,
+    enable_harness_enhance: bool | None,
+    harness_components: str | None,
+    harness_profile: str | None,
+    harness_compression_provider: str | None,
     **connection: str | None,
 ) -> None:
     """Write agent parameters into `harness.yaml`.
@@ -435,6 +484,30 @@ def add(
         data["system_prompt"] = system_prompt
     if runtime is not None:
         data["runtime"] = runtime
+
+    if any(
+        value is not None
+        for value in (
+            enable_harness_enhance,
+            harness_components,
+            harness_profile,
+            harness_compression_provider,
+        )
+    ):
+        enhance = data.get("harness_enhance")
+        if not isinstance(enhance, dict):
+            enhance = {}
+        if enable_harness_enhance is not None:
+            enhance["enabled"] = enable_harness_enhance
+        if harness_components is not None:
+            enhance["components"] = [
+                item.strip() for item in harness_components.split(",") if item.strip()
+            ]
+        if harness_profile is not None:
+            enhance["profile"] = harness_profile
+        if harness_compression_provider is not None:
+            enhance["compression_provider"] = harness_compression_provider
+        data["harness_enhance"] = enhance
     # Set only the backend `type`, preserving any connection params already set
     # under the component section.
     for type_value, section_key in (
@@ -780,7 +853,7 @@ def deploy(
         lines.append(f"Discovery:  {auth['discovery_url']}")
         lines.append(f"Allowed ids: {', '.join(auth['allowed_ids'])}")
     elif apikey:
-        lines.append(f"API key:    {apikey}")
+        lines.append("API key:    saved in local harness.json (not printed)")
 
     if endpoint:
         json_path = _record_harness(

--- a/veadk/cloud/harness_app/app.py
+++ b/veadk/cloud/harness_app/app.py
@@ -28,12 +28,22 @@ import os
 import tempfile
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from google.adk.agents import RunConfig
+from google.adk.plugins import BasePlugin
 
 from veadk import Agent
 from veadk.cloud.harness_app.agent import agent, short_term_memory
+from veadk.cloud.harness_app.harness_plugins import (
+    build_harness_plugins_from_enhance,
+    build_harness_plugins_from_headers,
+    build_harness_plugins_from_runtime_env,
+)
+from veadk.cloud.harness_app.metrics import HarnessLlmUsagePlugin
 from veadk.cloud.harness_app.types import (
+    HarnessCompactionMetric,
+    HarnessPluginMetrics,
+    HarnessResponseMetrics,
     InvokeHarnessRequest,
     InvokeHarnessResponse,
 )
@@ -54,6 +64,12 @@ HARNESS_NAME = os.getenv("HARNESS_NAME", "default")
 DEFAULT_MAX_LLM_CALLS = (
     int(os.environ["MAX_LLM_CALLS"]) if os.environ.get("MAX_LLM_CALLS") else None
 )
+RETURN_LLM_USAGE = os.getenv("HARNESS_APP_RETURN_LLM_USAGE", "").lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
 
 
 class HarnessApp:
@@ -69,10 +85,13 @@ class HarnessApp:
         self.short_term_memory = short_term_memory
         self.harness_name = harness_name
         self.max_llm_calls = max_llm_calls
+        self.return_llm_usage = RETURN_LLM_USAGE
+        self.plugins = build_harness_plugins_from_runtime_env()
         self.runner = Runner(
             agent=agent,
             short_term_memory=short_term_memory,
             app_name=harness_name,
+            plugins=self.plugins,
         )
 
         self.mount()
@@ -81,6 +100,7 @@ class HarnessApp:
         @self.app.post("/harness/invoke")
         async def invoke_harness(
             request: InvokeHarnessRequest,
+            http_request: Request,
         ) -> InvokeHarnessResponse:
             # max LLM calls: per-call override, else the harness default; if
             # neither is set, fall through to ADK RunConfig's own default.
@@ -94,6 +114,23 @@ class HarnessApp:
             )
 
             try:
+                header_plugins = build_harness_plugins_from_headers(
+                    http_request.headers
+                )
+                body_plugins = build_harness_plugins_from_enhance(
+                    request.harness_enhance
+                )
+                usage_plugin = (
+                    HarnessLlmUsagePlugin() if self.return_llm_usage else None
+                )
+                harness_plugins = body_plugins or header_plugins or self.plugins
+                self._reset_plugin_diagnostics(harness_plugins)
+                if harness_plugins:
+                    logger.info(
+                        "Harness plugins enabled for invocation: "
+                        + ", ".join(self._plugin_names(harness_plugins))
+                    )
+                plugins = self._plugins_for_run(harness_plugins, usage_plugin)
                 if request.harness is not None:
                     logger.info(
                         f"Applying once-time harness override: {request.harness}"
@@ -112,6 +149,7 @@ class HarnessApp:
                             agent=agent,
                             short_term_memory=self.short_term_memory,
                             app_name=self.harness_name,
+                            plugins=plugins,
                         )
                         output = await runner.run(
                             messages=[request.prompt],
@@ -119,6 +157,32 @@ class HarnessApp:
                             session_id=request.run_agent_request.session_id,
                             run_config=run_config,
                         )
+                elif header_plugins:
+                    runner = Runner(
+                        agent=self.agent,
+                        short_term_memory=self.short_term_memory,
+                        app_name=self.harness_name,
+                        plugins=plugins,
+                    )
+                    output = await runner.run(
+                        messages=[request.prompt],
+                        user_id=request.run_agent_request.user_id,
+                        session_id=request.run_agent_request.session_id,
+                        run_config=run_config,
+                    )
+                elif usage_plugin:
+                    runner = Runner(
+                        agent=self.agent,
+                        short_term_memory=self.short_term_memory,
+                        app_name=self.harness_name,
+                        plugins=plugins,
+                    )
+                    output = await runner.run(
+                        messages=[request.prompt],
+                        user_id=request.run_agent_request.user_id,
+                        session_id=request.run_agent_request.session_id,
+                        run_config=run_config,
+                    )
                 else:
                     output = await self.runner.run(
                         messages=[request.prompt],
@@ -151,7 +215,65 @@ class HarnessApp:
                 harness_name=self.harness_name,
                 overwrite=request.harness is not None,
                 output=output,
+                metrics=(
+                    self._response_metrics(harness_plugins, usage_plugin)
+                    if usage_plugin
+                    else None
+                ),
             )
+
+    def _plugins_for_run(
+        self,
+        plugins: list[BasePlugin],
+        usage_plugin: HarnessLlmUsagePlugin | None,
+    ) -> list[BasePlugin]:
+        if usage_plugin is None:
+            return plugins
+        return [*plugins, usage_plugin]
+
+    def _response_metrics(
+        self,
+        plugins: list[BasePlugin],
+        usage_plugin: HarnessLlmUsagePlugin,
+    ) -> HarnessResponseMetrics:
+        return HarnessResponseMetrics(
+            llm_usage=usage_plugin.metrics,
+            harness_plugins=HarnessPluginMetrics(
+                names=self._plugin_names(plugins),
+                compaction_reports=self._compaction_reports(plugins),
+            ),
+        )
+
+    def _plugin_names(self, plugins: list[BasePlugin]) -> list[str]:
+        return [
+            str(getattr(plugin, "name", plugin.__class__.__name__))
+            for plugin in plugins
+        ]
+
+    def _reset_plugin_diagnostics(self, plugins: list[BasePlugin]) -> None:
+        for plugin in plugins:
+            reset_diagnostics = getattr(plugin, "reset_diagnostics", None)
+            if callable(reset_diagnostics):
+                reset_diagnostics()
+
+    def _compaction_reports(
+        self, plugins: list[BasePlugin]
+    ) -> list[HarnessCompactionMetric]:
+        metrics: list[HarnessCompactionMetric] = []
+        for plugin in plugins:
+            reports = getattr(plugin, "compaction_reports", None)
+            if not isinstance(reports, list):
+                continue
+            for report in reports:
+                if hasattr(report, "model_dump"):
+                    metrics.append(
+                        HarnessCompactionMetric.model_validate(
+                            report.model_dump(mode="json")
+                        )
+                    )
+                elif isinstance(report, dict):
+                    metrics.append(HarnessCompactionMetric.model_validate(report))
+        return metrics
 
     def serve(self, host: str = "0.0.0.0", port: int = 8000) -> None:
         import uvicorn

--- a/veadk/cloud/harness_app/env_mapping.py
+++ b/veadk/cloud/harness_app/env_mapping.py
@@ -169,6 +169,8 @@ def to_runtime_env(spec: dict[str, Any]) -> dict[str, str]:
             continue
         env[key.upper()] = _stringify(value)
 
+    _add_harness_enhance_aliases(env, spec)
+
     # Component sections: `type` selector + backend-specific connection params.
     for component, type_env in COMPONENT_TYPE_ENV.items():
         section: dict[str, Any] = spec.get(component) or {}
@@ -195,3 +197,43 @@ def to_runtime_env(spec: dict[str, Any]) -> dict[str, str]:
             env[env_name] = _stringify(value)
 
     return env
+
+
+def _add_harness_enhance_aliases(env: dict[str, str], spec: dict[str, Any]) -> None:
+    """Expose harness_enhance fields under the SDK's generic env names too."""
+
+    section = spec.get("harness_enhance")
+    if not isinstance(section, dict):
+        return
+    compression = section.get("compression")
+    if not isinstance(compression, dict):
+        compression = {}
+    verifier = section.get("verifier")
+    if not isinstance(verifier, dict):
+        verifier = {}
+
+    aliases = {
+        "components": "HARNESS_COMPONENTS",
+        "profile": "HARNESS_PROFILE",
+        "compression_provider": "HARNESS_COMPRESSION_PROVIDER",
+        "max_context_chars": "HARNESS_MAX_CONTEXT_CHARS",
+        "max_tool_result_chars": "HARNESS_MAX_TOOL_RESULT_CHARS",
+        "verifier_mode": "HARNESS_VERIFIER_MODE",
+        "store_path": "HARNESS_STORE_PATH",
+    }
+    nested_aliases = {
+        "provider": "HARNESS_COMPRESSION_PROVIDER",
+        "max_context_chars": "HARNESS_MAX_CONTEXT_CHARS",
+        "max_tool_result_chars": "HARNESS_MAX_TOOL_RESULT_CHARS",
+    }
+    for key, env_name in aliases.items():
+        value = section.get(key)
+        if not _is_empty(value):
+            env[env_name] = _stringify(value)
+    for key, env_name in nested_aliases.items():
+        value = compression.get(key)
+        if not _is_empty(value):
+            env[env_name] = _stringify(value)
+    verifier_mode = verifier.get("mode")
+    if not _is_empty(verifier_mode):
+        env["HARNESS_VERIFIER_MODE"] = _stringify(verifier_mode)

--- a/veadk/cloud/harness_app/harness_plugins.py
+++ b/veadk/cloud/harness_app/harness_plugins.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Harness plugin assembly for HarnessApp Runtime."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+from google.adk.plugins import BasePlugin
+
+from veadk.cloud.harness_app.types import HarnessEnhanceOverrides
+from veadk.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def build_harness_plugins_from_runtime_env(
+    env: Mapping[str, str] | None = None,
+) -> list[BasePlugin]:
+    """Build Harness plugins from environment values."""
+
+    values = dict(env or os.environ)
+    try:
+        from veadk.extensions.harness.env import build_harness_plugins_from_env
+    except ImportError as e:
+        if _truthy(values.get("HARNESS_ENHANCE_ENABLED")):
+            logger.warning(
+                "HARNESS_ENHANCE_ENABLED is set but the Harness extension "
+                f"could not be imported: {e!r}"
+            )
+        return []
+    return build_harness_plugins_from_env(values)
+
+
+def build_harness_plugins_from_headers(
+    headers: Mapping[str, str],
+    *,
+    base_env: Mapping[str, str] | None = None,
+) -> list[BasePlugin]:
+    """Build per-invocation plugins from AgentKit/HTTP Harness headers."""
+
+    header_env = harness_env_from_headers(headers)
+    if not header_env:
+        return []
+    values = dict(base_env or os.environ)
+    values.update(header_env)
+    return build_harness_plugins_from_runtime_env(values)
+
+
+def build_harness_plugins_from_enhance(
+    enhance: HarnessEnhanceOverrides | None,
+    *,
+    base_env: Mapping[str, str] | None = None,
+) -> list[BasePlugin]:
+    """Build per-invocation plugins from request-body Harness settings."""
+
+    body_env = harness_env_from_enhance(enhance)
+    if not body_env:
+        return []
+    values = dict(base_env or os.environ)
+    values.update(body_env)
+    return build_harness_plugins_from_runtime_env(values)
+
+
+def harness_env_from_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    """Convert generic Harness headers into SDK environment keys."""
+
+    normalized = {str(key).lower(): str(value) for key, value in headers.items()}
+    enabled = normalized.get("x-harness-enhance") or normalized.get(
+        "x-harness-enable-context"
+    )
+    if not _truthy(enabled):
+        return {}
+    env = {"HARNESS_ENHANCE_ENABLED": "true"}
+    components = normalized.get("x-harness-components")
+    if components:
+        env["HARNESS_COMPONENTS"] = components
+        env["HARNESS_ENHANCE_COMPONENTS"] = components
+    profile = normalized.get("x-harness-profile")
+    if profile:
+        env["HARNESS_PROFILE"] = profile
+        env["HARNESS_ENHANCE_PROFILE"] = profile
+    compression_provider = normalized.get("x-harness-compression-provider")
+    if compression_provider:
+        env["HARNESS_COMPRESSION_PROVIDER"] = compression_provider
+        env["HARNESS_ENHANCE_COMPRESSION_PROVIDER"] = compression_provider
+    return env
+
+
+def harness_env_from_enhance(
+    enhance: HarnessEnhanceOverrides | None,
+) -> dict[str, str]:
+    """Convert request-body Harness settings into SDK environment keys."""
+
+    if enhance is None or not enhance.enabled:
+        return {}
+    env = {"HARNESS_ENHANCE_ENABLED": "true"}
+    if enhance.components:
+        env["HARNESS_COMPONENTS"] = enhance.components
+        env["HARNESS_ENHANCE_COMPONENTS"] = enhance.components
+    if enhance.profile:
+        env["HARNESS_PROFILE"] = enhance.profile
+        env["HARNESS_ENHANCE_PROFILE"] = enhance.profile
+    if enhance.compression_provider:
+        env["HARNESS_COMPRESSION_PROVIDER"] = enhance.compression_provider
+        env["HARNESS_ENHANCE_COMPRESSION_PROVIDER"] = enhance.compression_provider
+    return env
+
+
+def _truthy(value: str | None) -> bool:
+    return bool(value and value.strip().lower() in _TRUTHY)

--- a/veadk/cloud/harness_app/metrics.py
+++ b/veadk/cloud/harness_app/metrics.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-invocation metrics plugins for HarnessApp Runtime."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+from google.adk.models import LlmResponse
+from google.adk.plugins import BasePlugin
+
+from veadk.cloud.harness_app.types import LlmUsageMetrics
+
+if TYPE_CHECKING:
+    from google.adk.agents.callback_context import CallbackContext
+
+
+class HarnessLlmUsagePlugin(BasePlugin):
+    """Collect aggregate LLM usage from ADK model callbacks."""
+
+    def __init__(self) -> None:
+        super().__init__(name="harness_llm_usage_collector")
+        self.metrics = LlmUsageMetrics()
+
+    async def after_model_callback(
+        self,
+        *,
+        callback_context: "CallbackContext",
+        llm_response: LlmResponse,
+    ) -> LlmResponse | None:
+        usage = _usage_metrics_from_object(llm_response.usage_metadata)
+        if usage.has_tokens():
+            self.metrics.add(usage)
+        return None
+
+
+def _usage_metrics_from_object(value: object) -> LlmUsageMetrics:
+    return LlmUsageMetrics(
+        prompt_tokens=_int_value(
+            value,
+            "prompt_token_count",
+            "prompt_tokens",
+            "input_tokens",
+        ),
+        completion_tokens=_int_value(
+            value,
+            "candidates_token_count",
+            "completion_tokens",
+            "output_tokens",
+        ),
+        total_tokens=_int_value(
+            value,
+            "total_token_count",
+            "total_tokens",
+        ),
+        cached_tokens=_int_value(
+            value,
+            "cached_content_token_count",
+            "cached_tokens",
+        ),
+        usage_event_count=1,
+    )
+
+
+def _int_value(value: object, *names: str) -> int:
+    for name in names:
+        raw = _field_value(value, name)
+        if raw is None:
+            continue
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            continue
+    return 0
+
+
+def _field_value(value: object, name: str) -> object | None:
+    if isinstance(value, Mapping):
+        return value.get(name)
+    return getattr(value, name, None)

--- a/veadk/cloud/harness_app/types.py
+++ b/veadk/cloud/harness_app/types.py
@@ -80,6 +80,30 @@ class HarnessConfig(HarnessOverrides):
     )
 
 
+class HarnessEnhanceOverrides(BaseModel):
+    """Per-invocation Harness enhancement options.
+
+    This mirrors the runtime ``harness_enhance`` section but is intentionally
+    small: callers can enable the plugin bundle, choose components, select a
+    profile, and choose the compaction provider. Runtime limits keep their
+    deploy-time defaults.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description="Enable Harness plugins for this single invocation.",
+    )
+    components: str = Field(
+        default="invocation_context,compactor,response_verification",
+        description="Comma-separated Harness plugin components.",
+    )
+    profile: str = Field(default="default", description="Harness profile name.")
+    compression_provider: str | None = Field(
+        default=None,
+        description="Tool-result compaction provider, e.g. builtin or headroom.",
+    )
+
+
 class RunAgentRequest(BaseModel):
     user_id: str
     session_id: str
@@ -89,6 +113,55 @@ class RunAgentRequest(BaseModel):
     )
 
 
+class LlmUsageMetrics(BaseModel):
+    """Aggregated model usage for one HarnessApp invocation."""
+
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    cached_tokens: int = 0
+    usage_event_count: int = 0
+
+    def add(self, value: "LlmUsageMetrics") -> None:
+        self.prompt_tokens += value.prompt_tokens
+        self.completion_tokens += value.completion_tokens
+        self.total_tokens += value.total_tokens
+        self.cached_tokens += value.cached_tokens
+        self.usage_event_count += value.usage_event_count
+
+    def has_tokens(self) -> bool:
+        return bool(self.total_tokens or self.prompt_tokens or self.completion_tokens)
+
+
+class HarnessCompactionMetric(BaseModel):
+    """Compaction accounting exposed by HarnessApp diagnostics."""
+
+    provider: str = ""
+    original_chars: int = 0
+    compressed_chars: int = 0
+    changed: bool = False
+    tokens_before: int = 0
+    tokens_after: int = 0
+    tokens_saved: int = 0
+    compression_ratio: float = 0.0
+    transforms_applied: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class HarnessPluginMetrics(BaseModel):
+    """Harness plugin diagnostics for one invocation."""
+
+    names: list[str] = Field(default_factory=list)
+    compaction_reports: list[HarnessCompactionMetric] = Field(default_factory=list)
+
+
+class HarnessResponseMetrics(BaseModel):
+    """Optional machine-readable metrics returned by HarnessApp Runtime."""
+
+    llm_usage: LlmUsageMetrics = Field(default_factory=LlmUsageMetrics)
+    harness_plugins: HarnessPluginMetrics = Field(default_factory=HarnessPluginMetrics)
+
+
 class InvokeHarnessRequest(BaseModel):
     prompt: str
     harness_name: str
@@ -96,6 +169,7 @@ class InvokeHarnessRequest(BaseModel):
     # this single call. Only the fields actually set are applied; memory and the
     # knowledge base are never overridable (absent from HarnessOverrides).
     harness: HarnessOverrides | None = None
+    harness_enhance: HarnessEnhanceOverrides | None = None
     run_agent_request: RunAgentRequest
 
 
@@ -103,6 +177,10 @@ class InvokeHarnessResponse(BaseModel):
     harness_name: str
     overwrite: bool = Field(default=False)
     output: str
+    metrics: HarnessResponseMetrics | None = Field(
+        default=None,
+        description="Optional runtime metrics, enabled by HARNESS_APP_RETURN_LLM_USAGE.",
+    )
     error: str | None = Field(
         default=None,
         description=(

--- a/veadk/extensions/harness/README.md
+++ b/veadk/extensions/harness/README.md
@@ -1,0 +1,99 @@
+# veADK Harness Extension
+
+[中文](README.zh.md)
+
+`veadk.extensions.harness` is a lightweight Harness extension for veADK applications. It adds three reusable capabilities:
+
+- context preparation for each agent turn
+- tool-result compaction
+- answer verification and hallucination suppression
+
+The extension can be used directly as Python modules or attached to a veADK
+Runner. It does not require a separate runtime service.
+
+## Install
+
+```bash
+pip install "veadk-python[harness]"
+```
+
+The base extension is bundled with veADK. The `harness` extra installs the
+optional in-process Headroom compaction provider.
+
+For local development inside this repository:
+
+```bash
+pip install .
+```
+
+For local development with Headroom:
+
+```bash
+pip install ".[harness]"
+```
+
+## Quick Start
+
+```python
+from veadk.extensions.harness.adk import build_harness_plugins
+from veadk import Agent, Runner
+
+agent = Agent(name="research_agent")
+runner = Runner(
+    agent=agent,
+    app_name="research",
+    plugins=build_harness_plugins(
+        components=["invocation_context", "compactor", "response_verification"],
+        profile="research",
+    ),
+)
+```
+
+## Plugins
+
+| Plugin | Main hooks | Purpose |
+| --- | --- | --- |
+| `HarnessInvocationContextPlugin` | `on_user_message_callback`, `before_model_callback` | Prepares task anchors, recent context, and tool-use guardrails. |
+| `HarnessCompressPlugin` | `before_model_callback`, `after_tool_callback` | Shrinks oversized tool outputs while preserving useful facts. |
+| `HarnessResponseVerificationPlugin` | `after_tool_callback`, `after_model_callback`, `on_event_callback` | Records tool receipts and flags unsupported final claims. |
+
+## Runtime Environment
+
+```text
+HARNESS_ENHANCE_ENABLED=true
+HARNESS_ENHANCE_COMPONENTS=invocation_context,compactor,response_verification
+HARNESS_PROFILE=research
+HARNESS_COMPRESSION_PROVIDER=builtin
+```
+
+```python
+from veadk.extensions.harness.env import build_harness_plugins_from_env
+
+plugins = build_harness_plugins_from_env()
+```
+
+With veADK HarnessApp deployment, the same settings can be written in
+`harness.yaml`:
+
+```yaml
+harness_enhance:
+  enabled: true
+  components: [invocation_context, compactor, response_verification]
+  profile: general
+  compression_provider: builtin
+```
+
+## Direct Module Usage
+
+```python
+from veadk.extensions.harness import HarnessInvocationContextBuilder, HarnessInvocationRef
+
+context = HarnessInvocationRef(session_id="session-1", invocation_id="run-1")
+builder = HarnessInvocationContextBuilder()
+bundle = builder.prepare_context(context, user_input="Summarize these tool results.")
+```
+
+## Learn More
+
+See [docs/README.md](docs/README.md) for a short zero-to-first-run guide,
+concepts, configuration, and evaluation commands.

--- a/veadk/extensions/harness/README.zh.md
+++ b/veadk/extensions/harness/README.zh.md
@@ -1,0 +1,98 @@
+# veADK Harness Extension
+
+[English](README.md)
+
+`veadk.extensions.harness` 是一个轻量级 Harness Extension，它提供三个可复用能力：
+
+- 为每轮 Agent 调用准备上下文
+- 压缩大体积工具结果
+- 验证最终回答，降低幻觉
+
+Extension 可以作为普通 Python 模块直接使用，也可以挂载到 veADK Runner。
+它不需要单独启动运行时服务。
+
+## 安装
+
+```bash
+pip install "veadk-python[harness]"
+```
+
+基础 Harness Extension 已随 veADK 内置。`harness` extra 会安装可选的进程内
+Headroom 压缩 provider。
+
+在当前仓库内本地开发：
+
+```bash
+pip install .
+```
+
+本地开发并启用 Headroom：
+
+```bash
+pip install ".[harness]"
+```
+
+## 快速开始
+
+```python
+from veadk.extensions.harness.adk import build_harness_plugins
+from veadk import Agent, Runner
+
+agent = Agent(name="research_agent")
+runner = Runner(
+    agent=agent,
+    app_name="research",
+    plugins=build_harness_plugins(
+        components=["invocation_context", "compactor", "response_verification"],
+        profile="research",
+    ),
+)
+```
+
+## 插件能力
+
+| 插件 | 主要 Hook | 作用 |
+| --- | --- | --- |
+| `HarnessInvocationContextPlugin` | `on_user_message_callback`, `before_model_callback` | 准备任务锚点、近期上下文和工具使用约束。 |
+| `HarnessCompressPlugin` | `before_model_callback`, `after_tool_callback` | 压缩过大的工具输出，同时保留关键事实。 |
+| `HarnessResponseVerificationPlugin` | `after_tool_callback`, `after_model_callback`, `on_event_callback` | 记录工具执行 receipt，并标记缺少证据的最终回答。 |
+
+## 运行时配置
+
+```text
+HARNESS_ENHANCE_ENABLED=true
+HARNESS_ENHANCE_COMPONENTS=invocation_context,compactor,response_verification
+HARNESS_PROFILE=research
+HARNESS_COMPRESSION_PROVIDER=builtin
+```
+
+```python
+from veadk.extensions.harness.env import build_harness_plugins_from_env
+
+plugins = build_harness_plugins_from_env()
+```
+
+在 veADK HarnessApp 部署中，也可以写入 `harness.yaml`：
+
+```yaml
+harness_enhance:
+  enabled: true
+  components: [invocation_context, compactor, response_verification]
+  profile: general
+  compression_provider: builtin
+```
+
+## 直接使用模块
+
+```python
+from veadk.extensions.harness import HarnessInvocationContextBuilder, HarnessInvocationRef
+
+context = HarnessInvocationRef(session_id="session-1", invocation_id="run-1")
+builder = HarnessInvocationContextBuilder()
+bundle = builder.prepare_context(context, user_input="Summarize these tool results.")
+```
+
+## 更多文档
+
+请阅读 [docs/README.zh.md](docs/README.zh.md)。里面包含精简的新手教程、核心概念、
+配置方式和评测命令。

--- a/veadk/extensions/harness/__init__.py
+++ b/veadk/extensions/harness/__init__.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Composable Agent Harness SDK."""
+
+from veadk.extensions.harness.extension import HarnessExtension, HarnessExtensionConfig
+from veadk.extensions.harness.modules.headroom_provider import (
+    HeadroomCompressionProvider,
+)
+from veadk.extensions.harness.modules.invocation_context import (
+    ContextEngine,
+    HarnessInvocationContextBuilder,
+    HarnessInvocationContextConfig,
+)
+from veadk.extensions.harness.modules.final_response_verifier import (
+    FinalResponseVerifier,
+    ResultVerifier,
+)
+from veadk.extensions.harness.modules.tool_result_compactor import (
+    ToolResultCompactor,
+    ToolResultCompressor,
+)
+from veadk.extensions.harness.schemas import (
+    CapabilityReceipt,
+    ToolReceipt,
+    CompactionReport,
+    CompressionReport,
+    CompressionRequest,
+    CompactionResult,
+    CompressionResult,
+    ContextBundle,
+    InvocationContextBlock,
+    ConversationMessage,
+    EvidenceRef,
+    HarnessEvent,
+    HarnessIntervention,
+    VerificationDecision,
+    HarnessRunContext,
+    HarnessInvocationRef,
+    TaskContract,
+    VerificationReport,
+)
+
+__all__ = [
+    "CapabilityReceipt",
+    "ToolReceipt",
+    "CompactionReport",
+    "CompressionReport",
+    "CompressionRequest",
+    "CompactionResult",
+    "CompressionResult",
+    "ContextBundle",
+    "InvocationContextBlock",
+    "ContextEngine",
+    "ConversationMessage",
+    "EvidenceRef",
+    "HeadroomCompressionProvider",
+    "HarnessIntervention",
+    "VerificationDecision",
+    "HarnessEvent",
+    "HarnessExtension",
+    "HarnessExtensionConfig",
+    "HarnessInvocationContextBuilder",
+    "HarnessInvocationContextConfig",
+    "HarnessRunContext",
+    "HarnessInvocationRef",
+    "FinalResponseVerifier",
+    "ResultVerifier",
+    "TaskContract",
+    "ToolResultCompactor",
+    "ToolResultCompressor",
+    "VerificationReport",
+]

--- a/veadk/extensions/harness/adk/__init__.py
+++ b/veadk/extensions/harness/adk/__init__.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Harness plugin entry points for veADK Runner."""
+
+from veadk.extensions.harness.adk.plugins import (
+    HarnessCompressPlugin,
+    HarnessContextPlugin,
+    HarnessHallucinationPlugin,
+    HarnessInvocationContextPlugin,
+    HarnessResponseVerificationPlugin,
+    build_harness_plugins,
+)
+
+__all__ = [
+    "HarnessCompressPlugin",
+    "HarnessContextPlugin",
+    "HarnessHallucinationPlugin",
+    "HarnessInvocationContextPlugin",
+    "HarnessResponseVerificationPlugin",
+    "build_harness_plugins",
+]

--- a/veadk/extensions/harness/adk/content_adapter.py
+++ b/veadk/extensions/harness/adk/content_adapter.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Adapters between Google ADK content objects and Harness schemas."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from google.adk.models import LlmRequest
+from google.genai import types
+
+from veadk.extensions.harness.schemas import ConversationMessage
+from veadk.extensions.harness.utils import stringify_json_value
+
+
+def content_to_text(content: types.Content | None) -> str:
+    """Extract text-like content from a Google GenAI Content object."""
+
+    if content is None or not content.parts:
+        return ""
+    values: list[str] = []
+    for part in content.parts:
+        if part.text:
+            values.append(part.text)
+        elif part.function_response is not None:
+            values.append(stringify_json_value(part.function_response.model_dump()))
+        elif part.function_call is not None:
+            values.append(stringify_json_value(part.function_call.model_dump()))
+        elif part.executable_code is not None:
+            values.append(part.executable_code.code or "")
+        elif part.code_execution_result is not None:
+            values.append(stringify_json_value(part.code_execution_result.model_dump()))
+    return "\n".join(value for value in values if value)
+
+
+def contents_to_messages(
+    contents: Iterable[types.Content],
+) -> list[ConversationMessage]:
+    """Project ADK contents into protocol-neutral Harness messages."""
+
+    messages = []
+    for content in contents:
+        text = content_to_text(content)
+        if not text:
+            continue
+        messages.append(
+            ConversationMessage(role=content.role or "unknown", content=text)
+        )
+    return messages
+
+
+def append_system_instruction(llm_request: LlmRequest, instruction: str) -> None:
+    """Append Harness context to the model system instruction."""
+
+    existing = llm_request.config.system_instruction
+    if not existing:
+        llm_request.config.system_instruction = instruction
+        return
+    if isinstance(existing, str):
+        llm_request.config.system_instruction = f"{existing}\n\n{instruction}"
+        return
+    existing_text = _system_instruction_to_text(existing)
+    if existing_text:
+        llm_request.config.system_instruction = f"{existing_text}\n\n{instruction}"
+    else:
+        llm_request.config.system_instruction = instruction
+
+
+def response_text(content: types.Content | None) -> str:
+    """Extract final response text."""
+
+    return content_to_text(content)
+
+
+def text_response(text: str) -> types.Content:
+    """Build a model response content from text."""
+
+    return types.Content(role="model", parts=[types.Part(text=text)])
+
+
+def _system_instruction_to_text(value: object) -> str:
+    if isinstance(value, types.Content):
+        return content_to_text(value)
+    if isinstance(value, types.Part):
+        return value.text or stringify_json_value(value.model_dump())
+    if isinstance(value, list):
+        values = [_system_instruction_to_text(item) for item in value]
+        return "\n".join(item for item in values if item)
+    return stringify_json_value(value)

--- a/veadk/extensions/harness/adk/plugins.py
+++ b/veadk/extensions/harness/adk/plugins.py
@@ -1,0 +1,494 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runner plugins backed by atomic Harness modules."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import TYPE_CHECKING
+
+from google.adk.models import LlmRequest, LlmResponse
+from google.adk.plugins import BasePlugin
+
+from veadk.extensions.harness.adk.content_adapter import (
+    append_system_instruction,
+    contents_to_messages,
+    response_text,
+    text_response,
+)
+from veadk.extensions.harness.modules.invocation_context import (
+    HarnessInvocationContextBuilder,
+    HarnessInvocationContextConfig,
+)
+from veadk.extensions.harness.modules.final_response_verifier import (
+    FinalResponseVerifier,
+    FinalResponseVerifierConfig,
+)
+from veadk.extensions.harness.modules.tool_result_compactor import (
+    ToolResultCompactor,
+    ToolResultCompactorConfig,
+)
+from veadk.extensions.harness.schemas import (
+    ToolReceipt,
+    CompactionReport,
+    CompressionRequest,
+    ConversationMessage,
+    EvidenceRef,
+    HarnessEvent,
+    HarnessInvocationRef,
+    TaskContract,
+)
+from veadk.extensions.harness.stores import HarnessStoreProtocol, InMemoryHarnessStore
+from veadk.extensions.harness.utils import (
+    coerce_json_object,
+    stringify_json_value,
+    summarize_text,
+)
+
+if TYPE_CHECKING:
+    from google.adk.agents.callback_context import CallbackContext
+    from google.adk.agents.invocation_context import InvocationContext
+    from google.adk.events.event import Event
+    from google.adk.tools.base_tool import BaseTool
+    from google.adk.tools.tool_context import ToolContext
+    from google.genai import types
+
+
+ComponentName = str
+
+
+class HarnessInvocationContextPlugin(BasePlugin):
+    """Injects task context and guardrails before model calls."""
+
+    def __init__(
+        self,
+        *,
+        context_builder: HarnessInvocationContextBuilder | None = None,
+        context_engine: HarnessInvocationContextBuilder | None = None,
+        store: HarnessStoreProtocol | None = None,
+        profile: str = "default",
+    ) -> None:
+        super().__init__(name="harness_invocation_context_plugin")
+        self.context_builder = (
+            context_builder or context_engine or HarnessInvocationContextBuilder()
+        )
+        self.context_engine = self.context_builder
+        self.store = store or InMemoryHarnessStore()
+        self.profile = profile
+
+    async def before_model_callback(
+        self,
+        *,
+        callback_context: "CallbackContext",
+        llm_request: LlmRequest,
+    ) -> LlmResponse | None:
+        run_context = _run_context_from_callback(callback_context, profile=self.profile)
+        user_text = _user_text_from_callback(callback_context)
+        history = contents_to_messages(llm_request.contents)
+        receipts = self.store.load_receipts(
+            run_id=run_context.invocation_id,
+            session_id=run_context.session_id,
+            limit=8,
+        )
+        bundle = self.context_builder.prepare_context(
+            run_context,
+            user_input=user_text,
+            history=history,
+            receipts=receipts,
+            has_tools=bool(llm_request.tools_dict),
+        )
+        if bundle.header:
+            append_system_instruction(llm_request, bundle.header)
+            self.store.append_event(
+                HarnessEvent(
+                    event_type="invocation_context.injected",
+                    run_context=run_context,
+                    payload={
+                        "context_chars": bundle.context_chars,
+                        "history_messages": len(history),
+                        "receipt_count": len(receipts),
+                    },
+                )
+            )
+        return None
+
+    async def on_user_message_callback(
+        self,
+        *,
+        invocation_context: "InvocationContext",
+        user_message: "types.Content",
+    ) -> "types.Content | None":
+        text = stringify_json_value(user_message.model_dump(), max_chars=4000)
+        run_context = _run_context_from_invocation(
+            invocation_context,
+            profile=self.profile,
+        )
+        self.store.append_message(
+            run_context.session_id,
+            _message_from_text("user", text),
+        )
+        return None
+
+
+class HarnessCompressPlugin(BasePlugin):
+    """Compacts oversized tool results and historical tool context."""
+
+    def __init__(
+        self,
+        *,
+        compactor: ToolResultCompactor | None = None,
+        compressor: ToolResultCompactor | None = None,
+        store: HarnessStoreProtocol | None = None,
+        profile: str = "default",
+    ) -> None:
+        super().__init__(name="harness_compress_plugin")
+        self.compactor = compactor or compressor or ToolResultCompactor()
+        self.compressor = self.compactor
+        self.store = store or InMemoryHarnessStore()
+        self.profile = profile
+        self.compaction_reports: list[CompactionReport] = []
+
+    async def before_model_callback(
+        self,
+        *,
+        callback_context: "CallbackContext",
+        llm_request: LlmRequest,
+    ) -> LlmResponse | None:
+        tool_reports = self._compact_function_responses(llm_request)
+        messages = contents_to_messages(llm_request.contents)
+        self.compaction_reports.extend(tool_reports)
+        if not messages:
+            return None
+        result = self.compactor.compress_messages(
+            CompressionRequest(
+                messages=messages,
+                max_context_chars=self.compactor.config.max_context_chars,
+            )
+        )
+        if result.report.changed or tool_reports:
+            self.store.append_event(
+                HarnessEvent(
+                    event_type="compressor.model_context",
+                    run_context=_run_context_from_callback(
+                        callback_context,
+                        profile=self.profile,
+                    ),
+                    payload={
+                        "context_report": result.report.model_dump(mode="json"),
+                        "tool_reports": [
+                            report.model_dump(mode="json") for report in tool_reports
+                        ],
+                    },
+                )
+            )
+            if result.report.changed:
+                self.compaction_reports.append(result.report)
+        return None
+
+    async def after_tool_callback(
+        self,
+        *,
+        tool: "BaseTool",
+        tool_args: dict[str, object],
+        tool_context: "ToolContext",
+        result: dict[str, object],
+    ) -> dict[str, object] | None:
+        compressed, report = self.compactor.compress_tool_result(result)
+        if not report.changed:
+            return None
+        self.compaction_reports.append(report)
+        self.store.append_event(
+            HarnessEvent(
+                event_type="compressor.tool_result",
+                run_context=_run_context_from_tool(tool_context, profile=self.profile),
+                payload={
+                    "tool": _tool_name(tool),
+                    "tool_args": coerce_json_object(tool_args),
+                    "report": report.model_dump(mode="json"),
+                },
+            )
+        )
+        return compressed if isinstance(compressed, dict) else {"result": compressed}
+
+    def reset_diagnostics(self) -> None:
+        self.compaction_reports.clear()
+
+    def _compact_function_responses(
+        self, llm_request: LlmRequest
+    ) -> list[CompactionReport]:
+        reports: list[CompactionReport] = []
+        for content in llm_request.contents:
+            for part in content.parts or []:
+                function_response = part.function_response
+                if function_response is None:
+                    continue
+                response = function_response.response
+                if not isinstance(response, dict):
+                    continue
+                compressed, report = self.compactor.compress_tool_result(response)
+                if not report.changed:
+                    continue
+                function_response.response = compressed
+                reports.append(report)
+        return reports
+
+
+class HarnessResponseVerificationPlugin(BasePlugin):
+    """Records receipts and suppresses unsupported final claims."""
+
+    def __init__(
+        self,
+        *,
+        verifier: FinalResponseVerifier | None = None,
+        store: HarnessStoreProtocol | None = None,
+        profile: str = "default",
+    ) -> None:
+        super().__init__(name="harness_response_verification_plugin")
+        self.verifier = verifier or FinalResponseVerifier()
+        self.store = store or InMemoryHarnessStore()
+        self.profile = profile
+
+    async def after_tool_callback(
+        self,
+        *,
+        tool: "BaseTool",
+        tool_args: dict[str, object],
+        tool_context: "ToolContext",
+        result: object,
+    ) -> dict[str, object] | None:
+        run_context = _run_context_from_tool(tool_context, profile=self.profile)
+        tool_name = _tool_name(tool)
+        result_object = result if isinstance(result, dict) else {"result": result}
+        summary = summarize_text(stringify_json_value(result_object), max_chars=1200)
+        status = "error" if _looks_like_error_result(result_object) else "success"
+        receipt = ToolReceipt(
+            name=tool_name,
+            status=status,
+            summary=summary,
+            run_id=run_context.invocation_id,
+            session_id=run_context.session_id,
+            evidence=[EvidenceRef(source=tool_name, content=summary)],
+            metadata={"tool_args": coerce_json_object(tool_args)},
+        )
+        self.store.append_receipt(receipt)
+        return None
+
+    async def after_model_callback(
+        self,
+        *,
+        callback_context: "CallbackContext",
+        llm_response: LlmResponse,
+    ) -> LlmResponse | None:
+        text = response_text(llm_response.content)
+        if not text:
+            return None
+        run_context = _run_context_from_callback(callback_context, profile=self.profile)
+        receipts = self.store.load_receipts(
+            run_id=run_context.invocation_id,
+            session_id=run_context.session_id,
+            limit=20,
+        )
+        report = self.verifier.verify_text(text, receipts=receipts)
+        intervention = self.verifier.decide(report)
+        self.store.append_event(
+            HarnessEvent(
+                event_type="verifier.report",
+                run_context=run_context,
+                payload={
+                    "intervention": intervention.model_dump(mode="json"),
+                    "receipt_count": len(receipts),
+                },
+            )
+        )
+        if intervention.action == "block":
+            return LlmResponse(
+                content=text_response(
+                    "I cannot verify that result from the available tool evidence. "
+                    "Please rerun the required tool step or provide supporting evidence."
+                ),
+                custom_metadata={
+                    "harness_verification": report.model_dump(mode="json")
+                },
+            )
+        metadata = dict(llm_response.custom_metadata or {})
+        metadata["harness_verification"] = report.model_dump(mode="json")
+        llm_response.custom_metadata = metadata
+        return None
+
+    async def on_event_callback(
+        self,
+        *,
+        invocation_context: "InvocationContext",
+        event: "Event",
+    ) -> "Event | None":
+        run_context = _run_context_from_invocation(
+            invocation_context,
+            profile=self.profile,
+        )
+        self.store.append_event(
+            HarnessEvent(
+                event_type="adk.event",
+                run_context=run_context,
+                payload={"author": str(getattr(event, "author", ""))},
+            )
+        )
+        return None
+
+
+HarnessContextPlugin = HarnessInvocationContextPlugin
+HarnessHallucinationPlugin = HarnessResponseVerificationPlugin
+
+
+def build_harness_plugins(
+    *,
+    components: Iterable[ComponentName] | str | None = None,
+    profile: str = "default",
+    store: HarnessStoreProtocol | None = None,
+    context_config: HarnessInvocationContextConfig | None = None,
+    compaction_config: ToolResultCompactorConfig | None = None,
+    compression_config: ToolResultCompactorConfig | None = None,
+    verifier_config: FinalResponseVerifierConfig | None = None,
+) -> list[BasePlugin]:
+    """Build a shared-store Harness plugin bundle."""
+
+    selected = _normalize_components(components)
+    shared_store = store or InMemoryHarnessStore()
+    compactor_config = compaction_config or compression_config
+    plugins: list[BasePlugin] = []
+    if "context_engine" in selected:
+        plugins.append(
+            HarnessInvocationContextPlugin(
+                context_builder=HarnessInvocationContextBuilder(context_config),
+                store=shared_store,
+                profile=profile,
+            )
+        )
+    if "compressor" in selected:
+        plugins.append(
+            HarnessCompressPlugin(
+                compactor=ToolResultCompactor(compactor_config),
+                store=shared_store,
+                profile=profile,
+            )
+        )
+    if "hallucination" in selected:
+        plugins.append(
+            HarnessResponseVerificationPlugin(
+                verifier=FinalResponseVerifier(verifier_config),
+                store=shared_store,
+                profile=profile,
+            )
+        )
+    return plugins
+
+
+def _normalize_components(components: Iterable[ComponentName] | str | None) -> set[str]:
+    if components is None:
+        raw = ["invocation_context", "compactor", "response_verification"]
+    elif isinstance(components, str):
+        raw = [item.strip() for item in components.split(",")]
+    else:
+        raw = [str(item).strip() for item in components]
+    aliases = {
+        "context": "context_engine",
+        "context_engine": "context_engine",
+        "harness_context_plugin": "context_engine",
+        "invocation_context": "context_engine",
+        "harness_invocation_context_builder": "context_engine",
+        "compress": "compressor",
+        "compression": "compressor",
+        "compressor": "compressor",
+        "compact": "compressor",
+        "compaction": "compressor",
+        "compactor": "compressor",
+        "tool_compactor": "compressor",
+        "tool_compressor": "compressor",
+        "harness_compress_plugin": "compressor",
+        "hallucination": "hallucination",
+        "verifier": "hallucination",
+        "result_verifier": "hallucination",
+        "response_verification": "hallucination",
+        "final_response_verifier": "hallucination",
+        "harness_hallucination_plugin": "hallucination",
+        "harness_response_verification_plugin": "hallucination",
+    }
+    return {aliases[item] for item in raw if item in aliases}
+
+
+def _run_context_from_callback(
+    callback_context: "CallbackContext",
+    *,
+    profile: str,
+) -> HarnessInvocationRef:
+    session = callback_context.session
+    goal = _user_text_from_callback(callback_context)
+    return HarnessInvocationRef(
+        app_name=getattr(session, "app_name", ""),
+        user_id=getattr(callback_context, "user_id", ""),
+        session_id=getattr(session, "id", ""),
+        invocation_id=getattr(callback_context, "invocation_id", ""),
+        profile=profile,
+        task=TaskContract(goal=goal) if goal else None,
+    )
+
+
+def _run_context_from_invocation(
+    invocation_context: "InvocationContext",
+    *,
+    profile: str,
+) -> HarnessInvocationRef:
+    session = invocation_context.session
+    return HarnessInvocationRef(
+        app_name=getattr(session, "app_name", ""),
+        user_id=getattr(session, "user_id", ""),
+        session_id=getattr(session, "id", ""),
+        invocation_id=getattr(invocation_context, "invocation_id", ""),
+        profile=profile,
+    )
+
+
+def _run_context_from_tool(
+    tool_context: "ToolContext",
+    *,
+    profile: str,
+) -> HarnessInvocationRef:
+    session = tool_context.session
+    return HarnessInvocationRef(
+        app_name=getattr(session, "app_name", ""),
+        user_id=getattr(tool_context, "user_id", ""),
+        session_id=getattr(session, "id", ""),
+        invocation_id=getattr(tool_context, "invocation_id", ""),
+        profile=profile,
+    )
+
+
+def _user_text_from_callback(callback_context: "CallbackContext") -> str:
+    user_content = getattr(callback_context, "user_content", None)
+    return stringify_json_value(user_content.model_dump()) if user_content else ""
+
+
+def _message_from_text(role: str, text: str) -> "ConversationMessage":
+    return ConversationMessage(role=role, content=text)
+
+
+def _tool_name(tool: "BaseTool") -> str:
+    return str(getattr(tool, "name", tool.__class__.__name__))
+
+
+def _looks_like_error_result(result: Mapping[str, object]) -> bool:
+    if "error" in result or "exception" in result:
+        return True
+    status = str(result.get("status", "")).lower()
+    return status in {"error", "failed", "failure"}

--- a/veadk/extensions/harness/docs/README.md
+++ b/veadk/extensions/harness/docs/README.md
@@ -1,0 +1,114 @@
+# veADK Harness Extension Guide
+
+[中文](README.zh.md)
+
+This guide explains the SDK from zero to first run.
+
+## Install
+
+```bash
+pip install "veadk-python[harness]"
+```
+
+The Harness extension is bundled with veADK. The `harness` extra installs the
+optional in-process Headroom provider for `HARNESS_COMPRESSION_PROVIDER=headroom`.
+
+## What It Does
+
+veADK Harness Extension adds a small control layer around a veADK agent:
+
+1. It prepares a compact context block before model calls.
+2. It compacts oversized tool outputs before they pollute later turns.
+3. It records tool receipts and checks whether final answers are supported.
+
+Use it when your agent calls tools, handles long outputs, or needs stricter
+answer grounding.
+
+## Core Concepts
+
+| Concept | Meaning |
+| --- | --- |
+| Harness module | A standalone capability that can be imported and tested directly. |
+| Harness plugin | A veADK Runner plugin wrapper around one or more modules. |
+| Invocation context block | A compact instruction/context block injected before model calls. |
+| Tool receipt | A short record of what a tool did and whether it succeeded. |
+| Compaction report | Metrics showing how much context or tool output was reduced. |
+| Verification report | A result showing whether the final answer is supported. |
+
+## First Run With Plugins
+
+```python
+from veadk.extensions.harness.adk import build_harness_plugins
+from veadk import Agent, Runner
+
+agent = Agent(name="demo_agent")
+runner = Runner(
+    agent=agent,
+    app_name="demo",
+    plugins=build_harness_plugins(
+        components=["invocation_context", "compactor", "response_verification"],
+    ),
+)
+```
+
+## Use Individual Modules
+
+```python
+from veadk.extensions.harness import HarnessInvocationContextBuilder, HarnessInvocationRef
+
+context = HarnessInvocationRef(session_id="s1", invocation_id="r1")
+bundle = HarnessInvocationContextBuilder().prepare_context(
+    context,
+    user_input="Find the best model from the tool result.",
+)
+print(bundle.header)
+```
+
+```python
+from veadk.extensions.harness.modules.tool_result_compactor import ToolResultCompactor
+
+compactor = ToolResultCompactor()
+compressed, report = compactor.compress_tool_result({"rows": "x" * 8000})
+print(compressed)
+print(report.model_dump())
+```
+
+## Configuration
+
+Minimal runtime environment:
+
+```text
+HARNESS_ENHANCE_ENABLED=true
+HARNESS_ENHANCE_COMPONENTS=invocation_context,compactor,response_verification
+HARNESS_PROFILE=default
+HARNESS_COMPRESSION_PROVIDER=builtin
+```
+
+Compaction provider options:
+
+| Provider | Behavior |
+| --- | --- |
+| `builtin` | Default provider. Uses local structured compaction and safe fallback summaries. |
+| `headroom` | Calls the installed local `headroom` Python package in-process. It does not start a service or install dependencies at runtime; if unavailable, it falls back to `builtin`. |
+
+Verification defaults to observe behavior. Advanced hosts may configure block
+behavior if they want unsupported final claims to stop the response.
+
+## Evaluation
+
+Run deterministic unit-style checks:
+
+```bash
+PYTHONPATH=. pytest -q tests/extensions/harness
+```
+
+Run the local HarnessApp latency/context benchmark:
+
+```bash
+PYTHONPATH=. python \
+  veadk/extensions/harness/examples/harness_app_runtime/stable_latency_token_case.py \
+  --repeats 3
+```
+
+The benchmark compares normal invocation with Harness-enhanced invocation and
+prints latency, prompt-context size, compaction ratio, and answer consistency.

--- a/veadk/extensions/harness/docs/README.zh.md
+++ b/veadk/extensions/harness/docs/README.zh.md
@@ -1,0 +1,112 @@
+# veADK Harness Extension 使用指南
+
+[English](README.md)
+
+这份文档帮助开发者从零开始使用 SDK。
+
+## 安装
+
+```bash
+pip install "veadk-python[harness]"
+```
+
+Harness Extension 已随 veADK 内置。`harness` extra 会安装可选的进程内
+Headroom provider，用于 `HARNESS_COMPRESSION_PROVIDER=headroom`。
+
+## 它解决什么问题
+
+veADK Harness Extension 给 veADK Agent 增加一层轻量控制能力：
+
+1. 在模型调用前准备精简上下文。
+2. 在大工具结果进入后续对话前进行压缩。
+3. 记录工具执行 receipt，并检查最终回答是否有证据支撑。
+
+当你的 Agent 会调用工具、处理长输出，或者需要更强的回答可靠性时，可以使用它。
+
+## 核心概念
+
+| 概念 | 含义 |
+| --- | --- |
+| Harness module | 可直接 import 和测试的独立原子能力。 |
+| Harness plugin | 面向 veADK Runner 的运行时增强能力。 |
+| Invocation context block | 模型调用前注入的精简上下文块。 |
+| Tool receipt | 工具执行结果的简短记录，包括工具名称、状态和摘要。 |
+| Compaction report | 记录上下文或工具输出压缩效果的指标。 |
+| Verification report | 判断最终回答是否有证据支撑的结果。 |
+
+## 用 Plugin 接入
+
+```python
+from veadk.extensions.harness.adk import build_harness_plugins
+from veadk import Agent, Runner
+
+agent = Agent(name="demo_agent")
+runner = Runner(
+    agent=agent,
+    app_name="demo",
+    plugins=build_harness_plugins(
+        components=["invocation_context", "compactor", "response_verification"],
+    ),
+)
+```
+
+## 直接使用原子模块
+
+```python
+from veadk.extensions.harness import HarnessInvocationContextBuilder, HarnessInvocationRef
+
+context = HarnessInvocationRef(session_id="s1", invocation_id="r1")
+bundle = HarnessInvocationContextBuilder().prepare_context(
+    context,
+    user_input="Find the best model from the tool result.",
+)
+print(bundle.header)
+```
+
+```python
+from veadk.extensions.harness.modules.tool_result_compactor import ToolResultCompactor
+
+compactor = ToolResultCompactor()
+compressed, report = compactor.compress_tool_result({"rows": "x" * 8000})
+print(compressed)
+print(report.model_dump())
+```
+
+## 配置
+
+最小运行时配置：
+
+```text
+HARNESS_ENHANCE_ENABLED=true
+HARNESS_ENHANCE_COMPONENTS=invocation_context,compactor,response_verification
+HARNESS_PROFILE=default
+HARNESS_COMPRESSION_PROVIDER=builtin
+```
+
+压缩 provider：
+
+| Provider | 行为 |
+| --- | --- |
+| `builtin` | 默认 provider。使用本地结构化压缩和安全摘要 fallback。 |
+| `headroom` | 进程内调用已安装的本地 `headroom` Python 包；不会启动服务，也不会在运行时安装依赖；不可用时自动回退到 `builtin`。 |
+
+验证默认是 observe 行为。高级运行时可以配置 block 行为，用于阻断缺少证据支撑的最终回答。
+
+## 评测
+
+运行确定性测试：
+
+```bash
+PYTHONPATH=. pytest -q tests/extensions/harness
+```
+
+运行本地 HarnessApp 延迟和上下文 benchmark：
+
+```bash
+PYTHONPATH=. python \
+  veadk/extensions/harness/examples/harness_app_runtime/stable_latency_token_case.py \
+  --repeats 3
+```
+
+benchmark 会对比普通调用和 Harness 增强调用，并输出延迟、prompt 上下文长度、
+压缩比例和答案一致性。

--- a/veadk/extensions/harness/env.py
+++ b/veadk/extensions/harness/env.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""veADK helpers for Harness plugin assembly."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Literal
+
+from google.adk.plugins import BasePlugin
+
+from veadk.extensions.harness.adk import build_harness_plugins
+from veadk.extensions.harness.modules.final_response_verifier import (
+    FinalResponseVerifierConfig,
+)
+from veadk.extensions.harness.modules.invocation_context import (
+    HarnessInvocationContextConfig,
+)
+from veadk.extensions.harness.modules.tool_result_compactor import (
+    ToolResultCompactorConfig,
+)
+from veadk.extensions.harness.stores import JsonlHarnessStore
+
+
+def harness_enabled_from_env(env: Mapping[str, str] | None = None) -> bool:
+    """Return whether Harness plugins should be attached."""
+
+    values = env or os.environ
+    return _truthy(
+        values.get("HARNESS_ENHANCE_ENABLED")
+        or values.get("HARNESS_ENABLE")
+        or values.get("HARNESS_ENABLED")
+    )
+
+
+def build_harness_plugins_from_env(
+    env: Mapping[str, str] | None = None,
+) -> list[BasePlugin]:
+    """Build Harness plugins from generic runtime environment variables."""
+
+    values = env or os.environ
+    if not harness_enabled_from_env(values):
+        return []
+    components = (
+        values.get("HARNESS_ENHANCE_COMPONENTS")
+        or values.get("HARNESS_COMPONENTS")
+        or "invocation_context,compactor,response_verification"
+    )
+    profile = (
+        values.get("HARNESS_ENHANCE_PROFILE")
+        or values.get("HARNESS_PROFILE")
+        or "default"
+    )
+    max_context_chars = _int_value(
+        values.get("HARNESS_MAX_CONTEXT_CHARS")
+        or values.get("HARNESS_ENHANCE_MAX_CONTEXT_CHARS"),
+        default=24000,
+    )
+    max_tool_result_chars = _int_value(
+        values.get("HARNESS_MAX_TOOL_RESULT_CHARS")
+        or values.get("HARNESS_ENHANCE_MAX_TOOL_RESULT_CHARS"),
+        default=4000,
+    )
+    store_path = values.get("HARNESS_STORE_PATH") or values.get(
+        "HARNESS_ENHANCE_STORE_PATH"
+    )
+    store = JsonlHarnessStore(store_path) if store_path else None
+    return build_harness_plugins(
+        components=components,
+        profile=profile,
+        store=store,
+        context_config=HarnessInvocationContextConfig(
+            max_context_chars=max_context_chars
+        ),
+        compaction_config=ToolResultCompactorConfig(
+            provider=values.get("HARNESS_COMPRESSION_PROVIDER")
+            or values.get("HARNESS_ENHANCE_COMPRESSION_PROVIDER")
+            or "builtin",
+            max_context_chars=max_context_chars,
+            max_tool_result_chars=max_tool_result_chars,
+        ),
+        verifier_config=FinalResponseVerifierConfig(
+            mode=_verifier_mode(
+                values.get("HARNESS_VERIFIER_MODE")
+                or values.get("HARNESS_ENHANCE_VERIFIER_MODE")
+            )
+        ),
+    )
+
+
+def _truthy(value: str | None) -> bool:
+    return bool(value and value.strip().lower() in {"1", "true", "yes", "on"})
+
+
+def _int_value(value: str | None, *, default: int) -> int:
+    if not value:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def _verifier_mode(value: str | None) -> Literal["observe", "block"]:
+    normalized = (value or "observe").strip().lower()
+    return "block" if normalized == "block" else "observe"
+
+
+__all__ = ["build_harness_plugins_from_env", "harness_enabled_from_env"]

--- a/veadk/extensions/harness/eval/README.md
+++ b/veadk/extensions/harness/eval/README.md
@@ -1,0 +1,23 @@
+# Deterministic Harness Eval
+
+The SDK includes small synthetic evals that run without a model. They prove the
+core mechanics before live-model A/B testing:
+
+| Scenario | Baseline | Enhanced | Good Direction |
+| --- | ---: | ---: | --- |
+| Large historical tool result | original context chars | compressed context chars | lower enhanced chars while preserving latest feedback |
+| Unsupported completion claim | accepts unverified final claim | verifier marks it failed | false accept decreases |
+
+Run:
+
+```bash
+python - <<'PY'
+from veadk.extensions.harness.eval import run_deterministic_eval
+
+for row in run_deterministic_eval():
+    print(row.model_dump())
+PY
+```
+
+Live-model latency/token A/B evaluation should reuse the same scenario-first
+table shape with real usage metadata from the target runtime.

--- a/veadk/extensions/harness/eval/__init__.py
+++ b/veadk/extensions/harness/eval/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deterministic eval helpers."""
+
+from veadk.extensions.harness.eval.deterministic import (
+    HarnessEvalSummary,
+    run_deterministic_eval,
+)
+
+__all__ = ["HarnessEvalSummary", "run_deterministic_eval"]

--- a/veadk/extensions/harness/eval/deterministic.py
+++ b/veadk/extensions/harness/eval/deterministic.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deterministic module-level evals for Harness effects."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from veadk.extensions.harness.modules.final_response_verifier import (
+    FinalResponseVerifier,
+)
+from veadk.extensions.harness.modules.tool_result_compactor import (
+    ToolResultCompactor,
+    ToolResultCompactorConfig,
+)
+from veadk.extensions.harness.schemas import (
+    ToolReceipt,
+    CompressionRequest,
+    ConversationMessage,
+    HarnessBaseModel,
+)
+
+
+class HarnessEvalSummary(HarnessBaseModel):
+    """Human-readable deterministic eval metrics."""
+
+    scenario: str
+    baseline_chars: int
+    enhanced_chars: int
+    char_saving_ratio: float
+    baseline_false_accept: bool
+    enhanced_false_accept: bool
+    notes: list[str] = Field(default_factory=list)
+
+
+def run_deterministic_eval() -> list[HarnessEvalSummary]:
+    """Run small synthetic checks that demonstrate module effects."""
+
+    compactor = ToolResultCompactor(
+        ToolResultCompactorConfig(max_context_chars=1200, min_candidate_chars=200)
+    )
+    large_tool_output = "metric,value\n" + "\n".join(
+        f"item_{index},{index}" for index in range(500)
+    )
+    messages = [
+        ConversationMessage(role="user", content="Summarize the latest metrics."),
+        ConversationMessage(role="tool", content=large_tool_output),
+        ConversationMessage(role="assistant", content="I will summarize the data."),
+        ConversationMessage(role="tool", content="latest status: complete"),
+    ]
+    compressed = compactor.compress_messages(
+        CompressionRequest(messages=messages, max_context_chars=1200)
+    )
+    baseline_chars = sum(len(message.content) for message in messages)
+    enhanced_chars = sum(len(message.content) for message in compressed.messages)
+
+    verifier = FinalResponseVerifier()
+    unsupported = verifier.verify_text("Done, I created the report.")
+    supported = verifier.verify_text(
+        "Done, I created the report.",
+        receipts=[
+            ToolReceipt(
+                name="write_report",
+                status="success",
+                summary="report.md saved",
+            )
+        ],
+    )
+    return [
+        HarnessEvalSummary(
+            scenario="Large historical tool result",
+            baseline_chars=baseline_chars,
+            enhanced_chars=enhanced_chars,
+            char_saving_ratio=(
+                1 - enhanced_chars / baseline_chars if baseline_chars else 0.0
+            ),
+            baseline_false_accept=False,
+            enhanced_false_accept=False,
+            notes=["old large tool output is summarized while latest feedback is kept"],
+        ),
+        HarnessEvalSummary(
+            scenario="Unsupported completion claim",
+            baseline_chars=len("Done, I created the report."),
+            enhanced_chars=len("Done, I created the report."),
+            char_saving_ratio=0.0,
+            baseline_false_accept=True,
+            enhanced_false_accept=unsupported.status != "fail",
+            notes=[f"supported receipt status: {supported.status}"],
+        ),
+    ]

--- a/veadk/extensions/harness/events.py
+++ b/veadk/extensions/harness/events.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Event model exports."""
+
+from veadk.extensions.harness.schemas import HarnessEvent
+
+__all__ = ["HarnessEvent"]

--- a/veadk/extensions/harness/examples/harness_app_runtime/README.md
+++ b/veadk/extensions/harness/examples/harness_app_runtime/README.md
@@ -1,0 +1,43 @@
+# HarnessApp Runtime Example
+
+When deploying a veADK HarnessApp runtime, enable Harness plugins through the
+runtime configuration:
+
+```yaml
+harness_enhance:
+  enabled: true
+  components: [invocation_context, compactor, response_verification]
+  profile: general
+  compression_provider: builtin
+```
+
+The runtime reads this configuration as environment variables and attaches the
+plugin bundle to the veADK Runner.
+
+## Local Latency And Context Benchmark
+
+Run the local HarnessApp benchmark from the repository root:
+
+```bash
+PYTHONPATH=. python \
+  veadk/extensions/harness/examples/harness_app_runtime/stable_latency_token_case.py \
+  --repeats 3
+```
+
+If your local environment needs model or runtime variables, pass an env file:
+
+```bash
+PYTHONPATH=. python \
+  veadk/extensions/harness/examples/harness_app_runtime/stable_latency_token_case.py \
+  --env-file /path/to/.env \
+  --repeats 3
+```
+
+The script starts a local HarnessApp Runtime, invokes it through
+`veadk agentkit invoke`, and compares:
+
+- no enhancement headers
+- `--enable-harness-enhance` with built-in compression
+
+It prints a JSON report with latency, prompt-context size, compression impact,
+and answer consistency.

--- a/veadk/extensions/harness/examples/harness_app_runtime/stable_latency_token_case.py
+++ b/veadk/extensions/harness/examples/harness_app_runtime/stable_latency_token_case.py
@@ -1,0 +1,430 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Local HarnessApp Runtime latency/token-shape benchmark.
+
+This script starts a local HarnessApp Runtime and invokes it through
+`veadk agentkit invoke`. It compares the same runtime in two modes:
+
+* no_enhance: no Harness enhancement headers.
+* harness_enhance: `--enable-harness-enhance` with built-in compression.
+
+The model is deterministic so the test is stable on a developer laptop while
+still exercising the real Runtime, Runner, Harness plugin, tool callback, HTTP
+Runtime, and CLI invocation path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import socket
+import statistics
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import AsyncGenerator
+from pathlib import Path
+
+import uvicorn
+from google.adk.models.base_llm import BaseLlm
+from google.adk.models.llm_response import LlmResponse
+from google.genai import types
+from pydantic import BaseModel, ConfigDict, PrivateAttr
+
+
+PROMPT = (
+    "stable-latency-token-case: call metric_payload once, then identify the best "
+    "model from metric rows. Final answer must include best_model and accuracy."
+)
+
+
+class RunMetric(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    mode: str
+    elapsed_seconds: float
+    prompt_chars: int
+    output: str
+
+
+class BenchmarkLlm(BaseLlm):
+    _delay_divisor: float = PrivateAttr()
+    _max_delay_seconds: float = PrivateAttr()
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        delay_divisor: float,
+        max_delay_seconds: float,
+    ) -> None:
+        super().__init__(model=model)
+        self._delay_divisor = delay_divisor
+        self._max_delay_seconds = max_delay_seconds
+
+    async def generate_content_async(
+        self, llm_request: object, stream: bool = False
+    ) -> AsyncGenerator[LlmResponse, None]:
+        request_text = _request_text(llm_request)
+        has_function_response = _has_function_response(llm_request)
+        if PROMPT in request_text and not has_function_response:
+            yield LlmResponse(
+                content=types.Content(
+                    role="model",
+                    parts=[
+                        types.Part.from_function_call(name="metric_payload", args={})
+                    ],
+                )
+            )
+            return
+
+        prompt_chars = len(request_text)
+        delay = min(prompt_chars / self._delay_divisor, self._max_delay_seconds)
+        await asyncio.sleep(delay)
+        compressed = (
+            "harness_compressed" in request_text
+            or "COMPRESSED_METRIC_ROWS" in request_text
+        )
+        yield LlmResponse(
+            content=types.Content(
+                role="model",
+                parts=[
+                    types.Part(
+                        text=(
+                            "best_model: T5\n"
+                            "accuracy: 88\n"
+                            f"prompt_chars: {prompt_chars}\n"
+                            f"compressed_context: {str(compressed).lower()}"
+                        )
+                    )
+                ],
+            )
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--rows", type=int, default=2500)
+    parser.add_argument("--delay-divisor", type=float, default=60000.0)
+    parser.add_argument("--max-delay-seconds", type=float, default=2.5)
+    parser.add_argument(
+        "--env-file",
+        type=Path,
+        default=_default_env_file(),
+        help=(
+            "Optional env file used to seed local model/runtime variables. "
+            "Can also be set with HARNESS_BENCHMARK_ENV_FILE."
+        ),
+    )
+    args = parser.parse_args()
+
+    _load_env_file(args.env_file)
+    os.environ.setdefault("LOGGING_LEVEL", "WARNING")
+    os.environ["HARNESS_ENHANCE_ENABLED"] = "false"
+
+    runtime_port = _free_port()
+    runtime, server, server_thread = _start_runtime(
+        port=runtime_port,
+        rows=args.rows,
+        delay_divisor=args.delay_divisor,
+        max_delay_seconds=args.max_delay_seconds,
+    )
+    endpoint = f"http://127.0.0.1:{runtime_port}"
+
+    try:
+        baseline = [
+            _invoke_cli(
+                mode="no_enhance",
+                endpoint=endpoint,
+                session_id=f"baseline-{index}",
+                enhanced=False,
+            )
+            for index in range(args.repeats)
+        ]
+        enhanced = [
+            _invoke_cli(
+                mode="harness_enhance",
+                endpoint=endpoint,
+                session_id=f"enhanced-{index}",
+                enhanced=True,
+            )
+            for index in range(args.repeats)
+        ]
+        report = _build_report(
+            baseline=baseline,
+            enhanced=enhanced,
+            plugin_names=[plugin.name for plugin in runtime.plugins],
+        )
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+        return 0 if report["passed"] else 1
+    finally:
+        server.should_exit = True
+        server_thread.join(timeout=10)
+
+
+def _start_runtime(
+    *,
+    port: int,
+    rows: int,
+    delay_divisor: float,
+    max_delay_seconds: float,
+):
+    from veadk import Agent
+    from veadk.cloud.harness_app.app import HarnessApp
+    from veadk.memory.short_term_memory import ShortTermMemory
+
+    def metric_payload() -> dict[str, object]:
+        metric_rows = [
+            {"kind": "metric", "model": "T4", "accuracy": 82, "rank": 2},
+            {"kind": "metric", "model": "T5", "accuracy": 88, "rank": 1},
+        ]
+        debug_rows = [
+            {
+                "kind": "debug",
+                "row": index,
+                "trace": "diagnostic-noise-" + ("x" * 48),
+            }
+            for index in range(rows)
+        ]
+        return {"metric_rows": metric_rows, "debug_rows": debug_rows}
+
+    runtime = HarnessApp(
+        Agent(
+            name="local_latency_token_agent",
+            instruction="Use tools when requested and return the benchmark markers.",
+            model=BenchmarkLlm(
+                model="benchmark-fake",
+                delay_divisor=delay_divisor,
+                max_delay_seconds=max_delay_seconds,
+            ),
+            tools=[metric_payload],
+        ),
+        ShortTermMemory(backend="local"),
+        harness_name="local_latency_token_case",
+        max_llm_calls=6,
+    )
+    server = uvicorn.Server(
+        uvicorn.Config(runtime.app, host="127.0.0.1", port=port, log_level="warning")
+    )
+    server_thread = threading.Thread(target=server.run, daemon=True)
+    server_thread.start()
+    for _ in range(100):
+        if server.started:
+            return runtime, server, server_thread
+        time.sleep(0.05)
+    raise RuntimeError("local HarnessApp Runtime did not start")
+
+
+def _invoke_cli(
+    *,
+    mode: str,
+    endpoint: str,
+    session_id: str,
+    enhanced: bool,
+) -> RunMetric:
+    repo_root = Path(__file__).resolve().parents[5]
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(repo_root)
+    env.setdefault("LOGGING_LEVEL", "WARNING")
+    command = [
+        sys.executable,
+        "-m",
+        "veadk.cli.cli",
+        "agentkit",
+        "invoke",
+        "--endpoint",
+        endpoint,
+        "--apikey",
+        "local-test-key",
+        "--harness",
+        "local_latency_token_case",
+        "--user-id",
+        "local-user",
+        "--session-id",
+        session_id,
+        "--max-llm-calls",
+        "6",
+    ]
+    if enhanced:
+        command.extend(
+            [
+                "--enable-harness-enhance",
+                "--harness-components",
+                "invocation_context,compactor,response_verification",
+                "--harness-profile",
+                "benchmark",
+                "--harness-compression-provider",
+                "builtin",
+            ]
+        )
+    command.append(PROMPT)
+    started = time.perf_counter()
+    completed = subprocess.run(
+        command,
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    elapsed = time.perf_counter() - started
+    output = completed.stdout + completed.stderr
+    if completed.returncode != 0:
+        raise RuntimeError(f"{mode} invoke failed:\n{output}")
+    prompt_chars = _extract_prompt_chars(output)
+    return RunMetric(
+        mode=mode, elapsed_seconds=elapsed, prompt_chars=prompt_chars, output=output
+    )
+
+
+def _extract_prompt_chars(output: str) -> int:
+    match = re.search(r"prompt_chars:\s*(\d+)", output)
+    if not match:
+        raise RuntimeError(f"prompt_chars marker not found in CLI output:\n{output}")
+    return int(match.group(1))
+
+
+def _request_text(llm_request: object) -> str:
+    values: list[str] = []
+    for content in getattr(llm_request, "contents", []) or []:
+        for part in getattr(content, "parts", []) or []:
+            text = getattr(part, "text", None)
+            if text:
+                values.append(str(text))
+            function_call = getattr(part, "function_call", None)
+            if function_call is not None:
+                values.append(_json_for_context(function_call))
+            function_response = getattr(part, "function_response", None)
+            if function_response is not None:
+                values.append(_json_for_context(function_response))
+    return "\n".join(values)
+
+
+def _has_function_response(llm_request: object) -> bool:
+    for content in getattr(llm_request, "contents", []) or []:
+        for part in getattr(content, "parts", []) or []:
+            if getattr(part, "function_response", None) is not None:
+                return True
+    return False
+
+
+def _json_for_context(value: object) -> str:
+    if hasattr(value, "model_dump"):
+        value = value.model_dump()
+    return json.dumps(value, ensure_ascii=False, default=str)
+
+
+def _build_report(
+    *,
+    baseline: list[RunMetric],
+    enhanced: list[RunMetric],
+    plugin_names: list[str],
+) -> dict[str, object]:
+    baseline_latency = statistics.median(item.elapsed_seconds for item in baseline)
+    enhanced_latency = statistics.median(item.elapsed_seconds for item in enhanced)
+    baseline_chars = int(statistics.median(item.prompt_chars for item in baseline))
+    enhanced_chars = int(statistics.median(item.prompt_chars for item in enhanced))
+    latency_saved = baseline_latency - enhanced_latency
+    char_saved = baseline_chars - enhanced_chars
+    latency_saving_ratio = latency_saved / baseline_latency if baseline_latency else 0.0
+    char_saving_ratio = char_saved / baseline_chars if baseline_chars else 0.0
+    compression_ratio = enhanced_chars / baseline_chars if baseline_chars else 0.0
+    answers_match = all("best_model: T5" in item.output for item in baseline + enhanced)
+    baseline_uncompressed = all(
+        "compressed_context: false" in item.output for item in baseline
+    )
+    enhanced_compressed = all(
+        "compressed_context: true" in item.output for item in enhanced
+    )
+    passed = (
+        answers_match
+        and baseline_uncompressed
+        and enhanced_compressed
+        and enhanced_latency < baseline_latency
+        and enhanced_chars < baseline_chars
+        and compression_ratio < 0.1
+    )
+    return {
+        "case": "local_stable_latency_token_case",
+        "passed": passed,
+        "plugins_attached_by_default": plugin_names,
+        "repeats": len(baseline),
+        "median": {
+            "no_enhance_latency_seconds": round(baseline_latency, 4),
+            "harness_enhance_latency_seconds": round(enhanced_latency, 4),
+            "latency_saved_seconds": round(latency_saved, 4),
+            "latency_saving_pct": round(latency_saving_ratio * 100, 4),
+            "no_enhance_prompt_chars": baseline_chars,
+            "harness_enhance_prompt_chars": enhanced_chars,
+            "prompt_chars_saved": char_saved,
+            "prompt_chars_saving_pct": round(char_saving_ratio * 100, 4),
+        },
+        "compression": {
+            "provider": "builtin",
+            "median_original_prompt_chars": baseline_chars,
+            "median_compressed_prompt_chars": enhanced_chars,
+            "compression_ratio": round(compression_ratio, 6),
+        },
+        "answers_match": answers_match,
+        "baseline_uncompressed": baseline_uncompressed,
+        "enhanced_compressed": enhanced_compressed,
+        "details": {
+            "no_enhance": [_metric_row(item) for item in baseline],
+            "harness_enhance": [_metric_row(item) for item in enhanced],
+        },
+    }
+
+
+def _metric_row(metric: RunMetric) -> dict[str, object]:
+    return {
+        "mode": metric.mode,
+        "elapsed_seconds": round(metric.elapsed_seconds, 4),
+        "prompt_chars": metric.prompt_chars,
+    }
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _default_env_file() -> Path:
+    configured = os.getenv("HARNESS_BENCHMARK_ENV_FILE")
+    return Path(configured) if configured else Path()
+
+
+def _load_env_file(path: Path) -> None:
+    if not path.is_file():
+        return
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line.removeprefix("export ").strip()
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        os.environ.setdefault(key.strip(), value.strip().strip("\"'"))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/veadk/extensions/harness/examples/veadk_runner_plugins/README.md
+++ b/veadk/extensions/harness/examples/veadk_runner_plugins/README.md
@@ -1,0 +1,14 @@
+# veADK Runner Plugins Example
+
+This example shows the smallest local veADK integration: build a regular
+`Agent`, attach Harness plugins to `Runner`, and keep the agent code focused on
+business behavior.
+
+```python
+from agent import build_runner
+
+runner = build_runner()
+```
+
+The plugin bundle adds context engineering, tool-result compression, and answer
+verification without changing the agent class.

--- a/veadk/extensions/harness/examples/veadk_runner_plugins/agent.py
+++ b/veadk/extensions/harness/examples/veadk_runner_plugins/agent.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimal veADK Runner example with Harness plugins."""
+
+from veadk.extensions.harness.adk import build_harness_plugins
+from veadk import Agent, Runner
+
+
+def build_runner() -> Runner:
+    """Build a veADK runner with Harness context, compression, and verification."""
+
+    agent = Agent(
+        name="harness_sample_agent",
+        instruction="Answer with evidence from available tools and keep responses concise.",
+    )
+    return Runner(
+        agent=agent,
+        app_name="harness_sample",
+        plugins=build_harness_plugins(
+            components=["invocation_context", "compactor", "response_verification"],
+            profile="general",
+        ),
+    )

--- a/veadk/extensions/harness/extension.py
+++ b/veadk/extensions/harness/extension.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""veADK extension facade for Harness plugins."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable, Mapping
+
+from google.adk.plugins import BasePlugin
+from pydantic import Field
+
+from veadk.extensions.harness.adk import build_harness_plugins
+from veadk.extensions.harness.env import (
+    build_harness_plugins_from_env,
+    harness_enabled_from_env,
+)
+from veadk.extensions.harness.modules.final_response_verifier import (
+    FinalResponseVerifierConfig,
+)
+from veadk.extensions.harness.modules.invocation_context import (
+    HarnessInvocationContextConfig,
+)
+from veadk.extensions.harness.modules.tool_result_compactor import (
+    ToolResultCompactorConfig,
+)
+from veadk.extensions.harness.schemas import HarnessBaseModel
+from veadk.extensions.harness.stores import HarnessStoreProtocol
+
+
+class HarnessExtensionConfig(HarnessBaseModel):
+    """Configuration for :class:`HarnessExtension`."""
+
+    enabled: bool = True
+    components: list[str] = Field(
+        default_factory=lambda: [
+            "invocation_context",
+            "compactor",
+            "response_verification",
+        ]
+    )
+    profile: str = "default"
+
+
+class HarnessExtension:
+    """Small veADK-facing wrapper for Harness plugin assembly.
+
+    The extension owns no core Harness logic. It keeps the public veADK entry
+    point compact while delegating atomic behavior to the modules in this
+    package.
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = True,
+        components: Iterable[str] | str | None = None,
+        profile: str = "default",
+        store: HarnessStoreProtocol | None = None,
+        context_config: HarnessInvocationContextConfig | None = None,
+        compaction_config: ToolResultCompactorConfig | None = None,
+        verifier_config: FinalResponseVerifierConfig | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> None:
+        if components is None:
+            component_list = HarnessExtensionConfig().components
+        elif isinstance(components, str):
+            component_list = [
+                item.strip() for item in components.split(",") if item.strip()
+            ]
+        else:
+            component_list = [
+                str(item).strip() for item in components if str(item).strip()
+            ]
+        self.config = HarnessExtensionConfig(
+            enabled=enabled,
+            components=component_list,
+            profile=profile,
+        )
+        self.store = store
+        self.context_config = context_config
+        self.compaction_config = compaction_config
+        self.verifier_config = verifier_config
+        self.env = dict(env) if env is not None else None
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> HarnessExtension:
+        """Create an extension controlled by Harness environment variables."""
+
+        values = dict(env or os.environ)
+        return cls(enabled=harness_enabled_from_env(values), env=values)
+
+    def plugins(self) -> list[BasePlugin]:
+        """Build plugins for ``Runner(..., plugins=...)``."""
+
+        if self.env is not None:
+            return build_harness_plugins_from_env(self.env)
+        if not self.config.enabled:
+            return []
+        return build_harness_plugins(
+            components=self.config.components,
+            profile=self.config.profile,
+            store=self.store,
+            context_config=self.context_config,
+            compaction_config=self.compaction_config,
+            verifier_config=self.verifier_config,
+        )
+
+
+__all__ = ["HarnessExtension", "HarnessExtensionConfig"]

--- a/veadk/extensions/harness/modules/__init__.py
+++ b/veadk/extensions/harness/modules/__init__.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Atomic Harness modules."""
+
+from veadk.extensions.harness.modules.headroom_provider import (
+    HeadroomCompressionProvider,
+)
+from veadk.extensions.harness.modules.invocation_context import (
+    ContextEngine,
+    ContextEngineConfig,
+    HarnessInvocationContextBuilder,
+    HarnessInvocationContextConfig,
+)
+from veadk.extensions.harness.modules.final_response_verifier import (
+    FinalResponseVerifier,
+    FinalResponseVerifierConfig,
+    ResultVerifier,
+    ResultVerifierConfig,
+)
+from veadk.extensions.harness.modules.tool_result_compactor import (
+    ContextCompressionPolicy,
+    ContextCompactionPolicy,
+    ToolResultCompactor,
+    ToolResultCompactorConfig,
+    ToolResultCompressor,
+    ToolResultCompressorConfig,
+)
+
+__all__ = [
+    "ContextCompactionPolicy",
+    "ContextEngine",
+    "ContextEngineConfig",
+    "ContextCompressionPolicy",
+    "HarnessInvocationContextBuilder",
+    "HarnessInvocationContextConfig",
+    "HeadroomCompressionProvider",
+    "FinalResponseVerifier",
+    "FinalResponseVerifierConfig",
+    "ResultVerifier",
+    "ResultVerifierConfig",
+    "ToolResultCompactor",
+    "ToolResultCompactorConfig",
+    "ToolResultCompressor",
+    "ToolResultCompressorConfig",
+]

--- a/veadk/extensions/harness/modules/builtin_provider.py
+++ b/veadk/extensions/harness/modules/builtin_provider.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Built-in loss-aware compression provider."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+
+from veadk.extensions.harness.schemas import (
+    CompactionReport,
+    CompressionRequest,
+    CompactionResult,
+    ConversationMessage,
+)
+
+
+class BuiltinCompressionProvider:
+    """Compress tool outputs by preserving structured facts."""
+
+    name = "builtin"
+
+    def compress(self, request: CompressionRequest) -> CompactionResult | None:
+        """Compress eligible tool messages with built-in fact extraction."""
+
+        compressed: list[ConversationMessage] = []
+        changed = False
+        for message in request.messages:
+            if message.role not in {"tool", "tool_result", "function"}:
+                compressed.append(message)
+                continue
+            facts = _extract_tool_facts(message.content)
+            if facts and len(facts) < len(message.content):
+                compressed.append(
+                    message.model_copy(
+                        update={
+                            "content": (
+                                "COMPRESSED_TOOL_OUTPUT\n"
+                                "lossless_facts:\n"
+                                f"{facts}\n"
+                                "compression_policy=preserve_metric_rows_and_tool_identity"
+                            )
+                        }
+                    )
+                )
+                changed = True
+            else:
+                compressed.append(message)
+        if not changed:
+            return None
+        original_chars = _messages_char_count(request.messages)
+        compressed_chars = _messages_char_count(compressed)
+        return CompactionResult(
+            messages=compressed,
+            report=CompactionReport(
+                provider=self.name,
+                original_chars=original_chars,
+                compressed_chars=compressed_chars,
+                changed=True,
+                tokens_before=max(1, original_chars // 4),
+                tokens_after=max(1, compressed_chars // 4),
+                tokens_saved=max(0, original_chars // 4 - compressed_chars // 4),
+                compression_ratio=compressed_chars / max(1, original_chars),
+                transforms_applied=["builtin_tool_fact_compaction"],
+            ),
+        )
+
+
+def _messages_char_count(messages: list[ConversationMessage]) -> int:
+    return sum(len(message.content) for message in messages)
+
+
+def _extract_tool_facts(text: str) -> str:
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return ""
+    return _extract_facts_from_value(parsed)
+
+
+def _extract_facts_from_value(value: object) -> str:
+    facts: list[str] = []
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for item in value:
+            if isinstance(item, Mapping):
+                row = _extract_metric_row(item)
+                if row:
+                    facts.append(row)
+    elif isinstance(value, Mapping):
+        row = _extract_metric_row(value)
+        if row:
+            facts.append(row)
+        facts.extend(_extract_nested_output_facts(value))
+        for nested_key in (
+            "metric_rows",
+            "metrics",
+            "rows",
+            "data",
+            "result",
+            "stdout",
+            "output",
+        ):
+            nested = value.get(nested_key)
+            if nested is value:
+                continue
+            nested_facts = _extract_facts_from_value(nested)
+            if nested_facts:
+                facts.append(nested_facts)
+    elif isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return ""
+        if parsed is value:
+            return ""
+        return _extract_facts_from_value(parsed)
+    return "\n".join(dict.fromkeys(facts))
+
+
+def _extract_nested_output_facts(item: Mapping[object, object]) -> list[str]:
+    facts: list[str] = []
+    output_candidates: list[object] = []
+    data = item.get("data")
+    if isinstance(data, Mapping):
+        outputs = data.get("outputs")
+        if isinstance(outputs, Sequence) and not isinstance(
+            outputs, (str, bytes, bytearray)
+        ):
+            output_candidates.extend(outputs)
+    outputs = item.get("outputs")
+    if isinstance(outputs, Sequence) and not isinstance(
+        outputs, (str, bytes, bytearray)
+    ):
+        output_candidates.extend(outputs)
+    for key in ("stdout", "output", "text", "result"):
+        value = item.get(key)
+        if isinstance(value, str):
+            output_candidates.append({"text": value})
+    for output in output_candidates:
+        text = _output_text(output)
+        if not text:
+            continue
+        try:
+            nested = json.loads(text)
+        except json.JSONDecodeError:
+            continue
+        nested_facts = _extract_facts_from_value(nested)
+        if nested_facts:
+            facts.append(nested_facts)
+    return facts
+
+
+def _output_text(output: object) -> str:
+    if isinstance(output, Mapping):
+        for key in ("text", "data", "output"):
+            value = output.get(key)
+            if isinstance(value, str):
+                return value
+        return ""
+    return output if isinstance(output, str) else ""
+
+
+def _extract_metric_row(item: Mapping[object, object]) -> str:
+    kind = item.get("kind")
+    if isinstance(kind, str) and kind.lower() != "metric":
+        return ""
+    keys = {str(key).lower() for key in item}
+    if not ({"model", "accuracy"} <= keys or {"name", "score"} <= keys):
+        return ""
+    ordered_keys = (
+        "model",
+        "name",
+        "accuracy",
+        "score",
+        "ner_f1",
+        "latency_ms",
+        "latency",
+        "rank",
+    )
+    parts: list[str] = []
+    seen: set[str] = set()
+    normalized = {str(key): value for key, value in item.items()}
+    for key in ordered_keys:
+        if key in normalized:
+            parts.append(f"{key}={normalized[key]}")
+            seen.add(key)
+    for key in sorted(normalized):
+        if key in seen or key == "kind":
+            continue
+        value = normalized[key]
+        if value is None or isinstance(value, (str, int, float, bool)):
+            parts.append(f"{key}={value}")
+    return " ".join(parts)

--- a/veadk/extensions/harness/modules/context_engine.py
+++ b/veadk/extensions/harness/modules/context_engine.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backward-compatible imports for invocation context preparation."""
+
+from veadk.extensions.harness.modules.invocation_context import (
+    HarnessInvocationContextBuilder as ContextEngine,
+    HarnessInvocationContextConfig as ContextEngineConfig,
+)
+
+__all__ = ["ContextEngine", "ContextEngineConfig"]

--- a/veadk/extensions/harness/modules/final_response_verifier.py
+++ b/veadk/extensions/harness/modules/final_response_verifier.py
@@ -1,0 +1,261 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deterministic final-response verification."""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from typing import Literal
+
+from pydantic import Field
+
+from veadk.extensions.harness.schemas import (
+    ToolReceipt,
+    EvidenceRef,
+    HarnessBaseModel,
+    VerificationDecision,
+    VerificationReport,
+)
+
+
+class FinalResponseVerifierConfig(HarnessBaseModel):
+    """Settings for deterministic verification."""
+
+    mode: Literal["observe", "block"] = "observe"
+    require_receipt_for_completion_claims: bool = True
+    completion_markers: list[str] = Field(
+        default_factory=lambda: [
+            "created",
+            "saved",
+            "uploaded",
+            "deployed",
+            "verified",
+            "completed",
+            "done",
+            "生成",
+            "保存",
+            "部署",
+            "完成",
+        ]
+    )
+
+
+class FinalResponseVerifier:
+    """Checks whether final answers are grounded in available receipts."""
+
+    def __init__(self, config: FinalResponseVerifierConfig | None = None) -> None:
+        self.config = config or FinalResponseVerifierConfig()
+
+    def verify_text(
+        self,
+        text: str,
+        *,
+        receipts: list[ToolReceipt] | None = None,
+        evidence: list[EvidenceRef] | None = None,
+    ) -> VerificationReport:
+        """Verify answer text against tool receipts and evidence."""
+
+        receipts = receipts or []
+        evidence = evidence or self._evidence_from_receipts(receipts)
+        reasons = []
+        unsupported_claims = []
+        supported_claims = []
+        has_success_receipt = any(receipt.status == "success" for receipt in receipts)
+        if (
+            self.config.require_receipt_for_completion_claims
+            and self._has_completion_claim(text)
+            and not has_success_receipt
+        ):
+            reasons.append("completion claim has no successful capability receipt")
+            unsupported_claims.append(self._completion_sentence(text))
+
+        if self._looks_like_truncated_html(text):
+            reasons.append("response looks like truncated html")
+            unsupported_claims.append("html artifact is incomplete")
+
+        if evidence and not unsupported_claims:
+            supported_claims.append("answer has tool evidence")
+
+        status: Literal["pass", "warn", "fail"] = "pass"
+        if unsupported_claims:
+            status = "fail"
+        elif reasons:
+            status = "warn"
+        return VerificationReport(
+            status=status,
+            reasons=reasons,
+            supported_claims=supported_claims,
+            unsupported_claims=[claim for claim in unsupported_claims if claim],
+            evidence=evidence,
+        )
+
+    def decide(self, report: VerificationReport) -> VerificationDecision:
+        """Map a verification report to a plugin intervention."""
+
+        if report.status == "pass":
+            return VerificationDecision(action="allow", report=report)
+        if self.config.mode == "block" and report.status == "fail":
+            return VerificationDecision(
+                action="block",
+                reason="; ".join(report.reasons),
+                instruction=(
+                    "The answer was blocked because it made unsupported "
+                    "tool-backed completion claims."
+                ),
+                report=report,
+            )
+        return VerificationDecision(
+            action="observe",
+            reason="; ".join(report.reasons),
+            report=report,
+        )
+
+    def build_repair_instruction(
+        self, report: VerificationReport, *, goal: str = ""
+    ) -> str:
+        """Create a compact repair instruction for callers that support retry."""
+
+        reason_text = "; ".join(report.reasons or ["unsupported answer"])
+        parts = [
+            "[Harness Repair]",
+            "The previous answer failed verification.",
+            f"Problems: {reason_text}.",
+            "Retry the same task with evidence-backed claims only.",
+            "Do not claim that files, deployments, or artifacts exist unless a tool receipt proves it.",
+        ]
+        if goal:
+            parts.append(f"Original goal: {goal}")
+        parts.append("[/Harness Repair]")
+        return "\n".join(parts)
+
+    def try_repair_json_text(self, value: str) -> str:
+        """Repair common JSON-like tool argument text."""
+
+        candidate = self._strip_fences(value.strip())
+        if not candidate:
+            return value
+        for repaired in self._repair_candidates(candidate):
+            parsed = self._loads_json_or_python(repaired)
+            if parsed is not None:
+                return json.dumps(parsed, ensure_ascii=False, separators=(",", ":"))
+        return value
+
+    def _evidence_from_receipts(self, receipts: list[ToolReceipt]) -> list[EvidenceRef]:
+        evidence: list[EvidenceRef] = []
+        for receipt in receipts:
+            evidence.extend(receipt.evidence)
+            if receipt.summary:
+                evidence.append(
+                    EvidenceRef(
+                        source=receipt.name,
+                        content=receipt.summary,
+                        score=1.0 if receipt.status == "success" else 0.3,
+                    )
+                )
+        return evidence
+
+    def _has_completion_claim(self, text: str) -> bool:
+        lowered = text.lower()
+        return any(marker in lowered for marker in self.config.completion_markers)
+
+    def _completion_sentence(self, text: str) -> str:
+        sentences = re.split(r"(?<=[.!?。！？])\s+", text.strip())
+        for sentence in sentences:
+            if self._has_completion_claim(sentence):
+                return sentence
+        return sentences[0] if sentences else ""
+
+    def _looks_like_truncated_html(self, text: str) -> bool:
+        lowered = text.lower()
+        if "<html" in lowered and "</html>" not in lowered:
+            return True
+        if "<script" in lowered and "</script>" not in lowered:
+            return True
+        return "<div" in lowered and "</div>" not in lowered and len(text) > 1000
+
+    def _strip_fences(self, value: str) -> str:
+        stripped = value.strip()
+        if stripped.startswith("```"):
+            stripped = re.sub(r"^```[a-zA-Z0-9_-]*\s*", "", stripped)
+            stripped = re.sub(r"\s*```$", "", stripped)
+        return stripped.strip()
+
+    def _repair_candidates(self, candidate: str) -> list[str]:
+        values = [candidate]
+        extracted = self._extract_outer_json_text(candidate)
+        if extracted and extracted not in values:
+            values.append(extracted)
+        repaired = []
+        for value in values:
+            balanced = self._balance_brackets(value)
+            repaired.append(balanced)
+            normalized = self._normalize_json_like_text(balanced)
+            if normalized != balanced:
+                repaired.append(normalized)
+        return list(dict.fromkeys(repaired))
+
+    def _loads_json_or_python(
+        self, value: str
+    ) -> dict[str, object] | list[object] | None:
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, (dict, list)):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+        try:
+            parsed = ast.literal_eval(value)
+            if isinstance(parsed, (dict, list)):
+                return parsed
+        except (SyntaxError, ValueError):
+            pass
+        return None
+
+    def _extract_outer_json_text(self, value: str) -> str:
+        candidates = []
+        for start_char, end_char in (("{", "}"), ("[", "]")):
+            start = value.find(start_char)
+            end = value.rfind(end_char)
+            if start >= 0 and end > start:
+                candidates.append(value[start : end + 1])
+        return max(candidates, key=len) if candidates else ""
+
+    def _balance_brackets(self, value: str) -> str:
+        repaired = value.strip()
+        if repaired.count("{") > repaired.count("}"):
+            repaired += "}" * (repaired.count("{") - repaired.count("}"))
+        if repaired.count("[") > repaired.count("]"):
+            repaired += "]" * (repaired.count("[") - repaired.count("]"))
+        return repaired
+
+    def _normalize_json_like_text(self, value: str) -> str:
+        repaired = value.strip()
+        repaired = re.sub(r",\s*([}\]])", r"\1", repaired)
+        repaired = repaired.replace("\u201c", '"').replace("\u201d", '"')
+        repaired = repaired.replace("\u2018", "'").replace("\u2019", "'")
+        return repaired
+
+
+ResultVerifierConfig = FinalResponseVerifierConfig
+ResultVerifier = FinalResponseVerifier
+
+__all__ = [
+    "FinalResponseVerifier",
+    "FinalResponseVerifierConfig",
+    "ResultVerifier",
+    "ResultVerifierConfig",
+]

--- a/veadk/extensions/harness/modules/headroom_provider.py
+++ b/veadk/extensions/harness/modules/headroom_provider.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Headroom compression adapter for the atomic Harness SDK."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import importlib
+from typing import Protocol, cast
+
+from veadk.extensions.harness.schemas import (
+    CompactionReport,
+    CompressionRequest,
+    CompactionResult,
+    ConversationMessage,
+    JsonObject,
+)
+from veadk.extensions.harness.utils import coerce_json_object, stringify_json_value
+
+
+class _HeadroomCompressFn(Protocol):
+    def __call__(
+        self,
+        messages: list[JsonObject],
+        *,
+        model: str,
+        optimize: bool,
+    ) -> object: ...
+
+
+class HeadroomCompressionProvider:
+    """Adapter for local in-process Headroom compression."""
+
+    name = "headroom"
+
+    def __init__(
+        self,
+        *,
+        auto_install: bool | None = None,
+    ) -> None:
+        # Kept for source compatibility; Headroom is now code-only and never
+        # installed or started by the provider at runtime.
+        self.auto_install = auto_install
+
+    def compress(self, request: CompressionRequest) -> CompactionResult | None:
+        """Compress messages with Headroom when a provider is available."""
+
+        return self._compress_via_sdk(request)
+
+    def _compress_via_sdk(self, request: CompressionRequest) -> CompactionResult | None:
+        compress = self._load_compress()
+        if compress is None:
+            return None
+        try:
+            result = compress(
+                self._message_payloads(request.messages),
+                model=str(request.metadata.get("model") or "gpt-4o"),
+                optimize=True,
+            )
+        except Exception:
+            return None
+        compressed = self._messages_from_value(getattr(result, "messages", None))
+        if compressed is None:
+            return None
+        return self._build_result(
+            original_messages=request.messages,
+            compressed_messages=compressed,
+            metrics={
+                "tokens_before": getattr(result, "tokens_before", 0),
+                "tokens_after": getattr(result, "tokens_after", 0),
+                "tokens_saved": getattr(result, "tokens_saved", 0),
+                "compression_ratio": getattr(result, "compression_ratio", 0.0),
+                "transforms_applied": getattr(result, "transforms_applied", []),
+            },
+        )
+
+    def _load_compress(self) -> _HeadroomCompressFn | None:
+        return self._import_compress()
+
+    def _import_compress(self) -> _HeadroomCompressFn | None:
+        try:
+            module = importlib.import_module("headroom.compress")
+        except Exception:
+            return None
+        compress = getattr(module, "compress", None)
+        if not callable(compress):
+            return None
+        return cast(_HeadroomCompressFn, compress)
+
+    def _message_payloads(
+        self, messages: list[ConversationMessage]
+    ) -> list[JsonObject]:
+        return [message.model_dump(mode="json") for message in messages]
+
+    def _messages_from_value(self, value: object) -> list[ConversationMessage] | None:
+        if not isinstance(value, Sequence) or isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            return None
+        messages: list[ConversationMessage] = []
+        for item in value:
+            message = self._message_from_value(item)
+            if message is None:
+                return None
+            messages.append(message)
+        return messages
+
+    def _message_from_value(self, value: object) -> ConversationMessage | None:
+        if isinstance(value, ConversationMessage):
+            return value
+        if not isinstance(value, Mapping):
+            return None
+        role = value.get("role")
+        content = value.get("content")
+        if not isinstance(role, str):
+            return None
+        metadata = value.get("metadata")
+        name = value.get("name")
+        return ConversationMessage(
+            role=role,
+            content=content
+            if isinstance(content, str)
+            else stringify_json_value(content),
+            name=name if isinstance(name, str) else "",
+            metadata=coerce_json_object(metadata),
+        )
+
+    def _build_result(
+        self,
+        *,
+        original_messages: list[ConversationMessage],
+        compressed_messages: list[ConversationMessage],
+        metrics: Mapping[str, object],
+    ) -> CompactionResult:
+        original_chars = self._messages_char_count(original_messages)
+        compressed_chars = self._messages_char_count(compressed_messages)
+        tokens_before = self._int_metric(metrics.get("tokens_before"))
+        tokens_after = self._int_metric(metrics.get("tokens_after"))
+        tokens_saved = self._int_metric(metrics.get("tokens_saved"))
+        if tokens_saved == 0 and tokens_before > tokens_after:
+            tokens_saved = tokens_before - tokens_after
+        ratio = self._float_metric(metrics.get("compression_ratio"))
+        if ratio == 0.0 and original_chars:
+            ratio = compressed_chars / original_chars
+        return CompactionResult(
+            messages=compressed_messages,
+            report=CompactionReport(
+                provider=self.name,
+                original_chars=original_chars,
+                compressed_chars=compressed_chars,
+                changed=compressed_messages != original_messages,
+                tokens_before=tokens_before,
+                tokens_after=tokens_after,
+                tokens_saved=tokens_saved,
+                compression_ratio=ratio,
+                transforms_applied=self._string_list_metric(
+                    metrics.get("transforms_applied")
+                ),
+            ),
+        )
+
+    def _messages_char_count(self, messages: list[ConversationMessage]) -> int:
+        return sum(len(message.content) for message in messages)
+
+    def _int_metric(self, value: object) -> int:
+        try:
+            return int(value or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    def _float_metric(self, value: object) -> float:
+        try:
+            return float(value or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    def _string_list_metric(self, value: object) -> list[str]:
+        if not isinstance(value, Sequence) or isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            return []
+        return [str(item) for item in value]

--- a/veadk/extensions/harness/modules/invocation_context.py
+++ b/veadk/extensions/harness/modules/invocation_context.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Invocation context preparation module."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from veadk.extensions.harness.schemas import (
+    ToolReceipt,
+    InvocationContextBlock,
+    ConversationMessage,
+    HarnessBaseModel,
+    HarnessInvocationRef,
+)
+from veadk.extensions.harness.utils import summarize_text
+
+
+class HarnessInvocationContextConfig(HarnessBaseModel):
+    """Settings for invocation context generation."""
+
+    max_history_messages: int = 12
+    max_context_chars: int = 6000
+    include_history: bool = True
+    include_receipts: bool = True
+    precision_markers: list[str] = Field(
+        default_factory=lambda: [
+            ".csv",
+            "ranking",
+            "top ",
+            "filter",
+            "outlier",
+            "percentage",
+            "selector",
+            "sort",
+            "threshold",
+            "日志",
+            "排序",
+            "筛选",
+        ]
+    )
+    artifact_markers: list[str] = Field(
+        default_factory=lambda: [
+            "file",
+            "artifact",
+            "chart",
+            "plot",
+            "graph",
+            "dashboard",
+            "report",
+            "图表",
+            "文件",
+            "报告",
+        ]
+    )
+
+
+class HarnessInvocationContextBuilder:
+    """Build compact invocation context for an Agent turn."""
+
+    def __init__(self, config: HarnessInvocationContextConfig | None = None) -> None:
+        self.config = config or HarnessInvocationContextConfig()
+
+    def prepare_context(
+        self,
+        context: HarnessInvocationRef,
+        *,
+        user_input: str = "",
+        history: list[ConversationMessage] | None = None,
+        receipts: list[ToolReceipt] | None = None,
+        has_tools: bool = False,
+    ) -> InvocationContextBlock:
+        """Create an invocation context block for a model call."""
+
+        history = history or []
+        receipts = receipts or []
+        header = self.build_context_header(
+            context=context,
+            user_input=user_input,
+            history=history,
+            receipts=receipts,
+            has_tools=has_tools,
+        )
+        original_chars = sum(len(message.content) for message in history)
+        if len(header) > self.config.max_context_chars:
+            header = summarize_text(header, max_chars=self.config.max_context_chars)
+        return InvocationContextBlock(
+            header=header,
+            messages=history[-self.config.max_history_messages :],
+            original_chars=original_chars,
+            context_chars=len(header),
+            injected=bool(header.strip()),
+        )
+
+    def build_context_header(
+        self,
+        *,
+        context: HarnessInvocationRef,
+        user_input: str = "",
+        history: list[ConversationMessage] | None = None,
+        receipts: list[ToolReceipt] | None = None,
+        has_tools: bool = False,
+    ) -> str:
+        """Build the plain-text Harness Context block."""
+
+        task_goal = context.task.goal if context.task else user_input
+        acceptance = context.task.acceptance_criteria if context.task else []
+        lines = [
+            "[Harness Context]",
+            f"profile: {context.profile}",
+            f"session_id: {context.session_id}",
+            f"task_goal: {task_goal or user_input}",
+            "acceptance:",
+        ]
+        if acceptance:
+            lines.extend(f"- {item}" for item in acceptance)
+        else:
+            lines.extend(
+                [
+                    "- Stay anchored to the current user goal.",
+                    "- Preserve exact filenames, schemas, numbers, and dates.",
+                    "- Verify tool-backed claims before presenting completion.",
+                ]
+            )
+
+        recent = (history or [])[-self.config.max_history_messages :]
+        if self.config.include_history and recent:
+            lines.append("recent_history:")
+            for message in recent:
+                text = summarize_text(message.content, max_chars=500)
+                lines.append(f"- {message.role}: {text}")
+
+        if self.config.include_receipts and receipts:
+            lines.append("capability_receipts:")
+            for receipt in receipts[-6:]:
+                summary = summarize_text(receipt.summary, max_chars=300)
+                lines.append(f"- {receipt.name} [{receipt.status}]: {summary}")
+
+        mode_header = self._build_mode_header(
+            user_input=user_input, has_tools=has_tools
+        )
+        if mode_header:
+            lines.extend(["", mode_header])
+        lines.append("[/Harness Context]")
+        return "\n".join(lines)
+
+    def enhance_messages(
+        self,
+        messages: list[ConversationMessage],
+        context: HarnessInvocationRef,
+        *,
+        user_input: str = "",
+        receipts: list[ToolReceipt] | None = None,
+        has_tools: bool = False,
+    ) -> tuple[list[ConversationMessage], InvocationContextBlock]:
+        """Return messages with a Harness context message inserted."""
+
+        bundle = self.prepare_context(
+            context,
+            user_input=user_input,
+            history=messages,
+            receipts=receipts,
+            has_tools=has_tools,
+        )
+        if not bundle.header:
+            return messages, bundle
+
+        insert_at = 0
+        for index, message in enumerate(messages):
+            if message.role in {"system", "developer"}:
+                insert_at = index + 1
+        injected = ConversationMessage(
+            role="system",
+            name="veadk_harness_context",
+            content=bundle.header,
+        )
+        return messages[:insert_at] + [injected] + messages[insert_at:], bundle
+
+    def _build_mode_header(self, *, user_input: str, has_tools: bool) -> str:
+        lowered = user_input.lower()
+        blocks = []
+        if any(marker in lowered for marker in self.config.precision_markers):
+            blocks.append(
+                "\n".join(
+                    [
+                        "[Harness Precision Mode]",
+                        "- Treat selectors, schemas, dates, counts, and numeric thresholds as exact requirements.",
+                        "- Prefer deterministic parsing or tool checks over unsupported estimates.",
+                        "[/Harness Precision Mode]",
+                    ]
+                )
+            )
+        if any(marker in lowered for marker in self.config.artifact_markers):
+            blocks.append(
+                "\n".join(
+                    [
+                        "[Harness Artifact Mode]",
+                        "- Create the requested artifact before claiming completion.",
+                        "- Verify the artifact exists and is non-empty when tools are available.",
+                        "[/Harness Artifact Mode]",
+                    ]
+                )
+            )
+        if has_tools:
+            blocks.append(
+                "\n".join(
+                    [
+                        "[Harness Tool Protocol]",
+                        "- Tool-call arguments must be strict JSON object strings.",
+                        "- If a tool fails, use the failure as evidence and choose a different path when possible.",
+                        "[/Harness Tool Protocol]",
+                    ]
+                )
+            )
+        return "\n\n".join(blocks)
+
+
+ContextEngineConfig = HarnessInvocationContextConfig
+ContextEngine = HarnessInvocationContextBuilder
+
+__all__ = [
+    "ContextEngine",
+    "ContextEngineConfig",
+    "HarnessInvocationContextBuilder",
+    "HarnessInvocationContextConfig",
+]

--- a/veadk/extensions/harness/modules/result_verifier.py
+++ b/veadk/extensions/harness/modules/result_verifier.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backward-compatible imports for final-response verification."""
+
+from veadk.extensions.harness.modules.final_response_verifier import (
+    FinalResponseVerifier as ResultVerifier,
+    FinalResponseVerifierConfig as ResultVerifierConfig,
+)
+
+__all__ = ["ResultVerifier", "ResultVerifierConfig"]

--- a/veadk/extensions/harness/modules/tool_compressor.py
+++ b/veadk/extensions/harness/modules/tool_compressor.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backward-compatible imports for tool-result compaction."""
+
+from veadk.extensions.harness.modules.tool_result_compactor import (
+    ContextCompactionPolicy as ContextCompressionPolicy,
+    ToolResultCompactor as ToolResultCompressor,
+    ToolResultCompactorConfig as ToolResultCompressorConfig,
+)
+
+__all__ = [
+    "ContextCompressionPolicy",
+    "ToolResultCompressor",
+    "ToolResultCompressorConfig",
+]

--- a/veadk/extensions/harness/modules/tool_result_compactor.py
+++ b/veadk/extensions/harness/modules/tool_result_compactor.py
@@ -1,0 +1,598 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tool-result compaction module."""
+
+from __future__ import annotations
+
+import json
+from typing import Literal
+
+from veadk.extensions.harness.modules.builtin_provider import BuiltinCompressionProvider
+from veadk.extensions.harness.modules.headroom_provider import (
+    HeadroomCompressionProvider,
+)
+from veadk.extensions.harness.schemas import (
+    CompressionDecision,
+    CompressionPlan,
+    CompactionReport,
+    CompressionRequest,
+    CompactionResult,
+    ConversationMessage,
+    HarnessBaseModel,
+    JsonObject,
+)
+from veadk.extensions.harness.utils import (
+    coerce_json_object,
+    redact_text,
+    stringify_json_value,
+    summarize_text,
+)
+
+
+class ToolResultCompactorConfig(HarnessBaseModel):
+    """Settings for tool-result compaction."""
+
+    provider: str = "builtin"
+    max_context_chars: int = 24000
+    max_tool_result_chars: int = 4000
+    min_candidate_chars: int = 4000
+    protect_recent_messages: int = 2
+    summary_chars: int = 900
+
+
+class ContextCompactionPolicy:
+    """Select safe historical context for compaction."""
+
+    def __init__(self, config: ToolResultCompactorConfig | None = None) -> None:
+        self.config = config or ToolResultCompactorConfig()
+
+    def plan(self, messages: list[ConversationMessage]) -> CompressionPlan:
+        decisions = [
+            self._classify(index=index, total=len(messages), message=message)
+            for index, message in enumerate(messages)
+        ]
+        candidate_indexes = [
+            decision.index for decision in decisions if decision.action == "compress"
+        ]
+        by_action: dict[str, int] = {}
+        by_reason: dict[str, int] = {}
+        for decision in decisions:
+            by_action[decision.action] = by_action.get(decision.action, 0) + 1
+            key = f"{decision.action}:{decision.reason}"
+            by_reason[key] = by_reason.get(key, 0) + 1
+        summary: JsonObject = {
+            "mode": "role_and_recency_aware",
+            "message_count": len(decisions),
+            "candidate_count": len(candidate_indexes),
+            "candidate_indexes": list(candidate_indexes),
+            "by_action": by_action,
+            "by_reason": by_reason,
+        }
+        return CompressionPlan(
+            decisions=decisions,
+            candidate_indexes=candidate_indexes,
+            summary=summary,
+        )
+
+    def _classify(
+        self,
+        *,
+        index: int,
+        total: int,
+        message: ConversationMessage,
+    ) -> CompressionDecision:
+        role = message.role
+        chars = len(message.content)
+        messages_from_end = total - index
+        if role in {"system", "developer"}:
+            return self._decision(index, "protect", "instructions", role, chars)
+        if role == "user":
+            return self._decision(index, "protect", "user_intent", role, chars)
+        if role == "assistant":
+            return self._decision(index, "protect", "assistant_state", role, chars)
+        if messages_from_end <= self.config.protect_recent_messages:
+            return self._decision(index, "protect", "recent_feedback", role, chars)
+        if chars < self.config.min_candidate_chars:
+            return self._decision(index, "skip", "small_output", role, chars)
+        if role in {"tool", "tool_result", "function"}:
+            reason = (
+                "old_large_error_or_recovery_evidence"
+                if self._looks_like_recovery_evidence(message.content)
+                else "old_large_tool_output"
+            )
+            return self._decision(index, "compress", reason, role, chars)
+        return self._decision(index, "compress", "old_large_unknown_role", role, chars)
+
+    def _decision(
+        self,
+        index: int,
+        action: Literal["protect", "skip", "compress"],
+        reason: str,
+        role: str,
+        chars: int,
+    ) -> CompressionDecision:
+        return CompressionDecision(
+            index=index,
+            action=action,
+            reason=reason,
+            role=role,
+            chars=chars,
+        )
+
+    def _looks_like_recovery_evidence(self, text: str) -> bool:
+        lowered = text.lower()
+        signals = (
+            "traceback",
+            "exception",
+            "error:",
+            "failed",
+            "permission denied",
+            "no such file",
+            "syntaxerror",
+            "typeerror",
+            "diff --git",
+        )
+        return any(signal in lowered for signal in signals)
+
+
+class ToolResultCompactor:
+    """Dependency-free compactor for large historical tool results."""
+
+    def __init__(self, config: ToolResultCompactorConfig | None = None) -> None:
+        self.config = config or ToolResultCompactorConfig()
+        self.policy = ContextCompactionPolicy(self.config)
+        self.builtin = BuiltinCompressionProvider()
+        self._headroom: HeadroomCompressionProvider | None = None
+
+    def compress_messages(self, request: CompressionRequest) -> CompactionResult:
+        """Compact candidate messages while preserving control-plane messages."""
+
+        original_chars = self._messages_char_count(request.messages)
+        if original_chars <= request.max_context_chars:
+            return CompactionResult(
+                messages=list(request.messages),
+                report=CompactionReport(
+                    provider=self.config.provider,
+                    original_chars=original_chars,
+                    compressed_chars=original_chars,
+                    changed=False,
+                ),
+            )
+
+        plan = self.policy.plan(request.messages)
+        warnings: list[str] = []
+        if self._uses_headroom():
+            result = self._compress_messages_with_headroom(request, plan)
+            if result is not None:
+                return result
+            warnings.append("headroom provider unavailable; used builtin fallback")
+
+        if self._uses_headroom() or self._uses_builtin_or_default():
+            result = self._compress_messages_with_builtin(request, plan, warnings)
+            if result is not None:
+                return result
+
+        compressed = list(request.messages)
+        for index in plan.candidate_indexes:
+            message = compressed[index]
+            compressed[index] = message.model_copy(
+                update={"content": self._summary(message.content, index=index)}
+            )
+            if self._messages_char_count(compressed) <= request.max_context_chars:
+                break
+
+        omitted = 0
+        while (
+            self._messages_char_count(compressed) > request.max_context_chars
+            and len(compressed) > request.protected_message_count
+        ):
+            removable = self._oldest_removable_index(compressed)
+            if removable is None:
+                break
+            compressed.pop(removable)
+            omitted += 1
+
+        compressed_chars = self._messages_char_count(compressed)
+        if self._uses_headroom() and plan.candidate_indexes:
+            warnings[-1:] = [
+                "headroom and builtin providers unavailable; used heuristic fallback"
+            ]
+        if compressed_chars > request.max_context_chars:
+            warnings.append("context still exceeds max_context_chars")
+        return CompactionResult(
+            messages=compressed,
+            report=CompactionReport(
+                provider=self._fallback_provider(),
+                original_chars=original_chars,
+                compressed_chars=compressed_chars,
+                changed=compressed != request.messages,
+                omitted_messages=omitted,
+                protected_messages=len(
+                    [item for item in plan.decisions if item.action == "protect"]
+                ),
+                compression_ratio=(
+                    compressed_chars / original_chars if original_chars else 1.0
+                ),
+                transforms_applied=["heuristic_summary"]
+                if compressed != request.messages
+                else [],
+                policy=plan.summary,
+                warnings=warnings,
+            ),
+        )
+
+    def compress_tool_result(self, result: object) -> tuple[object, CompactionReport]:
+        """Compact a single tool result mapping if it exceeds the configured size."""
+
+        original_text = self._raw_payload_text(result)
+        original_chars = len(original_text)
+        if original_chars <= self.config.max_tool_result_chars:
+            return result, CompactionReport(
+                provider=self.config.provider,
+                original_chars=original_chars,
+                compressed_chars=original_chars,
+                changed=False,
+            )
+
+        warnings: list[str] = []
+        if self._uses_headroom():
+            headroom = self._compress_tool_result_with_headroom(
+                result=result,
+                original_text=original_text,
+                original_chars=original_chars,
+            )
+            if headroom is not None:
+                return headroom
+            warnings.append("headroom provider unavailable; used builtin fallback")
+
+        builtin = self._compress_tool_result_with_builtin(
+            result=result,
+            original_text=original_text,
+            original_chars=original_chars,
+            warnings=warnings,
+        )
+        if builtin is not None:
+            return builtin
+
+        summary = self._summary(original_text, index=0)
+        compressed: dict[str, object] = {
+            "harness_compressed": True,
+            "summary": summary,
+            "original_chars": original_chars,
+        }
+        if isinstance(result, dict) and "error" in result:
+            compressed["error"] = result["error"]
+        if isinstance(result, dict) and "status" in result:
+            compressed["status"] = result["status"]
+        report = CompactionReport(
+            provider=self._fallback_provider(),
+            original_chars=original_chars,
+            compressed_chars=len(self._raw_payload_text(compressed)),
+            changed=True,
+            transforms_applied=["tool_result_summary"],
+            policy={"mode": "single_tool_result"},
+            warnings=warnings
+            + (
+                ["builtin provider unavailable; used heuristic fallback"]
+                if self._uses_headroom()
+                else []
+            ),
+        )
+        return compressed, report
+
+    def receipt_summary(self, tool_name: str, result: dict[str, object]) -> str:
+        """Build a concise receipt summary for a tool result."""
+
+        status = result.get("status") or ("error" if "error" in result else "success")
+        body = stringify_json_value(result, max_chars=1200)
+        return f"{tool_name} status={status}; {body}"
+
+    def _summary(self, text: str, *, index: int) -> str:
+        return "\n".join(
+            [
+                "[Compressed tool context]",
+                f"message_index: {index}",
+                f"summary: {summarize_text(text, max_chars=self.config.summary_chars)}",
+            ]
+        )
+
+    def _oldest_removable_index(
+        self, messages: list[ConversationMessage]
+    ) -> int | None:
+        for index, message in enumerate(messages):
+            if message.role not in {"system", "developer", "user", "assistant"}:
+                return index
+        return None
+
+    def _compress_messages_with_headroom(
+        self, request: CompressionRequest, plan: CompressionPlan
+    ) -> CompactionResult | None:
+        if not plan.candidate_indexes:
+            return None
+        candidates = [request.messages[index] for index in plan.candidate_indexes]
+        metadata = self._headroom_metadata(
+            request.metadata,
+            mode="model_context",
+            token_budget=max(1, request.max_context_chars // 4),
+        )
+        result = self._headroom_provider().compress(
+            CompressionRequest(
+                messages=candidates,
+                max_context_chars=request.max_context_chars,
+                protected_message_count=0,
+                metadata=metadata,
+            )
+        )
+        if result is None or len(result.messages) != len(candidates):
+            return None
+
+        compressed = list(request.messages)
+        for index, message in zip(plan.candidate_indexes, result.messages):
+            compressed[index] = message
+
+        omitted = 0
+        while (
+            self._messages_char_count(compressed) > request.max_context_chars
+            and len(compressed) > request.protected_message_count
+        ):
+            removable = self._oldest_removable_index(compressed)
+            if removable is None:
+                break
+            compressed.pop(removable)
+            omitted += 1
+
+        original_chars = self._messages_char_count(request.messages)
+        compressed_chars = self._messages_char_count(compressed)
+        warnings = list(result.report.warnings)
+        if compressed_chars > request.max_context_chars:
+            warnings.append("context still exceeds max_context_chars")
+        transforms = list(result.report.transforms_applied)
+        if "headroom_candidate_compression" not in transforms:
+            transforms.append("headroom_candidate_compression")
+        return CompactionResult(
+            messages=compressed,
+            report=result.report.model_copy(
+                update={
+                    "original_chars": original_chars,
+                    "compressed_chars": compressed_chars,
+                    "changed": compressed != request.messages,
+                    "omitted_messages": omitted,
+                    "protected_messages": len(
+                        [item for item in plan.decisions if item.action == "protect"]
+                    ),
+                    "compression_ratio": (
+                        compressed_chars / original_chars if original_chars else 1.0
+                    ),
+                    "transforms_applied": transforms,
+                    "policy": plan.summary,
+                    "warnings": warnings,
+                }
+            ),
+        )
+
+    def _compress_messages_with_builtin(
+        self,
+        request: CompressionRequest,
+        plan: CompressionPlan,
+        warnings: list[str],
+    ) -> CompactionResult | None:
+        if not plan.candidate_indexes:
+            return None
+        candidates = [request.messages[index] for index in plan.candidate_indexes]
+        result = self.builtin.compress(
+            CompressionRequest(
+                messages=candidates,
+                max_context_chars=request.max_context_chars,
+                protected_message_count=0,
+                metadata=request.metadata,
+            )
+        )
+        if result is None or len(result.messages) != len(candidates):
+            return None
+        compressed = list(request.messages)
+        for index, message in zip(plan.candidate_indexes, result.messages):
+            compressed[index] = message
+        original_chars = self._messages_char_count(request.messages)
+        compressed_chars = self._messages_char_count(compressed)
+        return CompactionResult(
+            messages=compressed,
+            report=result.report.model_copy(
+                update={
+                    "original_chars": original_chars,
+                    "compressed_chars": compressed_chars,
+                    "changed": compressed != request.messages,
+                    "protected_messages": len(
+                        [item for item in plan.decisions if item.action == "protect"]
+                    ),
+                    "compression_ratio": (
+                        compressed_chars / original_chars if original_chars else 1.0
+                    ),
+                    "policy": plan.summary,
+                    "warnings": list(warnings),
+                }
+            ),
+        )
+
+    def _compress_tool_result_with_headroom(
+        self,
+        *,
+        result: object,
+        original_text: str,
+        original_chars: int,
+    ) -> tuple[dict[str, object], CompactionReport] | None:
+        metadata = self._headroom_metadata(
+            {},
+            mode="single_tool_result",
+            token_budget=max(1, self.config.max_tool_result_chars // 4),
+        )
+        headroom_result = self._headroom_provider().compress(
+            CompressionRequest(
+                messages=[
+                    ConversationMessage(
+                        role="tool",
+                        content=original_text,
+                        metadata=coerce_json_object(result),
+                    )
+                ],
+                max_context_chars=self.config.max_tool_result_chars,
+                protected_message_count=0,
+                metadata=metadata,
+            )
+        )
+        if headroom_result is None or not headroom_result.messages:
+            return None
+        summary = headroom_result.messages[0].content
+        if not summary or len(summary) >= original_chars:
+            return None
+        compressed: dict[str, object] = {
+            "harness_compressed": True,
+            "provider": "headroom",
+            "summary": summary,
+            "original_chars": original_chars,
+        }
+        if isinstance(result, dict) and "error" in result:
+            compressed["error"] = result["error"]
+        if isinstance(result, dict) and "status" in result:
+            compressed["status"] = result["status"]
+        compressed_chars = len(self._raw_payload_text(compressed))
+        transforms = list(headroom_result.report.transforms_applied)
+        if "headroom_tool_result_compression" not in transforms:
+            transforms.append("headroom_tool_result_compression")
+        report = headroom_result.report.model_copy(
+            update={
+                "original_chars": original_chars,
+                "compressed_chars": compressed_chars,
+                "changed": True,
+                "compression_ratio": compressed_chars / original_chars,
+                "transforms_applied": transforms,
+                "policy": {"mode": "single_tool_result", "provider": "headroom"},
+            }
+        )
+        return compressed, report
+
+    def _compress_tool_result_with_builtin(
+        self,
+        *,
+        result: object,
+        original_text: str,
+        original_chars: int,
+        warnings: list[str],
+    ) -> tuple[dict[str, object], CompactionReport] | None:
+        builtin_result = self.builtin.compress(
+            CompressionRequest(
+                messages=[
+                    ConversationMessage(
+                        role="tool",
+                        content=original_text,
+                        metadata=coerce_json_object(result),
+                    )
+                ],
+                max_context_chars=self.config.max_tool_result_chars,
+                protected_message_count=0,
+                metadata={},
+            )
+        )
+        if builtin_result is None or not builtin_result.messages:
+            return None
+        summary = builtin_result.messages[0].content
+        compressed: dict[str, object] = {
+            "harness_compressed": True,
+            "provider": "builtin",
+            "summary": summary,
+            "original_chars": original_chars,
+        }
+        if isinstance(result, dict) and "error" in result:
+            compressed["error"] = result["error"]
+        if isinstance(result, dict) and "status" in result:
+            compressed["status"] = result["status"]
+        compressed_chars = len(self._raw_payload_text(compressed))
+        report = builtin_result.report.model_copy(
+            update={
+                "original_chars": original_chars,
+                "compressed_chars": compressed_chars,
+                "changed": True,
+                "compression_ratio": compressed_chars / original_chars,
+                "policy": {"mode": "single_tool_result", "provider": "builtin"},
+                "warnings": list(warnings),
+            }
+        )
+        return compressed, report
+
+    def _messages_char_count(self, messages: list[ConversationMessage]) -> int:
+        return sum(len(message.content) for message in messages)
+
+    def _uses_headroom(self) -> bool:
+        return self._provider_name() in {
+            "headroom",
+            "managed_compressor",
+            "context_compressor",
+        }
+
+    def _uses_builtin_or_default(self) -> bool:
+        return self._provider_name() in {"", "auto", "builtin", "built_in", "managed"}
+
+    def _fallback_provider(self) -> str:
+        return "heuristic"
+
+    def _provider_name(self) -> str:
+        return self.config.provider.strip().lower()
+
+    def _headroom_provider(self) -> HeadroomCompressionProvider:
+        if self._headroom is None:
+            self._headroom = HeadroomCompressionProvider()
+        return self._headroom
+
+    def _headroom_metadata(
+        self,
+        metadata: JsonObject,
+        *,
+        mode: str,
+        token_budget: int,
+    ) -> JsonObject:
+        merged = dict(metadata)
+        merged.setdefault("compression_config", {"mode": mode})
+        merged.setdefault("token_budget", token_budget)
+        return merged
+
+    def dict_to_message(
+        self, role: str, payload: dict[str, object]
+    ) -> ConversationMessage:
+        """Convert a mapping into a message projection."""
+
+        return ConversationMessage(
+            role=role,
+            content=stringify_json_value(payload),
+            metadata=coerce_json_object(payload),
+        )
+
+    def _raw_payload_text(self, payload: object) -> str:
+        try:
+            return redact_text(json.dumps(payload, ensure_ascii=False, default=str))
+        except TypeError:
+            return redact_text(str(payload))
+
+
+ToolResultCompressorConfig = ToolResultCompactorConfig
+ContextCompressionPolicy = ContextCompactionPolicy
+ToolResultCompressor = ToolResultCompactor
+
+__all__ = [
+    "ContextCompactionPolicy",
+    "ContextCompressionPolicy",
+    "ToolResultCompactor",
+    "ToolResultCompactorConfig",
+    "ToolResultCompressor",
+    "ToolResultCompressorConfig",
+]

--- a/veadk/extensions/harness/schemas.py
+++ b/veadk/extensions/harness/schemas.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public Pydantic models shared by Harness modules and plugins."""
+
+from __future__ import annotations
+
+from typing import Literal, TypeAlias
+
+from pydantic import BaseModel, ConfigDict, Field
+
+JsonScalar: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = JsonScalar | list[object] | dict[str, object]
+JsonObject: TypeAlias = dict[str, JsonValue]
+
+
+class HarnessBaseModel(BaseModel):
+    """Strict base model for public SDK schemas."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        validate_assignment=True,
+    )
+
+
+class TaskContract(HarnessBaseModel):
+    """Stable task target used to keep multi-turn runs anchored."""
+
+    goal: str = ""
+    acceptance_criteria: list[str] = Field(default_factory=list)
+    metadata: JsonObject = Field(default_factory=dict)
+
+
+class HarnessInvocationRef(HarnessBaseModel):
+    """Run identity and profile propagated through Harness modules."""
+
+    app_name: str = ""
+    user_id: str = ""
+    session_id: str
+    invocation_id: str
+    profile: str = "default"
+    task: TaskContract | None = None
+    metadata: JsonObject = Field(default_factory=dict)
+
+
+class ConversationMessage(HarnessBaseModel):
+    """Protocol-neutral message projection used by atomic modules."""
+
+    role: str
+    content: str
+    name: str = ""
+    metadata: JsonObject = Field(default_factory=dict)
+
+
+class InvocationContextBlock(HarnessBaseModel):
+    """Context header and accounting generated before a model call."""
+
+    header: str
+    messages: list[ConversationMessage] = Field(default_factory=list)
+    original_chars: int = 0
+    context_chars: int = 0
+    injected: bool = False
+    warnings: list[str] = Field(default_factory=list)
+
+
+class CompressionDecision(HarnessBaseModel):
+    """Policy decision for one message."""
+
+    index: int
+    action: Literal["protect", "skip", "compress"]
+    reason: str
+    role: str
+    chars: int
+
+
+class CompressionPlan(HarnessBaseModel):
+    """Role and recency aware compression plan."""
+
+    decisions: list[CompressionDecision] = Field(default_factory=list)
+    candidate_indexes: list[int] = Field(default_factory=list)
+    summary: JsonObject = Field(default_factory=dict)
+
+
+class CompressionRequest(HarnessBaseModel):
+    """Messages and limits passed to a compressor."""
+
+    messages: list[ConversationMessage]
+    max_context_chars: int = 24000
+    protected_message_count: int = 2
+    metadata: JsonObject = Field(default_factory=dict)
+
+
+class CompactionReport(HarnessBaseModel):
+    """Compaction accounting and policy trace."""
+
+    provider: str
+    original_chars: int
+    compressed_chars: int
+    changed: bool = False
+    omitted_messages: int = 0
+    protected_messages: int = 0
+    tokens_before: int = 0
+    tokens_after: int = 0
+    tokens_saved: int = 0
+    compression_ratio: float = 0.0
+    transforms_applied: list[str] = Field(default_factory=list)
+    policy: JsonObject = Field(default_factory=dict)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class CompactionResult(HarnessBaseModel):
+    """Compacted messages and report."""
+
+    messages: list[ConversationMessage]
+    report: CompactionReport
+
+
+class EvidenceRef(HarnessBaseModel):
+    """Evidence extracted from tool outputs or other trusted context."""
+
+    source: str
+    content: str
+    score: float = 1.0
+    metadata: JsonObject = Field(default_factory=dict)
+
+
+class ToolReceipt(HarnessBaseModel):
+    """Structured record of a tool or capability result."""
+
+    name: str
+    status: Literal["success", "error", "unknown"] = "unknown"
+    summary: str = ""
+    run_id: str = ""
+    session_id: str = ""
+    evidence: list[EvidenceRef] = Field(default_factory=list)
+    metadata: JsonObject = Field(default_factory=dict)
+
+
+class VerificationReport(HarnessBaseModel):
+    """Answer grounding result."""
+
+    status: Literal["pass", "warn", "fail"] = "pass"
+    reasons: list[str] = Field(default_factory=list)
+    supported_claims: list[str] = Field(default_factory=list)
+    unsupported_claims: list[str] = Field(default_factory=list)
+    evidence: list[EvidenceRef] = Field(default_factory=list)
+    repaired: bool = False
+
+
+class VerificationDecision(HarnessBaseModel):
+    """Action a plugin can take after validation."""
+
+    action: Literal["allow", "observe", "repair", "block"] = "allow"
+    reason: str = ""
+    instruction: str = ""
+    report: VerificationReport | None = None
+
+
+class HarnessEvent(HarnessBaseModel):
+    """Generic event stored for receipts, reports, and diagnostics."""
+
+    event_type: str
+    run_context: HarnessInvocationRef | None = None
+    payload: JsonObject = Field(default_factory=dict)
+
+
+HarnessRunContext = HarnessInvocationRef
+ContextBundle = InvocationContextBlock
+CompressionReport = CompactionReport
+CompressionResult = CompactionResult
+CapabilityReceipt = ToolReceipt
+HarnessIntervention = VerificationDecision
+
+__all__ = [
+    "CapabilityReceipt",
+    "CompactionReport",
+    "CompactionResult",
+    "CompressionDecision",
+    "CompressionPlan",
+    "CompressionReport",
+    "CompressionRequest",
+    "CompressionResult",
+    "ContextBundle",
+    "ConversationMessage",
+    "EvidenceRef",
+    "HarnessBaseModel",
+    "HarnessEvent",
+    "HarnessIntervention",
+    "HarnessInvocationRef",
+    "HarnessRunContext",
+    "InvocationContextBlock",
+    "JsonObject",
+    "JsonScalar",
+    "JsonValue",
+    "TaskContract",
+    "ToolReceipt",
+    "VerificationDecision",
+    "VerificationReport",
+]

--- a/veadk/extensions/harness/stores/__init__.py
+++ b/veadk/extensions/harness/stores/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Harness store implementations."""
+
+from veadk.extensions.harness.stores.jsonl import JsonlHarnessStore
+from veadk.extensions.harness.stores.memory import InMemoryHarnessStore
+from veadk.extensions.harness.stores.protocols import HarnessStoreProtocol
+
+__all__ = ["HarnessStoreProtocol", "InMemoryHarnessStore", "JsonlHarnessStore"]

--- a/veadk/extensions/harness/stores/jsonl.py
+++ b/veadk/extensions/harness/stores/jsonl.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""JSONL Harness store."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from veadk.extensions.harness.schemas import (
+    ToolReceipt,
+    ConversationMessage,
+    HarnessEvent,
+)
+
+
+class JsonlHarnessStore:
+    """Append-only local JSONL store with lightweight reads."""
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def append_event(self, event: HarnessEvent) -> None:
+        self._append("events.jsonl", event.model_dump(mode="json"))
+
+    def append_receipt(self, receipt: ToolReceipt) -> None:
+        self._append("receipts.jsonl", receipt.model_dump(mode="json"))
+
+    def append_message(self, session_id: str, message: ConversationMessage) -> None:
+        payload = message.model_dump(mode="json")
+        payload["session_id"] = session_id
+        self._append("messages.jsonl", payload)
+
+    def load_messages(
+        self, session_id: str, limit: int | None = None
+    ) -> list[ConversationMessage]:
+        messages = []
+        for payload in self._read("messages.jsonl"):
+            if payload.get("session_id") != session_id:
+                continue
+            payload.pop("session_id", None)
+            messages.append(ConversationMessage.model_validate(payload))
+        return messages[-limit:] if limit else messages
+
+    def load_receipts(
+        self,
+        *,
+        run_id: str = "",
+        session_id: str = "",
+        limit: int | None = None,
+    ) -> list[ToolReceipt]:
+        receipts = []
+        for payload in self._read("receipts.jsonl"):
+            receipt = ToolReceipt.model_validate(payload)
+            if run_id and receipt.run_id != run_id:
+                continue
+            if session_id and receipt.session_id != session_id:
+                continue
+            receipts.append(receipt)
+        return receipts[-limit:] if limit else receipts
+
+    def _append(self, filename: str, payload: dict[str, object]) -> None:
+        path = self.root / filename
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+
+    def _read(self, filename: str) -> list[dict[str, object]]:
+        path = self.root / filename
+        if not path.is_file():
+            return []
+        rows: list[dict[str, object]] = []
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                value = json.loads(line)
+                if isinstance(value, dict):
+                    rows.append(value)
+        return rows

--- a/veadk/extensions/harness/stores/memory.py
+++ b/veadk/extensions/harness/stores/memory.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""In-memory Harness store for tests and local development."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from veadk.extensions.harness.schemas import (
+    ToolReceipt,
+    ConversationMessage,
+    HarnessEvent,
+)
+
+
+class InMemoryHarnessStore:
+    """Simple process-local store."""
+
+    def __init__(self) -> None:
+        self.events: list[HarnessEvent] = []
+        self.receipts: list[ToolReceipt] = []
+        self.messages: dict[str, list[ConversationMessage]] = defaultdict(list)
+
+    def append_event(self, event: HarnessEvent) -> None:
+        self.events.append(event)
+
+    def append_receipt(self, receipt: ToolReceipt) -> None:
+        self.receipts.append(receipt)
+
+    def append_message(self, session_id: str, message: ConversationMessage) -> None:
+        self.messages[session_id].append(message)
+
+    def load_messages(
+        self, session_id: str, limit: int | None = None
+    ) -> list[ConversationMessage]:
+        messages = list(self.messages.get(session_id, []))
+        return messages[-limit:] if limit else messages
+
+    def load_receipts(
+        self,
+        *,
+        run_id: str = "",
+        session_id: str = "",
+        limit: int | None = None,
+    ) -> list[ToolReceipt]:
+        receipts = [
+            receipt
+            for receipt in self.receipts
+            if (not run_id or receipt.run_id == run_id)
+            and (not session_id or receipt.session_id == session_id)
+        ]
+        return receipts[-limit:] if limit else receipts

--- a/veadk/extensions/harness/stores/protocols.py
+++ b/veadk/extensions/harness/stores/protocols.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Store protocols for Harness events and receipts."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from veadk.extensions.harness.schemas import (
+    ToolReceipt,
+    ConversationMessage,
+    HarnessEvent,
+)
+
+
+class HarnessStoreProtocol(Protocol):
+    """Minimal persistence protocol used by atomic modules and plugins."""
+
+    def append_event(self, event: HarnessEvent) -> None:
+        """Persist a Harness event."""
+
+    def append_receipt(self, receipt: ToolReceipt) -> None:
+        """Persist a capability receipt."""
+
+    def append_message(self, session_id: str, message: ConversationMessage) -> None:
+        """Persist a message projection for later context engineering."""
+
+    def load_messages(
+        self, session_id: str, limit: int | None = None
+    ) -> list[ConversationMessage]:
+        """Load recent messages for a session."""
+
+    def load_receipts(
+        self,
+        *,
+        run_id: str = "",
+        session_id: str = "",
+        limit: int | None = None,
+    ) -> list[ToolReceipt]:
+        """Load receipts filtered by run or session."""

--- a/veadk/extensions/harness/testing/__init__.py
+++ b/veadk/extensions/harness/testing/__init__.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Testing helpers for deterministic Harness evals."""
+
+from veadk.extensions.harness.testing.golden import (
+    GoldenCase,
+    GoldenResult,
+    run_golden_cases,
+)
+
+__all__ = ["GoldenCase", "GoldenResult", "run_golden_cases"]

--- a/veadk/extensions/harness/testing/golden.py
+++ b/veadk/extensions/harness/testing/golden.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tiny deterministic eval runner for Harness modules."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from pydantic import Field
+
+from veadk.extensions.harness.schemas import HarnessBaseModel, JsonObject
+
+
+class GoldenCase(HarnessBaseModel):
+    """One deterministic test case."""
+
+    name: str
+    input: JsonObject = Field(default_factory=dict)
+    expected: JsonObject = Field(default_factory=dict)
+
+
+class GoldenResult(HarnessBaseModel):
+    """Result for one golden case."""
+
+    name: str
+    passed: bool
+    observed: JsonObject = Field(default_factory=dict)
+    expected: JsonObject = Field(default_factory=dict)
+
+
+def run_golden_cases(
+    cases: list[GoldenCase],
+    runner: Callable[[GoldenCase], JsonObject],
+) -> list[GoldenResult]:
+    """Run exact-match deterministic golden cases."""
+
+    results = []
+    for case in cases:
+        observed = runner(case)
+        results.append(
+            GoldenResult(
+                name=case.name,
+                passed=observed == case.expected,
+                observed=observed,
+                expected=case.expected,
+            )
+        )
+    return results

--- a/veadk/extensions/harness/utils.py
+++ b/veadk/extensions/harness/utils.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Small text helpers used by Harness modules."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+
+from veadk.extensions.harness.schemas import JsonObject, JsonValue
+
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)(authorization\s*[:=]\s*bearer\s+)[^\s,;]+"),
+    re.compile(r"(?i)((?:api[_-]?key|secret|token|password)\s*[:=]\s*)[^\s,;]+"),
+    re.compile(r"(?i)((?:access[_-]?key|secret[_-]?key)\s*[:=]\s*)[^\s,;]+"),
+)
+
+
+def summarize_text(text: str, *, max_chars: int = 900) -> str:
+    """Return a compact single-string summary without model calls."""
+
+    normalized = " ".join(text.split())
+    if len(normalized) <= max_chars:
+        return normalized
+    head = normalized[: max_chars // 2].rstrip()
+    tail = normalized[-max_chars // 3 :].lstrip()
+    omitted = len(normalized) - len(head) - len(tail)
+    return f"{head} ... [omitted {omitted} chars] ... {tail}"
+
+
+def redact_text(text: str) -> str:
+    """Mask common credential shapes in traces and receipts."""
+
+    redacted = text
+    for pattern in _SECRET_PATTERNS:
+        redacted = pattern.sub(r"\1[REDACTED]", redacted)
+    return redacted
+
+
+def stringify_json_value(value: object, *, max_chars: int = 4000) -> str:
+    """Render dynamic values for receipts without leaking huge payloads."""
+
+    if isinstance(value, str):
+        return summarize_text(redact_text(value), max_chars=max_chars)
+    if isinstance(value, Mapping):
+        parts = []
+        for key, item in value.items():
+            parts.append(f"{key}: {stringify_json_value(item, max_chars=400)}")
+        return summarize_text(redact_text("; ".join(parts)), max_chars=max_chars)
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        parts = [stringify_json_value(item, max_chars=300) for item in value[:20]]
+        return summarize_text(redact_text("; ".join(parts)), max_chars=max_chars)
+    return summarize_text(redact_text(str(value)), max_chars=max_chars)
+
+
+def coerce_json_value(value: object) -> JsonValue:
+    """Convert a Python object into the SDK's JSON-safe value type."""
+
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): coerce_json_value(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        return [coerce_json_value(item) for item in value]
+    return str(value)
+
+
+def coerce_json_object(value: object) -> JsonObject:
+    """Convert a mapping-like object into a JSON object."""
+
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): coerce_json_value(item) for key, item in value.items()}

--- a/veadk/harness.py
+++ b/veadk/harness.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agent Harness plugin bridge for veADK users."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from google.adk.plugins import BasePlugin
+
+
+def build_harness_plugins(
+    *,
+    components: Iterable[str] | str | None = None,
+    profile: str = "default",
+) -> list[BasePlugin]:
+    """Build Harness plugins from the bundled veADK extension."""
+
+    from veadk.extensions.harness.adk import build_harness_plugins as _build
+
+    return _build(components=components, profile=profile)
+
+
+__all__ = ["build_harness_plugins"]


### PR DESCRIPTION
## Summary

  This PR adds Agent Harness support to veADK through two layers:

  1. A standalone `agentkit-harness-python` SDK package under `packages/`
     - ADK plugins for invocation context, tool-result compaction, and final response verification
     - Atomic modules with Pydantic schemas, in-memory/JSONL stores, golden fixtures, and deterministic tests
     - Optional `headroom` support via `agentkit-harness-python[headroom]`
     - No runtime service dependency for Harness modules

  2. Runtime-level Harness enhancement for HarnessApp / AgentKit invocation
     - `veadk harness` config now supports `harness_enhance`
     - `veadk agentkit invoke --enable-harness-enhance` maps enhancement options into the request body and headers
     - HarnessApp can attach plugins per invocation without changing existing public interfaces
     - Runtime metrics now expose LLM usage, enabled plugin names, and compaction reports

  ## Key Design Notes

  - Default install stays lightweight: `agentkit-harness-python` does not install `headroom`.
  - `headroom` is an optional extra: `agentkit-harness-python[headroom]`.
  - Runtime never starts a headroom service and never installs headroom dynamically.
  - If `provider=headroom` is configured but the package is not installed, compaction falls back to the built-in provider.
  - Existing HarnessApp request/response behavior remains backward compatible.

  ## Validation

  Local tests:

  ```bash
  PYTHONPATH=. pytest -q \
    packages/agentkit-harness-python/tests \
    tests/cloud/test_harness_app_contract.py \
    tests/cloud/test_harness_plugins.py \
    tests/cloud/test_harness_enhance_env.py \
    tests/cli/test_cli_agentkit_harness_invoke.py

  Result:

  59 passed

  Pre-commit:

  ruff check: passed
  ruff format: passed
  Detect hardcoded secrets: passed

  Cloud runtime validation was also completed on a HarnessApp Runtime. The enhanced path correctly loaded the Harness plugins and produced compaction
  reports.