### PR TITLE
feat(model): resolve model API key by name

### DIFF
--- a/tests/agent/test_model_api_key_resolution.py
+++ b/tests/agent/test_model_api_key_resolution.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+from veadk import Agent
+
+
+def test_explicit_key_beats_name(monkeypatch):
+    """A key value passed explicitly wins over a key name (no lookup happens)."""
+    monkeypatch.delenv("MODEL_AGENT_API_KEY", raising=False)
+    with patch("veadk.auth.veauth.ark_veauth.get_ark_token") as g:
+        agent = Agent(
+            name="a", model_api_key="sk-EXPLICIT", model_api_key_name="some-name"
+        )
+        assert agent.model_api_key == "sk-EXPLICIT"
+        g.assert_not_called()
+
+
+def test_env_key_beats_name(monkeypatch):
+    """MODEL_AGENT_API_KEY wins over a key name (no lookup happens)."""
+    monkeypatch.setenv("MODEL_AGENT_API_KEY", "sk-ENV")
+    with patch("veadk.auth.veauth.ark_veauth.get_ark_token") as g:
+        agent = Agent(name="b", model_api_key_name="some-name")
+        assert agent.model_api_key == "sk-ENV"
+        g.assert_not_called()
+
+
+def test_name_resolves_when_no_key(monkeypatch):
+    """With no key set, the value is resolved from the name."""
+    monkeypatch.delenv("MODEL_AGENT_API_KEY", raising=False)
+    with patch(
+        "veadk.auth.veauth.ark_veauth.get_ark_token", return_value="sk-BY-NAME"
+    ) as g:
+        agent = Agent(name="c", model_api_key_name="my-key")
+        assert agent.model_api_key == "sk-BY-NAME"
+        g.assert_called_once_with(api_key_name="my-key")

--- a/tests/auth/veauth/test_ark_veauth.py
+++ b/tests/auth/veauth/test_ark_veauth.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from unittest.mock import patch
+
+from veadk.auth.veauth.ark_veauth import get_ark_token
+
+
+def _list_page(items, total, page):
+    return {"Result": {"TotalCount": total, "PageNumber": page, "Items": items}}
+
+
+def _raw(api_key):
+    return {"Result": {"ApiKey": api_key}}
+
+
+def _key(id_, name):
+    return {"Id": id_, "Name": name}
+
+
+@pytest.fixture(autouse=True)
+def _creds(monkeypatch):
+    monkeypatch.setenv("VOLCENGINE_ACCESS_KEY", "ak")
+    monkeypatch.setenv("VOLCENGINE_SECRET_KEY", "sk")
+    monkeypatch.delenv("CLOUD_PROVIDER", raising=False)
+
+
+def test_no_name_uses_first_key():
+    """Legacy behavior: without a name, the first key on page 1 is used."""
+    with patch("veadk.auth.veauth.ark_veauth.ve_request") as m:
+        m.side_effect = [
+            _list_page(
+                [_key("id-1", "first"), _key("id-2", "second")], total=2, page=1
+            ),
+            _raw("sk-FIRST"),
+        ]
+        assert get_ark_token() == "sk-FIRST"
+        # Only one ListApiKeys page + one GetRawApiKey; no pagination.
+        assert m.call_count == 2
+        assert m.call_args_list[-1].kwargs["request_body"] == {"Id": "id-1"}
+
+
+def test_name_found_on_later_page_paginates_and_stops():
+    """A named key on page 3 is found by paging; paging stops once matched."""
+    with patch("veadk.auth.veauth.ark_veauth.ve_request") as m:
+        m.side_effect = [
+            _list_page([_key("a", "n1"), _key("b", "n2")], total=6, page=1),
+            _list_page([_key("c", "n3"), _key("d", "n4")], total=6, page=2),
+            _list_page([_key("e", "wanted"), _key("f", "n6")], total=6, page=3),
+            _raw("sk-WANTED"),
+        ]
+        assert get_ark_token(api_key_name="wanted") == "sk-WANTED"
+        # 3 ListApiKeys pages + 1 GetRawApiKey; did not fetch a 4th page.
+        assert m.call_count == 4
+        # Pagination is sent as query params, not in the body.
+        list_call = m.call_args_list[0]
+        assert list_call.kwargs["query"] == {"PageNumber": "1", "PageSize": "10"}
+        assert m.call_args_list[-1].kwargs["request_body"] == {"Id": "e"}
+
+
+def test_name_not_found_raises_after_full_scan():
+    """A wrong/absent name scans the whole list and then errors clearly."""
+    with patch("veadk.auth.veauth.ark_veauth.ve_request") as m:
+        m.side_effect = [
+            _list_page([_key("a", "n1")], total=2, page=1),
+            _list_page([_key("b", "n2")], total=2, page=2),
+        ]
+        with pytest.raises(ValueError, match="my-api-key.*not found"):
+            get_ark_token(api_key_name="my-api-key")
+        # Both pages scanned; GetRawApiKey never called.
+        assert m.call_count == 2
+
+
+def test_name_found_on_first_page_no_extra_pages():
+    with patch("veadk.auth.veauth.ark_veauth.ve_request") as m:
+        m.side_effect = [
+            _list_page([_key("x", "wanted"), _key("y", "other")], total=50, page=1),
+            _raw("sk-X"),
+        ]
+        assert get_ark_token(api_key_name="wanted") == "sk-X"
+        assert m.call_count == 2  # matched on page 1, no further paging

--- a/veadk/agent.py
+++ b/veadk/agent.py
@@ -109,7 +109,13 @@ class Agent(LlmAgent):
     )
     model_provider: str = Field(default_factory=lambda: settings.model.provider)
     model_api_base: str = Field(default_factory=lambda: settings.model.api_base)
-    model_api_key: str = Field(default_factory=lambda: settings.model.api_key)
+    model_api_key: str = ""
+    """The API key for accessing the model. Resolved at init if left empty:
+    by `model_api_key_name` if set, otherwise the configured/first ARK key."""
+    model_api_key_name: str = Field(default_factory=lambda: settings.model.api_key_name)
+    """Name of the ARK API key to resolve the value from (defaults to env
+    MODEL_AGENT_API_KEY_NAME). A key value always wins over a key name, so this
+    is ignored when `model_api_key` or the MODEL_AGENT_API_KEY env is set."""
     model_extra_config: dict = Field(default_factory=dict)
 
     tools: list[ToolUnion] = []
@@ -196,6 +202,23 @@ class Agent(LlmAgent):
 
     def model_post_init(self, __context: Any) -> None:
         super().model_post_init(None)  # for sub_agents init
+
+        # Resolve the model API key when not set explicitly. A key value always
+        # wins over a key name. Precedence:
+        #   explicit model_api_key
+        #   > MODEL_AGENT_API_KEY env
+        #   > model_api_key_name / MODEL_AGENT_API_KEY_NAME (resolved by name)
+        #   > first ARK key in the account
+        if not self.model_api_key:
+            env_key = os.getenv("MODEL_AGENT_API_KEY")
+            if env_key:
+                self.model_api_key = env_key
+            elif self.model_api_key_name:
+                from veadk.auth.veauth.ark_veauth import get_ark_token
+
+                self.model_api_key = get_ark_token(api_key_name=self.model_api_key_name)
+            else:
+                self.model_api_key = settings.model.api_key
 
         # Initialize run_processor if not provided
         if self.run_processor is None:

--- a/veadk/auth/veauth/ark_veauth.py
+++ b/veadk/auth/veauth/ark_veauth.py
@@ -21,7 +21,26 @@ from veadk.utils.volcengine_sign import ve_request
 logger = get_logger(__name__)
 
 
-def get_ark_token(region: str = "cn-beijing") -> str:
+# ARK ListApiKeys caps the page size at 10 server-side (a larger PageSize is
+# ignored), so a specific key may sit on any page. We page through until we
+# either match by name or exhaust the list.
+_ARK_PROJECT_NAME = "default"
+_ARK_PAGE_SIZE = 10
+
+
+def get_ark_token(region: str = "cn-beijing", api_key_name: str | None = None) -> str:
+    """Fetch a raw ARK API key.
+
+    Args:
+        region: VolcEngine region for signing (ARK keys are region-agnostic; this
+            only affects the signed host, kept for BytePlus routing).
+        api_key_name: When given, resolve the key whose ``Name`` matches exactly.
+            Raises ``ValueError`` if no key with that name exists. When omitted,
+            the first key in the account's list is used (legacy behavior).
+
+    Returns:
+        The raw API key string.
+    """
     logger.info("Fetching ARK token...")
 
     access_key = os.getenv("VOLCENGINE_ACCESS_KEY")
@@ -41,29 +60,66 @@ def get_ark_token(region: str = "cn-beijing") -> str:
         region = "ap-southeast-1"
         host = "open.byteplusapi.com"
 
-    res = ve_request(
-        request_body={"ProjectName": "default", "Filter": {"AllowAll": True}},
-        header={"X-Security-Token": session_token},
-        action="ListApiKeys",
-        ak=access_key,
-        sk=secret_key,
-        service="ark",
-        version="2024-01-01",
-        region=region,
-        host=host,
-    )
-    try:
-        first_api_key_id = res["Result"]["Items"][0]["Id"]
+    def _list_api_keys(page_number: int) -> dict:
+        # Pagination goes in the query string; putting PageNumber/PageSize in the
+        # request body makes the ARK gateway 504.
+        res = ve_request(
+            request_body={
+                "ProjectName": _ARK_PROJECT_NAME,
+                "Filter": {"AllowAll": True},
+            },
+            header={"X-Security-Token": session_token},
+            query={"PageNumber": str(page_number), "PageSize": str(_ARK_PAGE_SIZE)},
+            action="ListApiKeys",
+            ak=access_key,
+            sk=secret_key,
+            service="ark",
+            version="2024-01-01",
+            region=region,
+            host=host,
+        )
+        try:
+            return res["Result"]
+        except KeyError:
+            raise ValueError(f"Failed to get ARK api key list: {res}")
+
+    if api_key_name:
+        target_id = None
+        page = 1
+        scanned = 0
+        total = 0
+        while True:
+            result = _list_api_keys(page)
+            total = result.get("TotalCount", 0)
+            items = result.get("Items", [])
+            for item in items:
+                if item.get("Name") == api_key_name:
+                    target_id = item["Id"]
+                    break
+            scanned += len(items)
+            # Stop as soon as we match, run out of items, or cover the whole list.
+            if target_id is not None or not items or scanned >= total:
+                break
+            page += 1
+        if target_id is None:
+            raise ValueError(
+                f"ARK API Key named '{api_key_name}' not found in project "
+                f"'{_ARK_PROJECT_NAME}' (scanned {scanned} keys)."
+            )
+        logger.info(f"Using ARK API Key by name='{api_key_name}', id={target_id}.")
+    else:
+        items = _list_api_keys(1).get("Items", [])
+        if not items:
+            raise ValueError(f"No ARK API keys found in project '{_ARK_PROJECT_NAME}'.")
+        target_id = items[0]["Id"]
         logger.warning("By default, VeADK fetches the first API Key in the list.")
         logger.info(
-            f"Try to fetch ARK API Key with id={first_api_key_id}, name={res['Result']['Items'][0]['Name']}"
+            f"Try to fetch ARK API Key with id={target_id}, name={items[0].get('Name')}"
         )
-    except KeyError:
-        raise ValueError(f"Failed to get ARK api key list: {res}")
 
     # get raw api key
     res = ve_request(
-        request_body={"Id": first_api_key_id},
+        request_body={"Id": target_id},
         header={"X-Security-Token": session_token},
         action="GetRawApiKey",
         ak=access_key,

--- a/veadk/configs/model_configs.py
+++ b/veadk/configs/model_configs.py
@@ -40,9 +40,18 @@ class ModelConfig(BaseSettings):
     api_base: str = DEFAULT_MODEL_AGENT_API_BASE
     """The api base of the model for agent reasoning."""
 
+    api_key_name: str = ""
+    """Name of the ARK API key to use (env MODEL_AGENT_API_KEY_NAME). When set
+    and no explicit MODEL_AGENT_API_KEY is provided, the key value is resolved by
+    name at runtime instead of defaulting to the first key in the account."""
+
     @cached_property
     def api_key(self) -> str:
-        return os.getenv("MODEL_AGENT_API_KEY") or get_ark_token()
+        if explicit := os.getenv("MODEL_AGENT_API_KEY"):
+            return explicit
+        if self.api_key_name:
+            return get_ark_token(api_key_name=self.api_key_name)
+        return get_ark_token()
 
 
 class EmbeddingModelConfig(BaseSettings):


### PR DESCRIPTION
## What

Lets a user pick a **specific ARK API key by name** for model auth, instead of always falling back to the first key in the account. Only the **name** lives in config; the key **value** is fetched at runtime — so it stays out of code/config.

Builds on the existing AK/SK auto-provision (`get_ark_token`): same signing path, just selects by `Name` and pages the list.

## Usage

Any one of these; a **key value always wins over a key name**.

**By env var**
```bash
export MODEL_AGENT_API_KEY_NAME="my-ark-key"   # resolve this named key at runtime
# (MODEL_AGENT_API_KEY, if set, still wins over the name)
```

**Per agent**
```python
from veadk import Agent

# resolve the value of the ARK key named "my-ark-key"
agent = Agent(name="a", model_api_key_name="my-ark-key")

# explicit key still wins over any name
agent = Agent(name="b", model_api_key="sk-xxx", model_api_key_name="ignored")
```

If the name doesn't exist, resolution raises a clear error:
```
ValueError: ARK API Key named 'my-api-key' not found in project 'default' (scanned 335 keys).
```

## Precedence

```
explicit model_api_key
  > MODEL_AGENT_API_KEY (env)
  > model_api_key_name / MODEL_AGENT_API_KEY_NAME (resolved by name)
  > first ARK key in the account   (legacy default, unchanged)
```

Users who set nothing keep the current behavior (first key).

## Notes

- **Pagination**: ARK `ListApiKeys` caps page size at 10 server-side (a larger `PageSize` is ignored) and pagination params must go in the **query string** (in the body → 504). Name lookup pages through and **stops as soon as it matches**; only a miss scans the full list.
- ARK keys are region-agnostic; region only affects the signed host (BytePlus routing), unchanged.

## Changed

- `veadk/auth/veauth/ark_veauth.py` — `get_ark_token(api_key_name=...)` + pagination + not-found error
- `veadk/configs/model_configs.py` — `ModelConfig.api_key_name` (`MODEL_AGENT_API_KEY_NAME`) + precedence
- `veadk/agent.py` — `Agent.model_api_key_name`; resolve in `model_post_init`
- tests: `tests/auth/veauth/test_ark_veauth.py`, `tests/agent/test_model_api_key_resolution.py` (mock `ve_request` / `get_ark_token`; cover pagination, not-found, first-key, precedence)