### PR TITLE
docs(framework): align zh quickstart card wording with en

### DIFF
--- a/docs/content/docs/framework/index.mdx
+++ b/docs/content/docs/framework/index.mdx
@@ -13,7 +13,7 @@ print(asyncio.run(Runner(agent=agent).run("你好，介绍下你自己")))
 ```
 
 <Cards>
-  <Card title="快速开始" href="/cn/docs/framework/quickstart" description="几分钟运行你的第一个智能体。" />
+  <Card title="快速开始" href="/cn/docs/framework/quickstart" description="几分钟构建并运行你的第一个智能体。" />
   <Card title="构建智能体" href="/cn/docs/framework/agent" description="配置模型、工具、记忆与知识库。" />
   <Card title="部署到 VeFaaS" href="/cn/docs/framework/vefaas" description="一键将智能体部署上云。" />
 </Cards>


### PR DESCRIPTION
The Chinese "快速开始" card on the framework overview said only "运行"(run), while the English card says "Build and run your first agent in minutes." This aligns the zh wording to "构建并运行你的第一个智能体。".

One-line wording fix, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)