### PR TITLE
feat(mcp): auto-reconnect after the MCP server drops the session

### DIFF
--- a/tests/utils/test_mcp_session_retry.py
+++ b/tests/utils/test_mcp_session_retry.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from veadk.utils.patches import (
+    _is_dead_mcp_session,
+    _retry_once_on_dead_mcp_session,
+    patch_mcp_session_retry,
+)
+
+
+class BrokenResourceError(Exception):
+    pass
+
+
+@pytest.mark.parametrize(
+    "error, dead",
+    [
+        (RuntimeError("Session terminated"), True),
+        (RuntimeError("Invalid session ID: abc"), True),
+        (ConnectionError("boom"), True),
+        (BrokenResourceError("x"), True),
+        (ValueError("bad argument"), False),
+    ],
+)
+def test_is_dead_session(error, dead):
+    assert _is_dead_mcp_session(error) is dead
+
+
+class _Fake:
+    """Minimal stand-in exposing `_mcp_session_manager` like McpTool/McpToolset."""
+
+    def __init__(self, fail_times):
+        self._fail_times = fail_times
+        self.calls = 0
+        self._mcp_session_manager = AsyncMock()
+
+    async def run(self, *args, **kwargs):
+        self.calls += 1
+        if self.calls <= self._fail_times:
+            raise RuntimeError("Session terminated")
+        return "ok"
+
+
+@pytest.mark.asyncio
+async def test_retry_reconnects_and_succeeds():
+    wrapped = _retry_once_on_dead_mcp_session(_Fake.run)
+    obj = _Fake(fail_times=1)
+    assert await wrapped(obj) == "ok"
+    assert obj.calls == 2  # failed once, retried once
+    obj._mcp_session_manager.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_non_dead_error_not_retried():
+    async def boom(self, *a, **k):
+        raise ValueError("nope")
+
+    wrapped = _retry_once_on_dead_mcp_session(boom)
+    obj = _Fake(fail_times=0)
+    with pytest.raises(ValueError):
+        await wrapped(obj)
+    obj._mcp_session_manager.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_retry_only_once_then_reraises():
+    wrapped = _retry_once_on_dead_mcp_session(_Fake.run)
+    obj = _Fake(fail_times=2)  # fails on both attempts
+    with pytest.raises(RuntimeError, match="Session terminated"):
+        await wrapped(obj)
+    assert obj.calls == 2  # original + one retry, no more
+
+
+def test_apply_patch_idempotent_and_wraps():
+    from google.adk.tools.mcp_tool.mcp_tool import McpTool
+    from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+
+    patch_mcp_session_retry()
+    patch_mcp_session_retry()  # second call is a no-op
+    assert McpTool._veadk_mcp_retry_patched is True
+    assert McpToolset._veadk_mcp_retry_patched is True
+    assert hasattr(McpTool._run_async_impl, "__wrapped__")
+    assert hasattr(McpToolset.get_tools, "__wrapped__")

--- a/veadk/agent.py
+++ b/veadk/agent.py
@@ -52,7 +52,11 @@ from veadk.prompts.prompt_manager import BasePromptManager
 from veadk.tracing.base_tracer import BaseTracer
 from veadk.utils.adk_compat import is_adk_gte
 from veadk.utils.logger import get_logger
-from veadk.utils.patches import patch_asyncio, patch_tracer
+from veadk.utils.patches import (
+    patch_asyncio,
+    patch_mcp_session_retry,
+    patch_tracer,
+)
 from veadk.version import VERSION
 
 if TYPE_CHECKING:
@@ -61,6 +65,7 @@ if TYPE_CHECKING:
 
 patch_tracer()
 patch_asyncio()
+patch_mcp_session_retry()
 logger = get_logger(__name__)
 
 

--- a/veadk/utils/patches.py
+++ b/veadk/utils/patches.py
@@ -116,3 +116,83 @@ def patch_tracer() -> None:
                         ),
                     )
                     logger.debug(f"Patch {mod_name} {var_name} with VeADK tracer.")
+
+
+# Substrings / exception type names that signal a dead MCP session (server
+# restart, scale-down, idle expiry) or a broken transport — all recoverable by
+# dropping the cached session and reconnecting.
+_MCP_DEAD_MSGS = (
+    "invalid session id",
+    "session may have expired or does not exist",
+    "session terminated",
+    "connection lost",
+)
+_MCP_DEAD_TYPES = frozenset(
+    {
+        "BrokenResourceError",
+        "ClosedResourceError",
+        "EndOfStream",
+        "RemoteProtocolError",
+        "ReadError",
+        "ConnectError",
+    }
+)
+
+
+def _is_dead_mcp_session(error: BaseException) -> bool:
+    message = str(error).lower()
+    return (
+        isinstance(error, ConnectionError)
+        or type(error).__name__ in _MCP_DEAD_TYPES
+        or any(s in message for s in _MCP_DEAD_MSGS)
+    )
+
+
+def _retry_once_on_dead_mcp_session(func):
+    """Wrap an MCP coroutine so that, on a dead-session/broken-transport error,
+    it closes the manager's cached sessions (recreated lazily) and retries once.
+
+    Applies to any object exposing ``_mcp_session_manager`` (McpTool, McpToolset).
+    """
+    import functools
+
+    @functools.wraps(func)
+    async def wrapper(self, *args, **kwargs):
+        try:
+            return await func(self, *args, **kwargs)
+        except Exception as error:
+            task = asyncio.current_task()
+            cancelling = getattr(task, "cancelling", None)  # py>=3.11
+            if (cancelling and cancelling() > 0) or not _is_dead_mcp_session(error):
+                raise
+            logger.info(f"Reconnecting MCP after dead session: {func.__qualname__}")
+            await self._mcp_session_manager.close()  # drop all stale sessions
+            return await func(self, *args, **kwargs)
+
+    return wrapper
+
+
+def patch_mcp_session_retry() -> None:
+    """Reconnect to an MCP server after it drops the session.
+
+    ADK caches MCP sessions but does not recreate them when the server restarts
+    or scales down, so calls fail with "Session terminated" / broken transport.
+    This wraps ``McpTool._run_async_impl`` and ``McpToolset.get_tools`` to drop
+    the dead session and retry once. No-op if the google-adk internals are
+    unavailable (e.g. after an incompatible upgrade).
+    """
+    try:
+        from google.adk.tools.mcp_tool.mcp_tool import McpTool
+        from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+
+        # McpTool is the base for MCPTool (which does not override the method).
+        for cls, method in ((McpTool, "_run_async_impl"), (McpToolset, "get_tools")):
+            if getattr(cls, "_veadk_mcp_retry_patched", False):
+                continue
+            original = getattr(
+                getattr(cls, method), "__wrapped__", getattr(cls, method)
+            )
+            setattr(cls, method, _retry_once_on_dead_mcp_session(original))
+            cls._veadk_mcp_retry_patched = True
+    except Exception as e:  # pragma: no cover - defensive across adk versions
+        logger.warning(f"Skip MCP session-retry patch: {e}")


### PR DESCRIPTION
## Problem

ADK caches MCP sessions but does not recreate them when the MCP server **restarts / scales down / expires the session**. Subsequent calls then fail with `Session terminated` / `Invalid session ID` or a broken transport (`BrokenResourceError`, `ClosedResourceError`, `ConnectError`, …), and stay broken until the process restarts.

## Fix

`patch_mcp_session_retry()` (in `veadk/utils/patches.py`, applied at agent import alongside `patch_tracer` / `patch_asyncio`): on a dead-session / broken-transport error, **close the manager's cached sessions** (recreated lazily) and **retry the call once**.

One small generic wrapper covers both `McpTool._run_async_impl` (tool calls) and `McpToolset.get_tools` (listing) via their shared `_mcp_session_manager`. Because it calls `manager.close()` rather than recomputing a session key, it also reconnects correctly for **auth-header sessions** (Bearer / OIDC), and keeps the private-API surface to three symbols.

- idempotent (re-applies safely via `__wrapped__`)
- does not swallow task cancellation (`Task.cancelling()`, py≥3.11; ignored on 3.10)
- **no-op** if the google-adk internals are missing (defensive across adk upgrades)
- verified compatible with google-adk 1.32

## Usage

Nothing to do — it is applied automatically when `veadk` (agent) is imported, so MCP tools/toolsets reconnect transparently after a server restart.

## Trade-off

Retry-once can re-run a tool that already produced a side effect before the transport died (at-least-once). It only triggers on clear dead-session/transport signals; safe for read/idempotent tools, worth noting for mutating ones.

## Changed

- `veadk/utils/patches.py` — `patch_mcp_session_retry()` (+ `_is_dead_mcp_session`, `_retry_once_on_dead_mcp_session`)
- `veadk/agent.py` — apply it at import
- `tests/utils/test_mcp_session_retry.py` — mock tests: dead-session detection, reconnect-and-retry, non-dead not retried, retry-once-then-reraise, idempotent apply