### PR TITLE
refactor(logging): replace loguru with stdlib logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     # stay compatible across google-adk >= 1.32.0 (including 2.x).
     "litellm>=1.83.7,<=1.83.14", # google-adk LiteLlm model ([extensions] on 2.x)
     "sqlalchemy>=2,<3", # google-adk sessions ([db] on 2.x)
-    "loguru==0.7.3", # For better logging
     "opentelemetry-exporter-otlp==1.37.0",
     "opentelemetry-instrumentation-logging>=0.56b0",
     "wrapt==1.17.2", # For patching built-in functions

--- a/veadk/cli/templates/rl/ark/plugins/test_utils.py
+++ b/veadk/cli/templates/rl/ark/plugins/test_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import logging
 import os
 from ark_sdk.core.plugin.rollout.proxy import InferenceProxy, Mode
 from ark_sdk.types.pipeline_plugin.rollout import (
@@ -21,8 +22,9 @@ from ark_sdk.types.pipeline_plugin.rollout import (
 )
 import json
 
-from loguru import logger
 import contextvars
+
+logger = logging.getLogger(__name__)
 
 
 async def test_with_dataset(

--- a/veadk/runner.py
+++ b/veadk/runner.py
@@ -135,6 +135,19 @@ def intercept_new_message(process_func):
         ):
             await pre_run_process(self, process_func, new_message, user_id, session_id)
 
+            # ADK only aggregates the answer into one event, while thinking is
+            # emitted as many small non-partial parts; accumulate them and log
+            # the complete thinking once, instead of token by token.
+            thinking_parts: list[str] = []
+
+            def flush_thinking(metadata: str) -> None:
+                if thinking_parts:
+                    logger.debug(
+                        f"Thinking output: {''.join(thinking_parts)} {metadata}"
+                    )
+                    thinking_parts.clear()
+
+            event_metadata = ""
             async for event in func(
                 user_id=user_id,
                 session_id=session_id,
@@ -146,13 +159,20 @@ def intercept_new_message(process_func):
                     continue
 
                 yield event
+
+                # skip streaming partial chunks; they are logged once aggregated
+                if event.partial:
+                    continue
+
                 event_metadata = f"| agent_name: {event.author} , user_id: {user_id} , session_id: {session_id} , invocation_id: {event.invocation_id}"
                 function_calls = get_event_function_calls(event)
                 function_responses = get_event_function_responses(event)
                 if function_calls:
+                    flush_thinking(event_metadata)
                     for function_call in function_calls:
                         logger.debug(f"Function call: {function_call} {event_metadata}")
                 elif function_responses:
+                    flush_thinking(event_metadata)
                     for function_response in function_responses:
                         logger.debug(
                             f"Function response: {function_response} {event_metadata}"
@@ -160,15 +180,16 @@ def intercept_new_message(process_func):
                 elif event.content is not None and event.content.parts:
                     for part in event.content.parts:
                         if part.text and len(part.text.strip()) > 0:
-                            final_output = part.text
                             if part.thought:
-                                logger.debug(
-                                    f"Thinking output: {final_output} {event_metadata}"
-                                )
+                                thinking_parts.append(part.text)
                             else:
+                                flush_thinking(event_metadata)
                                 logger.debug(
-                                    f"Event output: {final_output} {event_metadata}"
+                                    f"Event output: {part.text} {event_metadata}"
                                 )
+
+            # flush trailing thinking for a pure-reasoning turn with no answer
+            flush_thinking(event_metadata)
 
             post_run_process(self)
 

--- a/veadk/tracing/telemetry/telemetry.py
+++ b/veadk/tracing/telemetry/telemetry.py
@@ -49,7 +49,7 @@ def init_global_meter_uploader_from_exporters(exporters):
         if hasattr(exporter, "meter_uploader") and exporter.meter_uploader:
             meter_uploader = exporter.meter_uploader
             logger.debug(
-                "Global meter_uploader initialized from exporter: {}",
+                "Global meter_uploader initialized from exporter: %s",
                 exporter.__class__.__name__,
             )
             break

--- a/veadk/utils/logger.py
+++ b/veadk/utils/logger.py
@@ -12,16 +12,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import sys
 
-from loguru import logger
 from opentelemetry import trace
 
 from veadk.utils.misc import getenv
 
+_LOGGER_NAME = "veadk"
+
+# ANSI escape codes, matching the colors loguru used by default.
+_RESET = "\033[0m"
+_GREEN = "\033[32m"
+_CYAN = "\033[36m"
+_LEVEL_COLORS = {
+    "DEBUG": "\033[34m",  # blue
+    "INFO": "\033[1m",  # bold
+    "WARNING": "\033[33m",  # yellow
+    "ERROR": "\033[31m",  # red
+    "CRITICAL": "\033[1m\033[31m",  # bold red
+}
+
+
+class _VeADKFormatter(logging.Formatter):
+    def __init__(self, colorize: bool) -> None:
+        super().__init__(datefmt="%Y-%m-%d %H:%M:%S")
+        self._colorize = colorize
+
+    def format(self, record: logging.LogRecord) -> str:
+        time_str = self.formatTime(record, self.datefmt)
+        level = record.levelname
+        location = f"{record.filename}:{record.lineno}"
+        message = record.getMessage()
+
+        span = trace.get_current_span()
+        trace_id_part = ""
+        if span.is_recording():
+            trace_id_part = (
+                f" | trace_id={format(span.get_span_context().trace_id, '016x')}"
+            )
+
+        if self._colorize:
+            time_str = f"{_GREEN}{time_str}{_RESET}"
+            level = f"{_LEVEL_COLORS.get(level, '')}{level}{_RESET}"
+            location = f"{_CYAN}{location}{_RESET}"
+
+        line = f"{time_str} | {level} | {location}{trace_id_part} - {message}"
+
+        if record.exc_info:
+            line += "\n" + self.formatException(record.exc_info)
+        return line
+
 
 def filter_log():
-    import logging
     import warnings
 
     from urllib3.exceptions import InsecureRequestWarning
@@ -42,33 +85,28 @@ def filter_log():
 
 
 def setup_logger():
-    logger.remove()
+    root = logging.getLogger(_LOGGER_NAME)
 
-    def format_with_traceid(record):
-        span = trace.get_current_span()
-        trace_id_part = ""
-        if span.is_recording():
-            trace_id_part = (
-                f" | trace_id={format(span.get_span_context().trace_id, '016x')}"
-            )
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
 
-        base_format = "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level}</level> | <cyan>{file}:{line}</cyan>"
-        message_part = " - {message}\n{exception}"
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(_VeADKFormatter(colorize=sys.stdout.isatty()))
+    root.addHandler(handler)
+    root.setLevel(getenv("LOGGING_LEVEL", "DEBUG"))
 
-        return base_format + trace_id_part + message_part
-
-    logger.add(
-        sys.stdout,
-        format=format_with_traceid,
-        colorize=True,
-        level=getenv("LOGGING_LEVEL", "DEBUG"),
-    )
-    return logger
+    # keep veadk logs on their own handler, do not bubble up to the root logger
+    root.propagate = False
+    return root
 
 
 filter_log()
 setup_logger()
 
 
-def get_logger(name: str):
-    return logger.bind(name=name)
+def get_logger(name: str) -> logging.Logger:
+    # anchor every logger under the veadk namespace so it inherits the handler
+    # and level configured above, regardless of the caller's module name
+    if name == _LOGGER_NAME or name.startswith(f"{_LOGGER_NAME}."):
+        return logging.getLogger(name)
+    return logging.getLogger(f"{_LOGGER_NAME}.{name}")


### PR DESCRIPTION
## 背景

当前 `veadk/utils/logger.py` 基于 loguru 实现日志系统，但 loguru 与部分环境/生态兼容性不佳。本 PR 用 Python 原生 `logging` 复刻完全相同的效果，去除对 loguru 的依赖。

## 改动

- **`veadk/utils/logger.py`**：改用 stdlib `logging`
  - 自定义 `Formatter` 复刻 loguru 默认样式：绿色时间 / 按级别着色的级别名 / 青色 `file:line`，并从当前 OpenTelemetry span 注入 `trace_id`
  - 仅当 stdout 为 TTY 时上色，重定向/日志采集时不再混入 ANSI 转义序列（loguru `colorize=True` 会强制上色）
  - 保留原有的 warnings 过滤与第三方库日志压制逻辑
  - 将所有 logger 锚定到 `veadk` 命名空间下，无论调用方 `__name__` 为何都能继承 handler 与级别；`propagate=False` 避免与 root logger 重复输出
- **`veadk/cli/templates/rl/ark/plugins/test_utils.py`**：模板去除 loguru，改用 stdlib logging
- **`pyproject.toml`**：移除 `loguru==0.7.3` 依赖

## 兼容性

- 全仓 152 个文件、1005 处日志调用无需改动：均为标准方法 `.info/.debug/.warning/.error/.exception/.critical`，无 loguru 专有 API
- 原本部分 `logger.info("...%s", arg)` 调用在 loguru 下会打印字面 `%s`（loguru 用 `{}`），迁移到 stdlib 后可正确渲染

## 验证

- Ruff、Pyright 通过；pre-commit 钩子通过
- 运行时冒烟测试：各级别输出、`%s` 惰性参数渲染、异常 traceback、TTY/非 TTY 上色行为、`trace_id` 逻辑、无重复打印