### PR TITLE
fix: add request timeouts, restore TLS verify, and stop logging secrets

### DIFF
--- a/veadk/auth/ve_credential_service.py
+++ b/veadk/auth/ve_credential_service.py
@@ -197,7 +197,7 @@ class VeCredentialService(BaseCredentialService):
                 credential_key="bearer_token"
             )
             if credential:
-                print(f"Found token: {credential.bearer_token}")
+                print("Credential found")
             ```
         """
         return self._credentials.get(app_name, {}).get(user_id, {}).get(credential_key)

--- a/veadk/tools/builtin_tools/llm_shield.py
+++ b/veadk/tools/builtin_tools/llm_shield.py
@@ -118,7 +118,7 @@ class LLMShieldPlugin(BasePlugin):
         version = "2025-08-31"
 
         # Check if using API key authentication
-        logger.debug(f"API key value: {self.api_key}, type: {type(self.api_key)}")
+        logger.debug(f"API key configured: {bool(self.api_key)}")
         if self.api_key and self.api_key != "":
             logger.debug("Using API key authentication (no AK/SK signature)")
             # Use API key authentication only - match curl command headers exactly

--- a/veadk/tools/builtin_tools/vesearch.py
+++ b/veadk/tools/builtin_tools/vesearch.py
@@ -41,7 +41,7 @@ def vesearch(query: str) -> str:
         "messages": [{"role": "user", "content": query}],
     }
 
-    response = requests.post(URL, json=data, headers=headers)
+    response = requests.post(URL, json=data, headers=headers, timeout=30)
     if response.status_code == 200:
         result = response.json()
         return result["choices"][0]["message"]["content"]

--- a/veadk/tools/builtin_tools/web_scraper.py
+++ b/veadk/tools/builtin_tools/web_scraper.py
@@ -52,7 +52,7 @@ def web_scraper(query: str) -> dict[str, Any]:
                 {"key": "filter", "value": 1},
             ],
         }
-        response = requests.post(url, headers=headers, json=data, verify=False)
+        response = requests.post(url, headers=headers, json=data, timeout=30)
 
         response.raise_for_status()
 

--- a/veadk/utils/volcengine_sign.py
+++ b/veadk/utils/volcengine_sign.py
@@ -21,6 +21,11 @@ from urllib.parse import quote
 
 import requests
 
+# Bounded default (connect, read) timeout in seconds for Volcengine API calls, so a
+# hung endpoint cannot block the caller forever. Callers with slow control-plane
+# operations (deploys, large uploads) can override via the ``timeout`` parameter.
+DEFAULT_REQUEST_TIMEOUT: tuple[float, float] = (10, 60)
+
 Service = ""
 Version = ""
 Region = ""
@@ -107,6 +112,7 @@ def volcengine_signed_request(
     scheme: Literal["http", "https"] = "https",
     unsigned_payload: bool = False,
     response_type: Literal["json", "content", "response"] = "json",
+    timeout: float | tuple[float, float] | None = DEFAULT_REQUEST_TIMEOUT,
 ):
     """Send a Volcengine SigV4 request to a concrete path.
 
@@ -203,6 +209,7 @@ def volcengine_signed_request(
         headers=header,
         params=query,
         data=body,
+        timeout=timeout,
     )
     response.raise_for_status()
     if response_type == "content":
@@ -226,6 +233,7 @@ def request(
     action,
     body,
     scheme: Literal["http", "https"] = "https",
+    timeout: float | tuple[float, float] | None = DEFAULT_REQUEST_TIMEOUT,
 ):
     # 第三步：创建身份证明。其中的 Service 和 Region 字段是固定的。ak 和 sk 分别代表
     # AccessKeyID 和 SecretAccessKey。同时需要初始化签名结构体。一些签名计算时需要的属性也在这里处理。
@@ -322,6 +330,7 @@ def request(
         headers=header,
         params=request_param["query"],
         data=request_param["body"],
+        timeout=timeout,
     )
     try:
         return r.json()


### PR DESCRIPTION
## What

Defensive-default hardening surfaced by a reliability/security/observability review. Five small, self-contained changes across two themes.

### Reliability — bound outbound calls
- **`veadk/utils/volcengine_sign.py`**: both signed-request helpers (`volcengine_signed_request` and `request`) previously called `requests.request(...)` with **no timeout**, so a hung Volcengine endpoint could block the caller indefinitely. Added an overridable `timeout` parameter defaulting to `(10, 60)` (10s connect / 60s read). This single change bounds the **~82 OpenAPI call sites** that route through these two helpers; slow control-plane calls (deploy/upload) can pass a larger value.
- **`veadk/tools/builtin_tools/web_scraper.py`** and **`vesearch.py`**: added a 30s timeout to their direct `requests.post` calls (these are on the agent's tool path).

### Security / log hygiene
- **`web_scraper.py`**: dropped `verify=False` (restored TLS certificate verification) on a request that carries `X-VE-API-Key`.
- **`llm_shield.py`**: stopped logging the full API key at `debug` level — now logs only whether it is configured. (Default log level is DEBUG, so the key was being emitted in normal runs.)
- **`ve_credential_service.py`**: fixed a docstring example that printed a bearer token.

## Reviewer note ⚠️
The `verify=False` removal in `web_scraper` is a behavior change: if `TOOL_WEB_SCRAPER_ENDPOINT` serves a **self-signed / private-CA certificate**, requests will now fail TLS verification. If that endpoint is not publicly trusted, the correct fix is `verify=<ca_bundle_path>` rather than re-disabling verification. Please confirm the endpoint uses a publicly-trusted cert before merging.

## Scope
These are the low-risk, no-design-needed items from the review. Not included here (need design/product decisions): unverified-JWT auth path, A2A hub authz, `trace_content` default, and the pre-existing type issues in `web_scraper` (unbound `response` in `except`, return-type mismatch). CI will validate; changes byte-compile clean.
