### PR TITLE
feat(skills): support skillhub spaces and skills

### DIFF
--- a/veadk/skills/skill.py
+++ b/veadk/skills/skill.py
@@ -24,6 +24,9 @@ class Skill(BaseModel):
     bucket_name: Optional[str] = None
     checklist: List[Dict[str, str]] = []
     id: Optional[str] = None
+    slug: Optional[str] = None
+    source_type: Optional[str] = None
+    version_id: Optional[str] = None
 
     def get_checklist_items(self) -> List[str]:
         return [item.get("item", item.get("id", "")) for item in self.checklist]

--- a/veadk/skills/utils.py
+++ b/veadk/skills/utils.py
@@ -16,13 +16,14 @@ import json
 from pathlib import Path
 import os
 import frontmatter
+from typing import Literal
 
 from google.adk.tools import BaseTool, ToolContext
 from typing import Any, Dict, Optional, Callable
 
 from veadk.skills.skill import Skill
 from veadk.utils.logger import get_logger
-from veadk.utils.volcengine_sign import ve_request
+from veadk.utils.volcengine_sign import ve_request, volcengine_signed_request
 
 logger = get_logger(__name__)
 
@@ -134,93 +135,333 @@ def load_skills_from_directory(skills_directory: Path) -> list[Skill]:
 
 
 def load_skills_from_cloud(skill_space_ids: str) -> list[Skill]:
-    skill_space_ids_list = [x.strip() for x in skill_space_ids.split(",")]
-    logger.info(f"Load skills from skill spaces: {skill_space_ids_list}")
-
-    from veadk.auth.veauth.utils import get_credential_from_vefaas_iam
+    skill_space_ids_list = [x.strip() for x in skill_space_ids.split(",") if x.strip()]
+    logger.info(f"Load skills from cloud skill sources: {skill_space_ids_list}")
 
     skills = []
 
     for skill_space_id in skill_space_ids_list:
-        try:
-            service = os.getenv("AGENTKIT_TOOL_SERVICE_CODE", "agentkit")
+        # SkillHub space ids use the `sp-` prefix; all other ids keep the
+        # legacy AgentKit skill-space behavior for backward compatibility.
+        if skill_space_id.startswith("sp-"):
+            skills.extend(_load_skills_from_skillhub_space_id(skill_space_id))
+        else:
+            skills.extend(_load_skills_from_space_id(skill_space_id))
 
-            provider = (os.getenv("CLOUD_PROVIDER") or "").lower()
-            if provider == "byteplus":
-                sld = "byteplusapi"
-                default_region = "ap-southeast-1"
-            else:
-                sld = "volcengineapi"
-                default_region = "cn-beijing"
+    return skills
 
-            region = os.getenv("AGENTKIT_TOOL_REGION", default_region)
-            host = os.getenv(
-                "AGENTKIT_SKILL_HOST", service + "." + region + f".{sld}.com"
+
+def _get_cloud_credentials() -> tuple[str, str, str]:
+    from veadk.auth.veauth.utils import get_credential_from_vefaas_iam
+
+    access_key = os.getenv("VOLCENGINE_ACCESS_KEY")
+    secret_key = os.getenv("VOLCENGINE_SECRET_KEY")
+    session_token = os.getenv("VOLCENGINE_SESSION_TOKEN", "")
+
+    if not (access_key and secret_key):
+        cred = get_credential_from_vefaas_iam()
+        access_key = cred.access_key_id
+        secret_key = cred.secret_access_key
+        session_token = cred.session_token
+
+    return access_key, secret_key, session_token
+
+
+def _get_agentkit_endpoint() -> tuple[str, str, str]:
+    service = os.getenv("AGENTKIT_TOOL_SERVICE_CODE", "agentkit")
+
+    provider = (os.getenv("CLOUD_PROVIDER") or "").lower()
+    if provider == "byteplus":
+        sld = "byteplusapi"
+        default_region = "ap-southeast-1"
+    else:
+        sld = "volcengineapi"
+        default_region = "cn-beijing"
+
+    region = os.getenv("AGENTKIT_TOOL_REGION", default_region)
+    host = os.getenv("AGENTKIT_SKILL_HOST", service + "." + region + f".{sld}.com")
+    return service, region, host
+
+
+def _get_skillhub_endpoint() -> tuple[str, str, str]:
+    service = os.getenv("SKILLHUB_SERVICE_NAME", "skillhub")
+    region = os.getenv("SKILLHUB_REGION", "cn-guilin-boe")
+    host = os.getenv("SKILLHUB_HOST", "skills.volces.com")
+    return service, region, host
+
+
+def _extract_items(response: Any) -> list[Any]:
+    if isinstance(response, str):
+        response = json.loads(response)
+
+    if not isinstance(response, dict):
+        return []
+
+    result = response.get("Result")
+    if isinstance(result, dict):
+        items = result.get("Items", [])
+    else:
+        items = response.get("Items", [])
+
+    return items if isinstance(items, list) else []
+
+
+def _build_skill_from_space_item(
+    item: dict[str, Any], skill_space_id: str
+) -> Optional[Skill]:
+    skill_name = item.get("Name")
+    if not skill_name:
+        return None
+
+    return Skill(
+        name=skill_name,
+        description=item.get("Description") or "",
+        path=item.get("TosPath") or "",
+        skill_space_id=skill_space_id,
+        bucket_name=item.get("BucketName"),
+        id=item.get("SkillId"),
+    )
+
+
+def _build_skill_from_skillhub_item(
+    item: dict[str, Any], skill_space_id: str
+) -> Optional[Skill]:
+    skill_name = item.get("Name")
+    skill_id = item.get("Id") or item.get("SkillId")
+    if not skill_name or not skill_id:
+        return None
+
+    metadata = item.get("Metadata") if isinstance(item.get("Metadata"), dict) else {}
+    related_version = (
+        item.get("RelatedSkillVersion")
+        if isinstance(item.get("RelatedSkillVersion"), dict)
+        else {}
+    )
+    latest_version = (
+        item.get("LatestVersionStatus")
+        if isinstance(item.get("LatestVersionStatus"), dict)
+        else {}
+    )
+    version_id = related_version.get("Id") or latest_version.get("VersionId")
+    slug = item.get("Slug")
+
+    return Skill(
+        name=skill_name,
+        description=metadata.get("DisplayDescription") or item.get("Description", ""),
+        path=slug or skill_id,
+        skill_space_id=skill_space_id,
+        id=skill_id,
+        slug=slug,
+        source_type="skillhub",
+        version_id=version_id,
+    )
+
+
+def _load_skills_from_space_id(skill_space_id: str) -> list[Skill]:
+    logger.info(f"Load skills from skill space: {skill_space_id}")
+
+    skills = []
+
+    try:
+        service, region, host = _get_agentkit_endpoint()
+        access_key, secret_key, session_token = _get_cloud_credentials()
+
+        request_body = {
+            "SkillSpaceId": skill_space_id,
+            "InnerTags": {"source": "sandbox"},
+        }
+        logger.debug(f"ListSkillsBySpaceId request body: {request_body}")
+        scheme = os.getenv("AGENTKIT_TOP_SCHEME", "https").lower()
+
+        response = ve_request(
+            request_body=request_body,
+            action="ListSkillsBySpaceId",
+            ak=access_key,
+            sk=secret_key,
+            service=service,
+            version="2025-10-30",
+            region=region,
+            host=host,
+            header={"X-Security-Token": session_token},
+            scheme=scheme,  # type: ignore[arg-type]
+        )
+
+        items = _extract_items(response)
+        if not items:
+            logger.warning(
+                f"No skills returned from skill space={skill_space_id}. "
+                f"Response may be empty or the space has no skills."
             )
 
-            access_key = os.getenv("VOLCENGINE_ACCESS_KEY")
-            secret_key = os.getenv("VOLCENGINE_SECRET_KEY")
-            session_token = ""
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            skill = _build_skill_from_space_item(item, skill_space_id)
+            if skill is None:
+                continue
 
-            if not (access_key and secret_key):
-                # Try to get from vefaas iam
-                cred = get_credential_from_vefaas_iam()
-                access_key = cred.access_key_id
-                secret_key = cred.secret_access_key
-                session_token = cred.session_token
+            skills.append(skill)
 
+            logger.info(
+                f"Successfully loaded skill {skill.name} from skill space={skill_space_id}, name={skill.name}, description={skill.description}"
+            )
+    except Exception as e:
+        logger.error(
+            f"Failed to load skills from skill space={skill_space_id}: {e}"
+        )
+
+    return skills
+
+
+def _skillhub_request(
+    path: str,
+    request_body: dict[str, Any],
+    response_type: Literal["json", "content"] = "json",
+):
+    access_key, secret_key, session_token = _get_cloud_credentials()
+    service, region, host = _get_skillhub_endpoint()
+    scheme = os.getenv("SKILLHUB_TOP_SCHEME", "https").lower()
+    header = {"X-Security-Token": session_token}
+
+    return volcengine_signed_request(
+        request_body=request_body,
+        ak=access_key,
+        sk=secret_key,
+        service=service,
+        region=region,
+        host=host,
+        path=path,
+        header=header,
+        scheme=scheme,  # type: ignore[arg-type]
+        # SkillHub follows the ve-skills-js-sdk signing flow: the request body is
+        # sent normally, but the signed payload hash is the literal
+        # "UNSIGNED-PAYLOAD".
+        unsigned_payload=True,
+        response_type=response_type,
+    )
+
+
+def _get_skillhub_page_size(default: int = 100) -> int:
+    raw = os.getenv("SKILLHUB_LIST_SKILLS_PAGE_SIZE")
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            f"Invalid SKILLHUB_LIST_SKILLS_PAGE_SIZE={raw!r}, fallback to {default}."
+        )
+        return default
+    if value <= 0:
+        logger.warning(
+            f"Non-positive SKILLHUB_LIST_SKILLS_PAGE_SIZE={value}, fallback to {default}."
+        )
+        return default
+    return value
+
+
+def _load_skills_from_skillhub_space_id(skill_space_id: str) -> list[Skill]:
+    logger.info(f"Load skills from SkillHub skill space: {skill_space_id}")
+
+    skills = []
+
+    try:
+        page_number = 1
+        page_size = _get_skillhub_page_size()
+        total_count: Optional[int] = None
+
+        # ListSkills is paginated. Keep fetching until the server-reported
+        # TotalCount is satisfied, or until a page returns no Items.
+        while total_count is None or len(skills) < total_count:
             request_body = {
-                "SkillSpaceId": skill_space_id,
-                "InnerTags": {"source": "sandbox"},
+                "PageNumber": page_number,
+                "PageSize": page_size,
+                "Filter": {"SkillSpaceId": skill_space_id},
             }
-            logger.debug(f"ListSkillsBySpaceId request body: {request_body}")
-            scheme = os.getenv("AGENTKIT_TOP_SCHEME", "https").lower()
-
-            response = ve_request(
-                request_body=request_body,
-                action="ListSkillsBySpaceId",
-                ak=access_key,
-                sk=secret_key,
-                service=service,
-                version="2025-10-30",
-                region=region,
-                host=host,
-                header={"X-Security-Token": session_token},
-                scheme=scheme,
-            )
+            logger.debug(f"SkillHub ListSkills request body: {request_body}")
+            response = _skillhub_request("/ListSkills", request_body)
 
             if isinstance(response, str):
                 response = json.loads(response)
+            if not isinstance(response, dict):
+                logger.warning(
+                    f"Unexpected SkillHub ListSkills response for skill space={skill_space_id}: {response}"
+                )
+                break
 
-            list_skills_result = response.get("Result")
-            items = list_skills_result.get("Items")
+            if total_count is None:
+                raw_total_count = response.get("TotalCount")
+                if raw_total_count is None and isinstance(response.get("Result"), dict):
+                    raw_total_count = response["Result"].get("TotalCount")
+                if raw_total_count is not None:
+                    try:
+                        total_count = int(raw_total_count)
+                    except (TypeError, ValueError):
+                        logger.warning(
+                            f"Invalid SkillHub TotalCount={raw_total_count!r} for skill space={skill_space_id}."
+                        )
+                        total_count = None
 
+            items = _extract_items(response)
+            if not items:
+                if page_number == 1:
+                    logger.warning(
+                        f"No skills returned from SkillHub skill space={skill_space_id}. "
+                        f"Response may be empty or the space has no skills."
+                    )
+                break
+
+            loaded_count_before_page = len(skills)
             for item in items:
                 if not isinstance(item, dict):
                     continue
-                skill_name = item.get("Name")
-                skill_description = item.get("Description")
-                tos_bucket = item.get("BucketName")
-                tos_path = item.get("TosPath")
-                skill_id = item.get("SkillId")
-                if not skill_name:
+                skill = _build_skill_from_skillhub_item(item, skill_space_id)
+                if skill is None:
                     continue
 
-                skill = Skill(
-                    name=skill_name,  # type: ignore
-                    description=skill_description,  # type: ignore
-                    path=tos_path,
-                    skill_space_id=skill_space_id,
-                    bucket_name=tos_bucket,
-                    id=skill_id,
-                )
-
                 skills.append(skill)
-
                 logger.info(
-                    f"Successfully loaded skill {skill_name} from skill space={skill_space_id}, name={skill_name}, description={skill_description}"
+                    f"Successfully loaded SkillHub skill {skill.name} from skill space={skill_space_id}, id={skill.id}, slug={skill.slug}"
                 )
-        except Exception as e:
-            logger.error(f"Failed to load skill from skill space: {e}")
+
+            if len(skills) == loaded_count_before_page:
+                logger.warning(
+                    f"SkillHub page {page_number} for skill space={skill_space_id} contained no valid skills."
+                )
+
+            page_number += 1
+    except Exception as e:
+        logger.error(f"Failed to load skills from SkillHub skill space: {e}")
 
     return skills
+
+
+def download_skillhub_skill(skill: Skill, save_path: Path) -> bool:
+    if not skill.id:
+        logger.error(f"SkillHub skill '{skill.name}' has no skill id.")
+        return False
+
+    request_body: dict[str, Any] = {
+        "SkillId": skill.id,
+        "IsPreview": True,
+    }
+    if skill.version_id:
+        request_body["SkillVersionId"] = skill.version_id
+
+    try:
+        content = _skillhub_request(
+            "/DownloadSkill",
+            request_body,
+            response_type="content",
+        )
+        if not isinstance(content, (bytes, bytearray)) or not content:
+            logger.error(f"DownloadSkill returned empty content for '{skill.name}'.")
+            return False
+
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(save_path, "wb") as f:
+            f.write(content)
+        return True
+    except Exception as e:
+        logger.error(f"Failed to download SkillHub skill '{skill.name}': {e}")
+        return False

--- a/veadk/skills/utils.py
+++ b/veadk/skills/utils.py
@@ -306,9 +306,7 @@ def _load_skills_from_space_id(skill_space_id: str) -> list[Skill]:
                 f"Successfully loaded skill {skill.name} from skill space={skill_space_id}, name={skill.name}, description={skill.description}"
             )
     except Exception as e:
-        logger.error(
-            f"Failed to load skills from skill space={skill_space_id}: {e}"
-        )
+        logger.error(f"Failed to load skills from skill space={skill_space_id}: {e}")
 
     return skills
 

--- a/veadk/tools/skills_tools/skills_tool.py
+++ b/veadk/tools/skills_tools/skills_tool.py
@@ -265,9 +265,7 @@ class SkillsTool(BaseTool):
 
                     if not success:
                         source_desc = (
-                            "SkillHub"
-                            if skill.source_type == "skillhub"
-                            else "TOS"
+                            "SkillHub" if skill.source_type == "skillhub" else "TOS"
                         )
                         return f"Error: Failed to download skill '{skill_name}' from {source_desc}."
 
@@ -394,9 +392,7 @@ class SkillsTool(BaseTool):
             for member in z.namelist():
                 target = (dest_root / member).resolve()
                 if target != dest_root and dest_root not in target.parents:
-                    raise ValueError(
-                        f"Unsafe path detected in zip archive: '{member}'"
-                    )
+                    raise ValueError(f"Unsafe path detected in zip archive: '{member}'")
             z.extractall(path=str(dest_root))
 
     def _download_skill_via_vestack(

--- a/veadk/tools/skills_tools/skills_tool.py
+++ b/veadk/tools/skills_tools/skills_tool.py
@@ -129,19 +129,10 @@ class SkillsTool(BaseTool):
                 )
 
                 try:
-                    from veadk.auth.veauth.utils import get_credential_from_vefaas_iam
                     from veadk.integrations.ve_tos.ve_tos import VeTOS
+                    from veadk.skills.utils import _get_cloud_credentials
 
-                    access_key = os.getenv("VOLCENGINE_ACCESS_KEY")
-                    secret_key = os.getenv("VOLCENGINE_SECRET_KEY")
-                    session_token = ""
-
-                    if not (access_key and secret_key):
-                        # Try to get from vefaas iam
-                        cred = get_credential_from_vefaas_iam()
-                        access_key = cred.access_key_id
-                        secret_key = cred.secret_access_key
-                        session_token = cred.session_token
+                    access_key, secret_key, session_token = _get_cloud_credentials()
 
                     tos_skills_dir = os.getenv(
                         "TOS_SKILLS_DIR"
@@ -230,56 +221,55 @@ class SkillsTool(BaseTool):
                     f"Attempting to download skill '{skill_name}' from skill space..."
                 )
                 try:
-                    from veadk.auth.veauth.utils import get_credential_from_vefaas_iam
-                    from veadk.integrations.ve_tos.ve_tos import VeTOS
-
-                    access_key = os.getenv("VOLCENGINE_ACCESS_KEY")
-                    secret_key = os.getenv("VOLCENGINE_SECRET_KEY")
-                    session_token = ""
-
-                    if not (access_key and secret_key):
-                        # Try to get from vefaas iam
-                        cred = get_credential_from_vefaas_iam()
-                        access_key = cred.access_key_id
-                        secret_key = cred.secret_access_key
-                        session_token = cred.session_token
-
-                    tos_bucket, tos_path = skill.bucket_name, skill.path
-
                     save_path = skill_dir / f"{skill_name}.zip"
 
-                    cloud_provider = (os.getenv("CLOUD_PROVIDER") or "").lower()
-                    if cloud_provider == "vestack":
-                        success = self._download_skill_via_vestack(
-                            skill=skill,
-                            tos_path=tos_path,
-                            cloud_provider=cloud_provider,
-                            access_key=access_key,
-                            secret_key=secret_key,
-                            session_token=session_token,
-                            skill_name=skill_name,
-                            save_path=save_path,
-                        )
-                    else:
-                        # Initialize VeTOS client
-                        tos_client = VeTOS(
-                            ak=access_key,
-                            sk=secret_key,
-                            session_token=session_token,
-                            bucket_name=tos_bucket,
-                            region=region,
-                        )
+                    if skill.source_type == "skillhub":
+                        from veadk.skills.utils import download_skillhub_skill
 
-                        success = tos_client.download(
-                            bucket_name=tos_bucket,
-                            object_key=tos_path,
-                            save_path=save_path,
-                        )
+                        success = download_skillhub_skill(skill, save_path)
+                    else:
+                        from veadk.integrations.ve_tos.ve_tos import VeTOS
+                        from veadk.skills.utils import _get_cloud_credentials
+
+                        access_key, secret_key, session_token = _get_cloud_credentials()
+
+                        tos_bucket, tos_path = skill.bucket_name, skill.path
+
+                        cloud_provider = (os.getenv("CLOUD_PROVIDER") or "").lower()
+                        if cloud_provider == "vestack":
+                            success = self._download_skill_via_vestack(
+                                skill=skill,
+                                tos_path=tos_path,
+                                cloud_provider=cloud_provider,
+                                access_key=access_key,
+                                secret_key=secret_key,
+                                session_token=session_token,
+                                skill_name=skill_name,
+                                save_path=save_path,
+                            )
+                        else:
+                            # Initialize VeTOS client
+                            tos_client = VeTOS(
+                                ak=access_key,
+                                sk=secret_key,
+                                session_token=session_token,
+                                bucket_name=tos_bucket,
+                                region=region,
+                            )
+
+                            success = tos_client.download(
+                                bucket_name=tos_bucket,
+                                object_key=tos_path,
+                                save_path=save_path,
+                            )
 
                     if not success:
-                        return (
-                            f"Error: Failed to download skill '{skill_name}' from TOS."
+                        source_desc = (
+                            "SkillHub"
+                            if skill.source_type == "skillhub"
+                            else "TOS"
                         )
+                        return f"Error: Failed to download skill '{skill_name}' from {source_desc}."
 
                     # Extract downloaded zip into the skill directory
                     import zipfile
@@ -299,8 +289,18 @@ class SkillsTool(BaseTool):
                             )
 
                     try:
-                        with zipfile.ZipFile(save_path, "r") as z:
-                            z.extractall(path=str(skill_dir))
+                        if skill.source_type == "skillhub":
+                            # SkillHub zips may contain files at archive root.
+                            # Extract them into the skill-specific directory so
+                            # they do not spill into the shared session skills dir.
+                            target_skill_dir.mkdir(parents=True, exist_ok=True)
+                            extract_dir = target_skill_dir
+                        else:
+                            # Legacy skill-space zips already include their
+                            # top-level skill directory; keep the previous
+                            # extraction location to avoid changing behavior.
+                            extract_dir = skill_dir
+                        self._safe_extract_zip(save_path, extract_dir)
                     except zipfile.BadZipFile:
                         logger.error(
                             f"Downloaded file for '{skill_name}' is not a valid zip"
@@ -344,7 +344,7 @@ class SkillsTool(BaseTool):
                             f"Failed to create skills symlink for {str(skills_mount)}: {e}"
                         )
 
-        skill_file = skill_dir / skill_name / "SKILL.md"
+        skill_file = self._find_skill_file(skill_dir, skill_name)
         if not skill_file.exists():
             return f"Error: Skill '{skill_name}' has no SKILL.md file."
 
@@ -362,6 +362,42 @@ class SkillsTool(BaseTool):
         except Exception as e:
             logger.error(f"Failed to invoke skill {skill_name}: {e}")
             return f"Error invoking skill '{skill_name}': {e}"
+
+    def _find_skill_file(self, skill_dir: Path, skill_name: str) -> Path:
+        skill_root = skill_dir / skill_name
+        skill_file = skill_root / "SKILL.md"
+        if skill_file.exists():
+            return skill_file
+
+        if skill_root.exists():
+            # Pick the shallowest SKILL.md to avoid matching nested examples,
+            # and sort for deterministic results.
+            nested_skill_files = sorted(
+                skill_root.rglob("SKILL.md"),
+                key=lambda p: (len(p.relative_to(skill_root).parts), str(p)),
+            )
+            if nested_skill_files:
+                return nested_skill_files[0]
+
+        return skill_file
+
+    def _safe_extract_zip(self, zip_path: Path, dest_dir: Path) -> None:
+        """Extract a zip archive while guarding against path traversal.
+
+        Rejects any member whose resolved path would escape ``dest_dir``
+        (e.g. absolute paths or paths containing ``..``).
+        """
+        import zipfile
+
+        dest_root = Path(dest_dir).resolve()
+        with zipfile.ZipFile(zip_path, "r") as z:
+            for member in z.namelist():
+                target = (dest_root / member).resolve()
+                if target != dest_root and dest_root not in target.parents:
+                    raise ValueError(
+                        f"Unsafe path detected in zip archive: '{member}'"
+                    )
+            z.extractall(path=str(dest_root))
 
     def _download_skill_via_vestack(
         self,

--- a/veadk/utils/volcengine_sign.py
+++ b/veadk/utils/volcengine_sign.py
@@ -15,6 +15,7 @@
 import datetime
 import hashlib
 import hmac
+import json
 from typing import Literal
 from urllib.parse import quote
 
@@ -57,6 +58,161 @@ def hmac_sha256(key: bytes, content: str):
 # sha256 hash算法
 def hash_sha256(content: str):
     return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _normalize_request_body(request_body):
+    if request_body is None:
+        return ""
+    if isinstance(request_body, (bytes, bytearray)):
+        return bytes(request_body)
+    if isinstance(request_body, str):
+        return request_body
+    return json.dumps(request_body)
+
+
+def _uri_escape(value: str) -> str:
+    return quote(str(value), safe="-_.~")
+
+
+def _normalize_path(path: str) -> str:
+    if not path:
+        return "/"
+    if not path.startswith("/"):
+        path = f"/{path}"
+    return "/".join(_uri_escape(part) for part in path.split("/")) or "/"
+
+
+def _normalize_query(query: dict) -> str:
+    query_parts = []
+    for key in sorted(query.keys()):
+        value = query[key]
+        values = value if isinstance(value, list) else [value]
+        for item in sorted(str(v) for v in values):
+            query_parts.append(f"{_uri_escape(key)}={_uri_escape(item)}")
+    return "&".join(query_parts)
+
+
+def volcengine_signed_request(
+    request_body,
+    ak: str,
+    sk: str,
+    service: str,
+    region: str,
+    host: str,
+    path: str,
+    content_type: str = "application/json",
+    header: dict | None = None,
+    query: dict | None = None,
+    method: Literal["GET", "POST", "PUT", "DELETE"] = "POST",
+    scheme: Literal["http", "https"] = "https",
+    unsigned_payload: bool = False,
+    response_type: Literal["json", "content", "response"] = "json",
+):
+    """Send a Volcengine SigV4 request to a concrete path.
+
+    This covers APIs that are not exposed through the Action/Version query style
+    used by :func:`ve_request`, such as SkillHub's ``/ListSkills`` and
+    ``/DownloadSkill`` endpoints.
+    """
+
+    header = dict(header or {})
+    query = dict(query or {})
+    body = _normalize_request_body(request_body)
+    # Some services, including SkillHub, sign the literal UNSIGNED-PAYLOAD while
+    # still sending the JSON body in the request.
+    body_for_hash = "UNSIGNED-PAYLOAD" if unsigned_payload else body
+    if isinstance(body_for_hash, bytes):
+        payload_hash = hashlib.sha256(body_for_hash).hexdigest()
+    else:
+        payload_hash = hash_sha256(body_for_hash)
+
+    now = datetime.datetime.utcnow()
+    x_date = now.strftime("%Y%m%dT%H%M%SZ")
+    short_x_date = x_date[:8]
+
+    request_host = host
+    header.update(
+        {
+            "Host": request_host,
+            "X-Date": x_date,
+            "X-Content-Sha256": payload_hash,
+            "Content-Type": content_type,
+        }
+    )
+
+    if header.get("X-Security-Token") == "":
+        del header["X-Security-Token"]
+
+    unsignable_headers = {
+        "authorization",
+        "content-type",
+        "content-length",
+        "user-agent",
+        "presigned-expires",
+        "expect",
+        "x-content-sha256",
+    }
+    headers_to_sign = {}
+    for key, value in header.items():
+        lowered_key = key.lower()
+        if lowered_key not in unsignable_headers:
+            headers_to_sign[lowered_key] = " ".join(str(value).split())
+
+    signed_header_keys = sorted(headers_to_sign.keys())
+    canonical_headers = "\n".join(
+        f"{key}:{headers_to_sign[key]}" for key in signed_header_keys
+    )
+    signed_headers_str = ";".join(signed_header_keys)
+    canonical_request_str = "\n".join(
+        [
+            method.upper(),
+            _normalize_path(path),
+            _normalize_query(query),
+            canonical_headers + "\n",
+            signed_headers_str,
+            payload_hash,
+        ]
+    )
+
+    credential_scope = "/".join([short_x_date, region, service, "request"])
+    string_to_sign = "\n".join(
+        [
+            "HMAC-SHA256",
+            x_date,
+            credential_scope,
+            hash_sha256(canonical_request_str),
+        ]
+    )
+
+    k_date = hmac_sha256(sk.encode("utf-8"), short_x_date)
+    k_region = hmac_sha256(k_date, region)
+    k_service = hmac_sha256(k_region, service)
+    k_signing = hmac_sha256(k_service, "request")
+    signature = hmac_sha256(k_signing, string_to_sign).hex()
+    header["Authorization"] = (
+        "HMAC-SHA256 Credential={}, SignedHeaders={}, Signature={}".format(
+            ak + "/" + credential_scope,
+            signed_headers_str,
+            signature,
+        )
+    )
+
+    response = requests.request(
+        method=method,
+        url=f"{scheme}://{request_host}{_normalize_path(path)}",
+        headers=header,
+        params=query,
+        data=body,
+    )
+    response.raise_for_status()
+    if response_type == "content":
+        return response.content
+    if response_type == "response":
+        return response
+    try:
+        return response.json()
+    except Exception:
+        raise ValueError(f"Error occurred. Bad response: {response}")
 
 
 # 第二步：签名请求函数


### PR DESCRIPTION
Add SkillHub space support (`sp-` prefixed IDs) alongside the existing AgentKit skill-space flow.

- **SkillHub integration**: Route `sp-*` space IDs to SkillHub `/ListSkills` and `/DownloadSkill` APIs with paginated listing.
- **`volcengine_signed_request()`**: Generic SigV4 signing function supporting custom paths, `UNSIGNED-PAYLOAD`, and multiple response types.
- **Credential consolidation**: Extracted `_get_cloud_credentials()` to eliminate duplicated AK/SK retrieval logic.
- **Safe zip extraction**: `_safe_extract_zip()` guards against path traversal attacks.
- **Skill model**: Added `slug`, `source_type`, `version_id` fields for SkillHub metadata.