### PR TITLE
feat(memory): isolate short-term memory in a PostgreSQL schema

### DIFF
--- a/tests/memory/test_postgres_schema.py
+++ b/tests/memory/test_postgres_schema.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+
+from veadk.configs.database_configs import PostgreSqlConfig
+from veadk.memory.short_term_memory_backends.postgresql_backend import (
+    PostgreSqlSTMBackend,
+    _validate_schema,
+    _with_search_path,
+)
+
+_PKG = "veadk.memory.short_term_memory_backends.postgresql_backend"
+
+
+def _config(schema=""):
+    return PostgreSqlConfig(
+        host="h", port=5432, user="u", password="p", database="db", schema=schema
+    )
+
+
+def test_schema_env(monkeypatch):
+    """The schema is populated from DATABASE_POSTGRESQL_SCHEMA."""
+    monkeypatch.setenv("DATABASE_POSTGRESQL_SCHEMA", "tenant_42")
+    assert PostgreSqlConfig().schema == "tenant_42"
+
+
+def test_with_search_path_pins_via_server_settings():
+    """search_path is pinned through the asyncpg startup parameter."""
+    out = _with_search_path({}, "tenant_42")
+    assert out["connect_args"]["server_settings"]["search_path"] == "tenant_42"
+
+
+def test_with_search_path_preserves_existing_connect_args():
+    """Existing connect_args / server_settings are kept, not clobbered."""
+    given = {
+        "pool_size": 3,
+        "connect_args": {"server_settings": {"application_name": "veadk"}},
+    }
+    out = _with_search_path(given, "tenant_42")
+    assert out["pool_size"] == 3
+    ss = out["connect_args"]["server_settings"]
+    assert ss["application_name"] == "veadk"
+    assert ss["search_path"] == "tenant_42"
+    # original dict is not mutated
+    assert given["connect_args"]["server_settings"] == {"application_name": "veadk"}
+
+
+@pytest.mark.parametrize("bad", ["has-dash", "has space", "1leading", 'quote";x', ""])
+def test_invalid_schema_rejected(bad):
+    with pytest.raises(ValueError):
+        _validate_schema(bad)
+
+
+def test_backend_pins_when_schema_set():
+    """With a schema: create it, then build the service with search_path pinned."""
+    with (
+        patch(f"{_PKG}._ensure_schema") as ensure,
+        patch(f"{_PKG}.DatabaseSessionService") as dss,
+    ):
+        backend = PostgreSqlSTMBackend(postgresql_config=_config(schema="tenant_42"))
+        _ = backend.session_service
+        ensure.assert_called_once_with(backend._db_url, "tenant_42")
+        kwargs = dss.call_args.kwargs
+        assert kwargs["connect_args"]["server_settings"]["search_path"] == "tenant_42"
+
+
+def test_backend_plain_without_schema():
+    """Without a schema: legacy behavior, no schema creation, no search_path."""
+    with (
+        patch(f"{_PKG}._ensure_schema") as ensure,
+        patch(f"{_PKG}.DatabaseSessionService") as dss,
+    ):
+        backend = PostgreSqlSTMBackend(postgresql_config=_config(schema=""))
+        _ = backend.session_service
+        ensure.assert_not_called()
+        assert "connect_args" not in dss.call_args.kwargs

--- a/veadk/configs/database_configs.py
+++ b/veadk/configs/database_configs.py
@@ -69,6 +69,12 @@ class PostgreSqlConfig(BaseSettings):
 
     database: str = ""
 
+    schema: str = ""
+    """Optional PostgreSQL schema to isolate this deployment's short-term memory
+    tables in. When set, the connection's search_path is pinned to it (and the
+    schema is created if absent), so several deployments can share one database
+    while keeping their sessions in separate schemas. Env: DATABASE_POSTGRESQL_SCHEMA."""
+
     secret_token: str = ""
 
 

--- a/veadk/memory/short_term_memory_backends/postgresql_backend.py
+++ b/veadk/memory/short_term_memory_backends/postgresql_backend.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+import concurrent.futures
+import re
 from functools import cached_property
 from typing import Any
 from urllib.parse import quote_plus
@@ -21,6 +24,8 @@ from google.adk.sessions import (
     DatabaseSessionService,
 )
 from pydantic import Field
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
 from typing_extensions import override
 
 import veadk.config  # noqa E401
@@ -29,6 +34,67 @@ from veadk.memory.short_term_memory_backends.base_backend import (
     BaseShortTermMemoryBackend,
 )
 from veadk.utils.adk_compat import should_use_async_db_drivers
+from veadk.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# A conservative, injection-safe schema identifier: letters, digits, underscore,
+# not starting with a digit. It is interpolated into DDL, so it must be validated.
+_SCHEMA_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _validate_schema(schema: str) -> None:
+    if not _SCHEMA_RE.match(schema):
+        raise ValueError(
+            f"Invalid PostgreSQL schema name '{schema}'. Allowed: letters, "
+            "digits, underscore; must not start with a digit."
+        )
+
+
+def _with_search_path(db_kwargs: dict, schema: str) -> dict:
+    """Return db_kwargs with the connection's search_path pinned to `schema` via
+    the asyncpg startup parameter (reliable; unlike a per-statement ``SET`` in a
+    connect listener, which asyncpg does not persist). Existing connect_args are
+    preserved."""
+    kwargs = dict(db_kwargs)
+    connect_args = dict(kwargs.get("connect_args", {}))
+    server_settings = dict(connect_args.get("server_settings", {}))
+    server_settings["search_path"] = schema
+    connect_args["server_settings"] = server_settings
+    kwargs["connect_args"] = connect_args
+    return kwargs
+
+
+async def _acreate_schema(db_url: str, schema: str) -> None:
+    # Use a throwaway engine so the real session-service engine is never bound to
+    # this temporary event loop. CREATE SCHEMA is schema-qualified, so it works
+    # regardless of search_path.
+    engine = create_async_engine(db_url)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
+    finally:
+        await engine.dispose()
+
+
+def _ensure_schema(db_url: str, schema: str) -> None:
+    """Create `schema` if absent, before ADK's lazy ``create_all`` runs, so the
+    session tables are created inside it. Safe to call from sync or async
+    context."""
+    try:
+        asyncio.get_running_loop()
+        running = True
+    except RuntimeError:
+        running = False
+    if running:
+        # A loop is already running here; run the coroutine on its own loop in a
+        # worker thread so we don't touch the caller's loop.
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            executor.submit(
+                lambda: asyncio.run(_acreate_schema(db_url, schema))
+            ).result()
+    else:
+        asyncio.run(_acreate_schema(db_url, schema))
 
 
 class PostgreSqlSTMBackend(BaseShortTermMemoryBackend):
@@ -46,4 +112,13 @@ class PostgreSqlSTMBackend(BaseShortTermMemoryBackend):
     @cached_property
     @override
     def session_service(self) -> BaseSessionService:
-        return DatabaseSessionService(db_url=self._db_url, **self.db_kwargs)
+        schema = self.postgresql_config.schema
+        if not schema:
+            return DatabaseSessionService(db_url=self._db_url, **self.db_kwargs)
+
+        _validate_schema(schema)
+        # 1) make sure the schema exists, then 2) pin every connection to it.
+        _ensure_schema(self._db_url, schema)
+        db_kwargs = _with_search_path(self.db_kwargs, schema)
+        logger.info(f"Short-term memory isolated in PostgreSQL schema '{schema}'.")
+        return DatabaseSessionService(db_url=self._db_url, **db_kwargs)


### PR DESCRIPTION
## What

Adds `DATABASE_POSTGRESQL_SCHEMA`. When set, the short-term memory backend puts this deployment's ADK session tables in that **PostgreSQL schema**, so **multiple deployments/runtimes can share one PostgreSQL database while staying isolated by schema**. Applied at short-term-memory init — **independent of `get_fast_api_app`**. Unset → unchanged legacy behavior (default `public` search_path).

## How

ADK's session tables (`sessions`, `events`, `app_states`, `user_states`, `adk_internal_metadata`) carry no hard-coded schema, so they land in the connection's `search_path`. `PostgreSqlSTMBackend`, when a schema is configured:

1. validates the name (`^[A-Za-z_][A-Za-z0-9_]*$`, injection-safe);
2. **creates the schema eagerly** (`CREATE SCHEMA IF NOT EXISTS`, via a throwaway async engine) before ADK's lazy `create_all`;
3. **pins `search_path`** to it through the **asyncpg startup parameter** (`connect_args.server_settings.search_path`), preserving any existing `connect_args`.

> Note: a per-statement `SET search_path` in a SQLAlchemy `connect` listener does **not** persist under asyncpg (verified live — `current_schema()` stayed `public`), which is why the startup parameter + eager create is used instead.

## Usage

```bash
export DATABASE_POSTGRESQL_HOST=...
export DATABASE_POSTGRESQL_PORT=5432
export DATABASE_POSTGRESQL_USER=...
export DATABASE_POSTGRESQL_PASSWORD=...
export DATABASE_POSTGRESQL_DATABASE=shared_db
export DATABASE_POSTGRESQL_SCHEMA=tenant_42     # new; omit for legacy (public)
```

```python
from veadk.memory.short_term_memory import ShortTermMemory
stm = ShortTermMemory(backend="postgresql")   # sessions for this deployment now live in schema "tenant_42"
```

Run several deployments against the same `shared_db` with different `DATABASE_POSTGRESQL_SCHEMA` → isolated by schema.

## Behavior

- **Schema not set** → legacy: tables in `public`, no isolation.
- **Schema set but missing** → auto-created (needs the DB user to have `CREATE` on the database; otherwise init fails loudly with a permission error).
- **Invalid schema name** → `ValueError` at init, before any DB call.

## Verified

- Mock unit tests: env mapping, `connect_args` merge (preserves existing), invalid-name rejection, backend wiring with/without schema.
- **Live PostgreSQL**: two schemas each get the full ADK table set; a session created in schema A is invisible to schema B; per-schema state does not bleed.

## Changed

- `veadk/configs/database_configs.py` — `PostgreSqlConfig.schema` (env `DATABASE_POSTGRESQL_SCHEMA`)
- `veadk/memory/short_term_memory_backends/postgresql_backend.py` — validate + create schema + pin search_path
- `tests/memory/test_postgres_schema.py` — mock unit tests