### PR TITLE
fix: add DevServer.get_runner_async hook for memory service support

### DIFF
--- a/veadk/cli/cli_web.py
+++ b/veadk/cli/cli_web.py
@@ -198,6 +198,12 @@ def web(
         adk_web_server.AdkWebServer.get_runner_async
     )
 
+    from google.adk.cli.dev_server import DevServer
+
+    DevServer.get_runner_async = before_get_runner_async(
+        DevServer.get_runner_async
+    )
+
     patch_adkwebserver_disable_openapi()
 
     from google.adk.cli.cli_tools_click import cli_web


### PR DESCRIPTION
## Problem

`veadk web` uses `DevServer` (google-adk 2.x), but the memory-service hook only patches `AdkWebServer.get_runner_async`. Since `DevServer` is not a subclass of `AdkWebServer`, the hook never runs, `long_term_memory` is never injected into the Runner, and `LoadMemoryTool` always returns empty results.

### Class hierarchy in google-adk 2.x

```
ApiServer              <- defines get_runner_async
  ^
DevServer              <- what veadk web actually creates (fast_api.py:558)
  ^
AdkWebServer           <- DEPRECATED, but this is the only class veadk hooks
```

## Root Cause

google-adk 2.0.0 refactored the Server class hierarchy and deprecated `AdkWebServer`. veadk 1.0.0 still hooks only `AdkWebServer`, so the monkey-patch is ineffective when `DevServer` is used.

veadk dependency declaration (google-adk with no version constraint) allows google-adk 2.x to be installed, exposing this incompatibility.

## Fix

Also hook `DevServer.get_runner_async` alongside the existing `AdkWebServer` hook. This ensures the memory service is injected regardless of which Server class is instantiated.

## Testing

- Verified that veadk web now correctly injects LongTermMemory into the Runner
- LoadMemoryTool returns expected results from long-term memory

## Notes

Longer-term fixes to consider:
1. Pin google-adk>=1,<2 in dependencies (breaking change for users on 2.x)
2. Fully adapt to google-adk 2.x API changes and drop the deprecated AdkWebServer hook