### PR TITLE
feat(feishu): add concurrent mode for parallel message handling

### DIFF
--- a/docs/content/docs/framework/tools/feishu-channel.en.mdx
+++ b/docs/content/docs/framework/tools/feishu-channel.en.mdx
@@ -37,6 +37,7 @@ Environment variables:
 - `TOOL_FEISHU_CHANNEL_TRANSPORT`: defaults to `ws`
 - `TOOL_FEISHU_CHANNEL_STREAMING`: whether to enable streaming output, defaults to `false`
 - `TOOL_FEISHU_CHANNEL_REACTIONS`: whether to reply with a "received" reaction on incoming messages, defaults to `false`
+- `TOOL_FEISHU_CHANNEL_CONCURRENT`: whether to enable concurrent mode, defaults to `false`
 
 Or configure in `config.yaml`:
 
@@ -85,6 +86,26 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 ```
+
+## Concurrent mode
+
+By default the Feishu `Channel` serializes messages per `chat_id` (one at a time), so when several people @ the bot in a group it replies to them sequentially.
+
+With concurrent mode (`concurrent=True` or `TOOL_FEISHU_CHANNEL_CONCURRENT=true`):
+
+- the channel's per-chat serialization queue and text batching are disabled, so messages in the same chat are handled in parallel;
+- session identity defaults to per-sender isolation (`chat_id:user_id`) so parallel runs don't corrupt a shared chat session;
+- `max_concurrency` (default `8`) caps how many messages are processed at once.
+
+```python
+extension = FeishuChannelExtension(
+    runner=runner,
+    concurrent=True,
+    max_concurrency=8,
+)
+```
+
+Trade-off: in concurrent mode each sender is an isolated session, so the bot does **not** see other people's context in the group. Keep the default (per-chat serial) if you want a shared group context.
 
 ## Notes
 

--- a/docs/content/docs/framework/tools/feishu-channel.mdx
+++ b/docs/content/docs/framework/tools/feishu-channel.mdx
@@ -37,6 +37,7 @@ pip install lark-oapi
 - `TOOL_FEISHU_CHANNEL_TRANSPORT`：默认 `ws`
 - `TOOL_FEISHU_CHANNEL_STREAMING`：是否开启流式输出，默认 `false`
 - `TOOL_FEISHU_CHANNEL_REACTIONS`：是否在收到消息时回复“收到”表情，默认 `false`
+- `TOOL_FEISHU_CHANNEL_CONCURRENT`：是否开启并发模式，默认 `false`
 
 或在 `config.yaml` 中配置：
 
@@ -85,6 +86,26 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 ```
+
+## 并发模式
+
+默认情况下，飞书 `Channel` 会按 `chat_id` 串行处理同一会话内的消息（一次处理一条），因此群里多人同时 @ 机器人时会依次回复。
+
+开启并发模式（`concurrent=True` 或 `TOOL_FEISHU_CHANNEL_CONCURRENT=true`）后：
+
+- 关闭 `Channel` 的按会话串行队列与文本批处理，使同一会话内的消息并行处理；
+- 会话身份默认改为按发送者隔离（`chat_id:user_id`），避免并行运行写坏同一条会话；
+- 通过 `max_concurrency`（默认 `8`）限制同时处理的消息数量。
+
+```python
+extension = FeishuChannelExtension(
+    runner=runner,
+    concurrent=True,
+    max_concurrency=8,
+)
+```
+
+权衡：并发模式下每个发送者是独立会话，机器人**看不到群内其他人的上下文**。如果需要全群共享上下文，请保持默认（同会话串行）。
 
 ## 说明
 

--- a/tests/test_feishu_channel_extension.py
+++ b/tests/test_feishu_channel_extension.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -194,6 +195,100 @@ async def test_extension_ignores_empty_message_by_default():
 
     assert runner.calls == []
     assert channel.sent_messages == []
+
+
+@pytest.mark.anyio
+async def test_concurrent_mode_isolates_session_per_sender():
+    """In concurrent mode, two senders in the same chat get separate sessions
+    (chat_id:user_id) so parallel runs don't share one chat session."""
+    runner = FakeRunner()
+    channel = FakeChannel()
+    extension = FeishuChannelExtension(runner=runner, channel=channel, concurrent=True)
+
+    a = build_message(
+        message_id="om_a",
+        sender=SimpleNamespace(union_id="on_a", open_id="ou_a", user_id="u_a"),
+    )
+    b = build_message(
+        message_id="om_b",
+        sender=SimpleNamespace(union_id="on_b", open_id="ou_b", user_id="u_b"),
+    )
+
+    await asyncio.gather(extension._on_message(a), extension._on_message(b))
+
+    sessions = {c["user_id"]: c["session_id"] for c in runner.calls}
+    assert sessions == {
+        "on_a": "oc_chat:on_a",
+        "on_b": "oc_chat:on_b",
+    }
+
+
+@pytest.mark.anyio
+async def test_default_mode_shares_chat_session():
+    """Without concurrent mode, senders in the same chat share the chat-wide
+    session (the historical behavior)."""
+    runner = FakeRunner()
+    channel = FakeChannel()
+    extension = FeishuChannelExtension(runner=runner, channel=channel)
+
+    a = build_message(
+        message_id="om_a",
+        sender=SimpleNamespace(union_id="on_a", open_id="ou_a", user_id="u_a"),
+    )
+    b = build_message(
+        message_id="om_b",
+        sender=SimpleNamespace(union_id="on_b", open_id="ou_b", user_id="u_b"),
+    )
+
+    await asyncio.gather(extension._on_message(a), extension._on_message(b))
+
+    assert {c["session_id"] for c in runner.calls} == {"oc_chat"}
+
+
+@pytest.mark.anyio
+async def test_concurrent_mode_caps_in_flight_runs():
+    """max_concurrency bounds how many runs are in flight at once."""
+    peak = 0
+    active = 0
+    gate = asyncio.Event()
+
+    class BlockingRunner:
+        def __init__(self):
+            self.calls = []
+
+        async def run(self, messages, user_id="", session_id="", **kwargs):
+            nonlocal peak, active
+            active += 1
+            peak = max(peak, active)
+            self.calls.append(session_id)
+            await gate.wait()
+            active -= 1
+            return "ok"
+
+    runner = BlockingRunner()
+    extension = FeishuChannelExtension(
+        runner=runner, channel=FakeChannel(), concurrent=True, max_concurrency=2
+    )
+
+    messages = [
+        build_message(
+            message_id=f"om_{i}",
+            sender=SimpleNamespace(
+                union_id=f"on_{i}", open_id=f"ou_{i}", user_id=f"u_{i}"
+            ),
+        )
+        for i in range(5)
+    ]
+    tasks = [asyncio.create_task(extension._on_message(m)) for m in messages]
+    # let the semaphore admit up to the cap, then release everyone
+    await asyncio.sleep(0.05)
+    admitted = peak
+    gate.set()
+    await asyncio.gather(*tasks)
+
+    assert admitted == 2
+    assert peak == 2
+    assert len(runner.calls) == 5
 
 
 @pytest.mark.anyio

--- a/veadk/extensions/feishu_channel.py
+++ b/veadk/extensions/feishu_channel.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import inspect
 import os
 from dataclasses import dataclass
@@ -89,10 +90,29 @@ class FeishuChannelExtension:
         channel_kwargs: dict[str, Any] | None = None,
         streaming: bool = False,
         reactions: bool = False,
+        concurrent: bool = False,
+        max_concurrency: int = 8,
     ) -> None:
         self.runner = runner
-        self.session_id_factory = session_id_factory or self.default_session_id_factory
+        # Concurrent mode: handle multiple @mentions in the same chat in
+        # parallel instead of one-at-a-time. This (1) disables the channel's
+        # per-chat serialization queue + text batching, (2) isolates each
+        # sender into their own session so parallel runs don't corrupt a
+        # shared chat session, and (3) caps in-flight runs with a semaphore.
+        self.concurrent = (
+            concurrent
+            or str(os.getenv("TOOL_FEISHU_CHANNEL_CONCURRENT", "")).lower() == "true"
+        )
+        if session_id_factory is not None:
+            self.session_id_factory = session_id_factory
+        elif self.concurrent:
+            self.session_id_factory = self.concurrent_session_id_factory
+        else:
+            self.session_id_factory = self.default_session_id_factory
         self.user_id_factory = user_id_factory or self.default_user_id_factory
+        self._semaphore = (
+            asyncio.Semaphore(max_concurrency) if self.concurrent else None
+        )
         self.message_handler = message_handler
         self.response_formatter = response_formatter or self.default_response_formatter
         self.reply_in_thread = reply_in_thread
@@ -142,6 +162,15 @@ class FeishuChannelExtension:
             _read_attr(message, "conversation", "chat_id"),
         )
         return thread_id or chat_id or getattr(message, "message_id", "")
+
+    @classmethod
+    def concurrent_session_id_factory(cls, message: Any) -> str:
+        """Per-sender session within a chat, so parallel replies don't share
+        (and corrupt) one chat-wide session. Note: the bot loses cross-user
+        group context in this mode."""
+        base = cls.default_session_id_factory(message)
+        user = cls.default_user_id_factory(message)
+        return f"{base}:{user}" if base else user
 
     @staticmethod
     def default_response_formatter(text: str) -> dict[str, str]:
@@ -220,6 +249,17 @@ class FeishuChannelExtension:
         if self.reply_in_thread and context.message_id:
             send_options["reply_to"] = context.message_id
 
+        # In concurrent mode, cap the number of in-flight runs; otherwise the
+        # channel already serializes per chat so no cap is needed.
+        if self._semaphore is not None:
+            async with self._semaphore:
+                await self._respond(context, send_options)
+        else:
+            await self._respond(context, send_options)
+
+    async def _respond(
+        self, context: "FeishuMessageContext", send_options: dict[str, Any]
+    ) -> None:
         if self.message_handler is not None:
             response_text = await self._maybe_await(self.message_handler(context))
             if not response_text:
@@ -376,6 +416,22 @@ class FeishuChannelExtension:
         resolved_channel_kwargs.setdefault(
             "transport", os.getenv("TOOL_FEISHU_CHANNEL_TRANSPORT", "ws")
         )
+
+        # In concurrent mode, turn off the per-chat serialization queue and
+        # text batching so same-chat messages are dispatched in parallel
+        # rather than merged and run one-at-a-time. Caller-supplied `safety`
+        # in channel_kwargs wins.
+        if self.concurrent and "safety" not in resolved_channel_kwargs:
+            from lark_oapi.channel import (
+                ChatQueueConfig,
+                SafetyConfig,
+                TextBatchConfig,
+            )
+
+            resolved_channel_kwargs["safety"] = SafetyConfig(
+                chat_queue=ChatQueueConfig(enabled=False),
+                text_batch=TextBatchConfig(delay_ms=0),
+            )
 
         return FeishuChannel(
             app_id=resolved_app_id,


### PR DESCRIPTION
## 背景

飞书 channel 的底层 SDK 默认按 `chat_id` **串行**处理同一会话的消息(per-chat 队列 + 文本批处理),因此群里多人同时 @ 机器人时是**一条接一条**回复,而不是并行。

排查确认:串行发生在 SDK 的 safety `ChatPipeline` 层(默认 `ChatQueueConfig.enabled=True`),在 veadk handler 与 session 映射之前,所以单纯拆 session 无法并行。

## 改动

给 `FeishuChannelExtension` 增加 opt-in 的**并发模式**(`concurrent=True` 或 `TOOL_FEISHU_CHANNEL_CONCURRENT=true`):

1. 关闭 channel 的 per-chat 串行队列与文本批处理(`SafetyConfig(chat_queue=ChatQueueConfig(enabled=False), text_batch=TextBatchConfig(delay_ms=0))`),使同会话消息并行处理
2. 会话身份默认按发送者隔离(`chat_id:user_id`),避免并行运行写坏同一条会话
3. 用信号量限制同时处理数(`max_concurrency`,默认 8)

**不改动 reaction / streaming / 身份映射等既有逻辑**,默认行为(全群共享会话、串行)保持不变。

## 权衡

并发模式下每个发送者是独立会话,机器人**看不到群内其他人的上下文**。需要全群共享上下文时应保持默认(同会话串行)。这是"并行"与"共享上下文"的固有取舍。

## 测试

`tests/test_feishu_channel_extension.py` 新增 3 个用例:
- `test_concurrent_mode_isolates_session_per_sender`:并发模式下同群不同发送者 → 独立 session
- `test_default_mode_shares_chat_session`:默认模式同群 → 共享 session(历史行为)
- `test_concurrent_mode_caps_in_flight_runs`:`max_concurrency` 限制并发数

全部 7 个用例通过;Ruff/Pyright/pre-commit 通过。文档(中英)已更新新参数与并发模式说明。

## 本地实测

用真实飞书机器人在群里验证:同群不同用户各得独立 session(`oc_xxx:on_yyy`),链路(WS → veadk → 模型 → 回复)正常。