### PR TITLE
Add STS session token support for temporary Volcengine credentials

### DIFF
--- a/veadk/a2a/registry_client.py
+++ b/veadk/a2a/registry_client.py
@@ -422,6 +422,8 @@ def _signed_openapi_post(
         "Host": parsed.netloc,
         "Content-Type": "application/json",
     }
+    if credentials.session_token:
+        headers_to_sign["X-Security-Token"] = credentials.session_token
     auth_headers = _volc_sign_v4(
         access_key=credentials.access_key,
         secret_key=credentials.secret_key,
@@ -438,8 +440,6 @@ def _signed_openapi_post(
         "Host": parsed.netloc,
         **auth_headers,
     }
-    if credentials.session_token:
-        request_headers["X-Security-Token"] = credentials.session_token
 
     response = None
     try:

--- a/veadk/auth/veauth/base_veauth.py
+++ b/veadk/auth/veauth/base_veauth.py
@@ -25,23 +25,44 @@ class BaseVeAuth(ABC, BaseAuth):
     volcengine_secret_key: str
     """Volcengine Secret Key"""
 
+    session_token: str
+    """Volcengine STS Session Token (optional, for temporary credentials)"""
+
     def __init__(
         self,
         access_key: str | None = None,
         secret_key: str | None = None,
+        session_token: str | None = None,
     ) -> None:
         super().__init__()
 
         final_ak = access_key or os.getenv("VOLCENGINE_ACCESS_KEY")
         final_sk = secret_key or os.getenv("VOLCENGINE_SECRET_KEY")
+        final_token = (
+            session_token
+            or os.getenv("VOLCENGINE_SESSION_TOKEN")
+            or os.getenv("VOLC_SESSIONTOKEN")
+            or ""
+        )
+
+        if not (final_ak and final_sk):
+            # Fall back to VeFaaS IAM credential file when env/args are missing.
+            from veadk.auth.veauth.utils import get_credential_from_vefaas_iam
+
+            cred = get_credential_from_vefaas_iam()
+            final_ak = cred.access_key_id
+            final_sk = cred.secret_access_key
+            final_token = cred.session_token or final_token
 
         assert final_ak, "Volcengine access key cannot be empty."
         assert final_sk, "Volcengine secret key cannot be empty."
 
         self.access_key = final_ak
         self.secret_key = final_sk
+        self.session_token = final_token
 
-        self._token: str = ""
+        # Cached API bearer token (distinct from STS session_token above).
+        self._api_token: str = ""
 
     @abstractmethod
     def _fetch_token(self) -> None: ...

--- a/veadk/auth/veauth/opensearch_veauth.py
+++ b/veadk/auth/veauth/opensearch_veauth.py
@@ -43,10 +43,12 @@ class OpensearchVeAuth(BaseVeAuth):
         self,
         access_key: str = os.getenv("VOLCENGINE_ACCESS_KEY", ""),
         secret_key: str = os.getenv("VOLCENGINE_SECRET_KEY", ""),
+        session_token: str = os.getenv("VOLCENGINE_SESSION_TOKEN", "")
+        or os.getenv("VOLC_SESSIONTOKEN", ""),
     ) -> None:
-        super().__init__(access_key, secret_key)
+        super().__init__(access_key, secret_key, session_token=session_token)
 
-        self._token: str = ""
+        self._api_token: str = ""
 
     @override
     def _fetch_token(self) -> None:
@@ -61,15 +63,16 @@ class OpensearchVeAuth(BaseVeAuth):
         #     version="2024-01-01",
         #     region="cn-beijing",
         #     host="open.volcengineapi.com",
+        #     session_token=self.session_token,
         # )
         # try:
-        #     self._token = res["Result"]["APIKeys"][0]["APIKey"]
+        #     self._api_token = res["Result"]["APIKeys"][0]["APIKey"]
         # except KeyError:
         #     raise ValueError(f"Failed to get Prompt Pilot token: {res}")
 
     @property
     def token(self) -> str:
-        if self._token:
-            return self._token
+        if self._api_token:
+            return self._api_token
         self._fetch_token()
-        return self._token
+        return self._api_token

--- a/veadk/auth/veauth/postgresql_veauth.py
+++ b/veadk/auth/veauth/postgresql_veauth.py
@@ -43,10 +43,12 @@ class PostgreSqlVeAuth(BaseVeAuth):
         self,
         access_key: str = os.getenv("VOLCENGINE_ACCESS_KEY", ""),
         secret_key: str = os.getenv("VOLCENGINE_SECRET_KEY", ""),
+        session_token: str = os.getenv("VOLCENGINE_SESSION_TOKEN", "")
+        or os.getenv("VOLC_SESSIONTOKEN", ""),
     ) -> None:
-        super().__init__(access_key, secret_key)
+        super().__init__(access_key, secret_key, session_token=session_token)
 
-        self._token: str = ""
+        self._api_token: str = ""
 
     @override
     def _fetch_token(self) -> None:
@@ -61,15 +63,16 @@ class PostgreSqlVeAuth(BaseVeAuth):
         #     version="2024-01-01",
         #     region="cn-beijing",
         #     host="open.volcengineapi.com",
+        #     session_token=self.session_token,
         # )
         # try:
-        #     self._token = res["Result"]["APIKeys"][0]["APIKey"]
+        #     self._api_token = res["Result"]["APIKeys"][0]["APIKey"]
         # except KeyError:
         #     raise ValueError(f"Failed to get Prompt Pilot token: {res}")
 
     @property
     def token(self) -> str:
-        if self._token:
-            return self._token
+        if self._api_token:
+            return self._api_token
         self._fetch_token()
-        return self._token
+        return self._api_token

--- a/veadk/auth/veauth/prompt_pilot_veauth.py
+++ b/veadk/auth/veauth/prompt_pilot_veauth.py
@@ -28,10 +28,12 @@ class PromptPilotVeAuth(BaseVeAuth):
         self,
         access_key: str = os.getenv("VOLCENGINE_ACCESS_KEY", ""),
         secret_key: str = os.getenv("VOLCENGINE_SECRET_KEY", ""),
+        session_token: str = os.getenv("VOLCENGINE_SESSION_TOKEN", "")
+        or os.getenv("VOLC_SESSIONTOKEN", ""),
     ) -> None:
-        super().__init__(access_key, secret_key)
+        super().__init__(access_key, secret_key, session_token=session_token)
 
-        self._token: str = ""
+        self._api_token: str = ""
 
     @override
     def _fetch_token(self) -> None:
@@ -46,15 +48,16 @@ class PromptPilotVeAuth(BaseVeAuth):
             version="2024-01-01",
             region="cn-beijing",
             host="open.volcengineapi.com",
+            session_token=self.session_token,
         )
         try:
-            self._token = res["Result"]["APIKeys"][0]["APIKey"]
+            self._api_token = res["Result"]["APIKeys"][0]["APIKey"]
         except KeyError:
             raise ValueError(f"Failed to get Prompt Pilot token: {res}")
 
     @property
     def token(self) -> str:
-        if self._token:
-            return self._token
+        if self._api_token:
+            return self._api_token
         self._fetch_token()
-        return self._token
+        return self._api_token

--- a/veadk/auth/veauth/utils.py
+++ b/veadk/auth/veauth/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import os
 from pathlib import Path
 
 from pydantic import BaseModel
@@ -60,10 +61,19 @@ def get_credential_from_vefaas_iam() -> VeIAMCredential:
         )
 
 
-def refresh_ak_sk(access_key: str, secret_key: str) -> VeIAMCredential:
+def refresh_ak_sk(
+    access_key: str, secret_key: str, session_token: str = ""
+) -> VeIAMCredential:
     if access_key and secret_key:
+        final_token = (
+            session_token
+            or os.getenv("VOLCENGINE_SESSION_TOKEN", "")
+            or os.getenv("VOLC_SESSIONTOKEN", "")
+        )
         return VeIAMCredential(
-            access_key_id=access_key, secret_access_key=secret_key, session_token=""
+            access_key_id=access_key,
+            secret_access_key=secret_key,
+            session_token=final_token,
         )
 
     return get_credential_from_vefaas_iam()

--- a/veadk/auth/veauth/vesearch_veauth.py
+++ b/veadk/auth/veauth/vesearch_veauth.py
@@ -28,10 +28,12 @@ class VesearchVeAuth(BaseVeAuth):
         self,
         access_key: str = os.getenv("VOLCENGINE_ACCESS_KEY", ""),
         secret_key: str = os.getenv("VOLCENGINE_SECRET_KEY", ""),
+        session_token: str = os.getenv("VOLCENGINE_SESSION_TOKEN", "")
+        or os.getenv("VOLC_SESSIONTOKEN", ""),
     ) -> None:
-        super().__init__(access_key, secret_key)
+        super().__init__(access_key, secret_key, session_token=session_token)
 
-        self._token: str = ""
+        self._api_token: str = ""
 
     @override
     def _fetch_token(self):
@@ -46,9 +48,10 @@ class VesearchVeAuth(BaseVeAuth):
             version="2025-01-01",
             region="cn-beijing",
             host="open.volcengineapi.com",
+            session_token=self.session_token,
         )
         try:
-            self._token = res["Result"]["api_key_vos"][0]["api_key"]
+            self._api_token = res["Result"]["api_key_vos"][0]["api_key"]
 
             logger.info("Fetching VeSearch token done.")
         except KeyError:
@@ -56,7 +59,7 @@ class VesearchVeAuth(BaseVeAuth):
 
     @property
     def token(self) -> str:
-        if self._token:
-            return self._token
+        if self._api_token:
+            return self._api_token
         self._fetch_token()
-        return self._token
+        return self._api_token

--- a/veadk/cli/cli_deploy.py
+++ b/veadk/cli/cli_deploy.py
@@ -32,6 +32,11 @@ TEMP_PATH = "/tmp"
     help="Volcengine secret key",
 )
 @click.option(
+    "--volcengine-session-token",
+    default=None,
+    help="Volcengine session token (STS, for temporary credentials)",
+)
+@click.option(
     "--vefaas-app-name", required=True, help="Expected Volcengine FaaS application name"
 )
 @click.option(
@@ -71,6 +76,7 @@ TEMP_PATH = "/tmp"
 def deploy(
     volcengine_access_key: str,
     volcengine_secret_key: str,
+    volcengine_session_token: str,
     vefaas_app_name: str,
     veapig_instance_name: str,
     veapig_service_name: str,
@@ -142,6 +148,13 @@ def deploy(
         volcengine_access_key = getenv("VOLCENGINE_ACCESS_KEY")
     if not volcengine_secret_key:
         volcengine_secret_key = getenv("VOLCENGINE_SECRET_KEY")
+    if not volcengine_session_token:
+        volcengine_session_token = getenv("VOLCENGINE_SESSION_TOKEN", "") or getenv(
+            "VOLC_SESSIONTOKEN", ""
+        )
+    if volcengine_session_token:
+        os.environ["VOLCENGINE_SESSION_TOKEN"] = volcengine_session_token
+        veadk_environments["VOLCENGINE_SESSION_TOKEN"] = volcengine_session_token
     if not iam_role:
         iam_role = getenv("IAM_ROLE", None, allow_false_values=True)
     else:

--- a/veadk/cloud/cloud_agent_engine.py
+++ b/veadk/cloud/cloud_agent_engine.py
@@ -89,11 +89,13 @@ class CloudAgentEngine(BaseModel):
             access_key=self.volcengine_access_key,
             secret_key=self.volcengine_secret_key,
             region=self.region,
+            session_token=self.volcengine_session_token,
         )
         self._veapig_service = APIGateway(
             access_key=self.volcengine_access_key,
             secret_key=self.volcengine_secret_key,
             region=self.region,
+            session_token=self.volcengine_session_token,
         )
         self._veidentity_service = IdentityClient(
             access_key=self.volcengine_access_key,

--- a/veadk/integrations/ve_apig/ve_apig.py
+++ b/veadk/integrations/ve_apig/ve_apig.py
@@ -22,14 +22,23 @@ from veadk.utils.volcengine_sign import ve_request
 
 
 class APIGateway:
-    def __init__(self, access_key: str, secret_key: str, region: str = "cn-beijing"):
+    def __init__(
+        self,
+        access_key: str,
+        secret_key: str,
+        region: str = "cn-beijing",
+        session_token: str = "",
+    ):
         self.ak = access_key
         self.sk = secret_key
         self.region = region
+        self.session_token = session_token
         configuration = volcenginesdkcore.Configuration()
         configuration.ak = self.ak
         configuration.sk = self.sk
         configuration.region = region
+        if session_token:
+            configuration.session_token = session_token
 
         self.api_client = volcenginesdkcore.ApiClient(configuration=configuration)
         self.apig_20221112_client = APIG20221112Api(api_client=self.api_client)
@@ -197,6 +206,7 @@ class APIGateway:
             version="2021-03-03",
             region=self.region,
             host="open.volcengineapi.com",
+            session_token=self.session_token,
         )
 
         try:
@@ -233,6 +243,7 @@ class APIGateway:
             version="2021-03-03",
             region=self.region,
             host="open.volcengineapi.com",
+            session_token=self.session_token,
         )
 
         try:

--- a/veadk/integrations/ve_apig/ve_apig_utils.py
+++ b/veadk/integrations/ve_apig/ve_apig_utils.py
@@ -101,23 +101,23 @@ def request(method, date, query, header, region, ak, sk, token, action, body):
         "Content-Type": request_param["content_type"],
     }
     # 第五步：计算 Signature 签名。
-    signed_headers_str = ";".join(
-        ["content-type", "host", "x-content-sha256", "x-date"]
-    )
-    # signed_headers_str = signed_headers_str + ";x-security-token"
+    canonical_header_rows = [
+        "content-type:" + request_param["content_type"],
+        "host:" + request_param["host"],
+        "x-content-sha256:" + x_content_sha256,
+        "x-date:" + x_date,
+    ]
+    signed_headers_list = ["content-type", "host", "x-content-sha256", "x-date"]
+    if token:
+        canonical_header_rows.append("x-security-token:" + token)
+        signed_headers_list.append("x-security-token")
+    signed_headers_str = ";".join(signed_headers_list)
     canonical_request_str = "\n".join(
         [
             request_param["method"].upper(),
             request_param["path"],
             norm_query(request_param["query"]),
-            "\n".join(
-                [
-                    "content-type:" + request_param["content_type"],
-                    "host:" + request_param["host"],
-                    "x-content-sha256:" + x_content_sha256,
-                    "x-date:" + x_date,
-                ]
-            ),
+            "\n".join(canonical_header_rows),
             "",
             signed_headers_str,
             x_content_sha256,
@@ -150,7 +150,8 @@ def request(method, date, query, header, region, ak, sk, token, action, body):
         )
     )
     header = {"Region": region, **header, **sign_result}
-    header = {**header, **{"X-Security-Token": token}}
+    if token:
+        header["X-Security-Token"] = token
     # 第六步：将 Signature 签名写入 HTTP Header 中，并发送 HTTP 请求。
     r = requests.request(
         method=method,
@@ -187,7 +188,7 @@ def validate_and_set_region(region: str = "cn-beijing") -> str:
 
 
 # Uniformly process requests and send requests
-def handle_request(ak, sk, region, action, body) -> str:
+def handle_request(ak, sk, region, action, body, session_token: str = "") -> str:
     """
     Uniformly process and send requests.
 
@@ -195,13 +196,20 @@ def handle_request(ak, sk, region, action, body) -> str:
         region(str): The region of the request.
         action (str): The name of the operation to be performed by the request.
         body (dict): The main content of the request, stored in a dictionary.
+        session_token (str): STS session token for temporary credentials.
 
     Returns:
         str: The response body of the request.
     """
+    import os
+
     date = datetime.datetime.utcnow()
 
-    token = ""
+    token = (
+        session_token
+        or os.getenv("VOLCENGINE_SESSION_TOKEN", "")
+        or os.getenv("VOLC_SESSIONTOKEN", "")
+    )
 
     response_body = request(
         "POST", date, {}, {}, region, ak, sk, token, action, json.dumps(body)

--- a/veadk/integrations/ve_code_pipeline/ve_code_pipeline.py
+++ b/veadk/integrations/ve_code_pipeline/ve_code_pipeline.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 import json
+import os
 from string import Template
 
 import requests
 
+from veadk.auth.veauth.utils import refresh_ak_sk
 from veadk.utils.logger import get_logger
 from veadk.utils.misc import formatted_timestamp
 from veadk.utils.volcengine_sign import ve_request
@@ -109,12 +111,19 @@ def get_dockerfile(tag: str = "latest") -> str:
 class VeCodePipeline:
     def __init__(
         self,
-        volcengine_access_key: str,
-        volcengine_secret_key: str,
+        volcengine_access_key: str = "",
+        volcengine_secret_key: str = "",
+        session_token: str = "",
         region: str = "cn-beijing",
     ) -> None:
-        self.volcengine_access_key = volcengine_access_key
-        self.volcengine_secret_key = volcengine_secret_key
+        cred = refresh_ak_sk(
+            volcengine_access_key or os.getenv("VOLCENGINE_ACCESS_KEY", ""),
+            volcengine_secret_key or os.getenv("VOLCENGINE_SECRET_KEY", ""),
+            session_token,
+        )
+        self.volcengine_access_key = cred.access_key_id
+        self.volcengine_secret_key = cred.secret_access_key
+        self.session_token = cred.session_token
         self.region = region
 
         self.service = "CP"
@@ -146,6 +155,7 @@ class VeCodePipeline:
             region=self.region,
             host=self.host,
             content_type=self.content_type,
+            session_token=self.session_token,
         )
 
         try:
@@ -169,6 +179,7 @@ class VeCodePipeline:
             region=self.region,
             host=self.host,
             content_type=self.content_type,
+            session_token=self.session_token,
         )
 
         try:
@@ -227,6 +238,7 @@ class VeCodePipeline:
             region="cn-beijing",
             host="open.volcengineapi.com",
             content_type="application/json",
+            session_token=self.session_token,
         )
 
         try:
@@ -254,6 +266,7 @@ class VeCodePipeline:
             region=self.region,
             host=self.host,
             content_type=self.content_type,
+            session_token=self.session_token,
         )
 
         webhook_url = ""
@@ -369,6 +382,7 @@ class VeCodePipeline:
             region=self.region,
             host=self.host,
             content_type=self.content_type,
+            session_token=self.session_token,
         )
 
         try:

--- a/veadk/integrations/ve_cr/ve_cr.py
+++ b/veadk/integrations/ve_cr/ve_cr.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import time
 
+from veadk.auth.veauth.utils import refresh_ak_sk
 from veadk.consts import (
     DEFAULT_CR_INSTANCE_NAME,
     DEFAULT_CR_NAMESPACE_NAME,
@@ -26,9 +28,21 @@ logger = get_logger(__name__)
 
 
 class VeCR:
-    def __init__(self, access_key: str, secret_key: str, region: str = "cn-beijing"):
-        self.ak = access_key
-        self.sk = secret_key
+    def __init__(
+        self,
+        access_key: str = "",
+        secret_key: str = "",
+        session_token: str = "",
+        region: str = "cn-beijing",
+    ):
+        cred = refresh_ak_sk(
+            access_key or os.getenv("VOLCENGINE_ACCESS_KEY", ""),
+            secret_key or os.getenv("VOLCENGINE_SECRET_KEY", ""),
+            session_token,
+        )
+        self.ak = cred.access_key_id
+        self.sk = cred.secret_access_key
+        self.session_token = cred.session_token
         self.region = region
         assert region in ["cn-beijing", "cn-guangzhou", "cn-shanghai"]
         self.version = "2022-05-12"
@@ -61,6 +75,7 @@ class VeCR:
             version=self.version,
             region=self.region,
             host=f"cr.{self.region}.volcengineapi.com",
+            session_token=self.session_token,
         )
         logger.debug(f"create cr instance {instance_name}: {response}")
 
@@ -113,6 +128,7 @@ class VeCR:
             version=self.version,
             region=self.region,
             host=f"cr.{self.region}.volcengineapi.com",
+            session_token=self.session_token,
         )
         logger.debug(f"check cr instance {instance_name}: {response}")
 
@@ -150,6 +166,7 @@ class VeCR:
             version=self.version,
             region=self.region,
             host=f"cr.{self.region}.volcengineapi.com",
+            session_token=self.session_token,
         )
         logger.debug(f"create cr namespace {namespace_name}: {response}")
 
@@ -200,6 +217,7 @@ class VeCR:
             version=self.version,
             region=self.region,
             host=f"cr.{self.region}.volcengineapi.com",
+            session_token=self.session_token,
         )
         logger.debug(f"create cr repo {repo_name}: {response}")
 

--- a/veadk/integrations/ve_faas/ve_faas.py
+++ b/veadk/integrations/ve_faas/ve_faas.py
@@ -44,15 +44,24 @@ logger = get_logger(__name__)
 
 
 class VeFaaS:
-    def __init__(self, access_key: str, secret_key: str, region: str = "cn-beijing"):
+    def __init__(
+        self,
+        access_key: str,
+        secret_key: str,
+        region: str = "cn-beijing",
+        session_token: str = "",
+    ):
         self.ak = access_key
         self.sk = secret_key
         self.region = region
+        self.session_token = session_token
 
         configuration = volcenginesdkcore.Configuration()
         configuration.ak = self.ak
         configuration.sk = self.sk
         configuration.region = region
+        if session_token:
+            configuration.session_token = session_token
 
         configuration.client_side_validation = True
         volcenginesdkcore.Configuration.set_default(configuration)
@@ -61,7 +70,7 @@ class VeFaaS:
             volcenginesdkcore.ApiClient(configuration)
         )
 
-        self.apig_client = APIGateway(self.ak, self.sk, self.region)
+        self.apig_client = APIGateway(self.ak, self.sk, self.region, session_token=session_token)
 
         self.template_id = "6874f3360bdbc40008ecf8c7"
 
@@ -99,6 +108,7 @@ class VeFaaS:
             sk=self.sk,
             target="CodeUploadCallback",
             body={"FunctionId": function_id},
+            session_token=self.session_token,
         )
 
         return res
@@ -171,6 +181,7 @@ class VeFaaS:
             version="2021-03-03",
             region="cn-beijing",
             host="open.volcengineapi.com",
+            session_token=self.session_token,
         )
 
         try:
@@ -191,6 +202,7 @@ class VeFaaS:
             version="2021-03-03",
             region="cn-beijing",
             host="open.volcengineapi.com",
+            session_token=self.session_token,
         )
 
         status, full_response = self._get_application_status(app_id)
@@ -232,6 +244,7 @@ class VeFaaS:
             version="2021-03-03",
             region="cn-beijing",
             host="open.volcengineapi.com",
+            session_token=self.session_token,
         )
         return response["Result"]["Status"], response
 
@@ -265,6 +278,7 @@ class VeFaaS:
                     version="2021-03-03",
                     region="cn-beijing",
                     host="open.volcengineapi.com",
+                    session_token=self.session_token,
                 )
                 result = response.get("Result", {})
                 items = result.get("Items", [])
@@ -432,6 +446,7 @@ class VeFaaS:
                 version="2021-03-03",
                 region="cn-beijing",
                 host="open.volcengineapi.com",
+                session_token=self.session_token,
             )
         except Exception as e:
             logger.error(f"Delete application failed. Response: {e}")
@@ -606,6 +621,7 @@ class VeFaaS:
                     version="2021-03-03",
                     region="cn-beijing",
                     host="open.volcengineapi.com",
+                    session_token=self.session_token,
                 )
 
                 current_status = query_resp.get("Result", {}).get("Ready", False)
@@ -622,6 +638,7 @@ class VeFaaS:
                     version="2021-03-03",
                     region="cn-beijing",
                     host="open.volcengineapi.com",
+                    session_token=self.session_token,
                 )
 
                 # Handle EnableUserCrVpcTunnel response correctly
@@ -647,6 +664,7 @@ class VeFaaS:
                     version="2021-03-03",
                     region="cn-beijing",
                     host="open.volcengineapi.com",
+                    session_token=self.session_token,
                 )
 
                 final_status = verify_resp.get("Result", {}).get("Ready", False)
@@ -816,6 +834,7 @@ class VeFaaS:
             version="2021-03-03",
             region="cn-beijing",
             host="open.volcengineapi.com",
+            session_token=self.session_token,
         )
 
         try:

--- a/veadk/integrations/ve_faas/ve_faas_utils.py
+++ b/veadk/integrations/ve_faas/ve_faas_utils.py
@@ -253,23 +253,23 @@ def request(method, date, query, header, ak, sk, token, action, body):
         "Content-Type": request_param["content_type"],
     }
 
-    signed_headers_str = ";".join(
-        ["content-type", "host", "x-content-sha256", "x-date"]
-    )
-    # signed_headers_str = signed_headers_str + ";x-security-token"
+    canonical_header_rows = [
+        "content-type:" + request_param["content_type"],
+        "host:" + request_param["host"],
+        "x-content-sha256:" + x_content_sha256,
+        "x-date:" + x_date,
+    ]
+    signed_headers_list = ["content-type", "host", "x-content-sha256", "x-date"]
+    if token:
+        canonical_header_rows.append("x-security-token:" + token)
+        signed_headers_list.append("x-security-token")
+    signed_headers_str = ";".join(signed_headers_list)
     canonical_request_str = "\n".join(
         [
             request_param["method"].upper(),
             request_param["path"],
             norm_query(request_param["query"]),
-            "\n".join(
-                [
-                    "content-type:" + request_param["content_type"],
-                    "host:" + request_param["host"],
-                    "x-content-sha256:" + x_content_sha256,
-                    "x-date:" + x_date,
-                ]
-            ),
+            "\n".join(canonical_header_rows),
             "",
             signed_headers_str,
             x_content_sha256,
@@ -299,7 +299,8 @@ def request(method, date, query, header, ak, sk, token, action, body):
         )
     )
     header = {**header, **sign_result}
-    header = {**header, **{"X-Security-Token": token}}
+    if token:
+        header["X-Security-Token"] = token
     r = requests.request(
         method=method,
         url="https://{}{}".format(request_param["host"], request_param["path"]),
@@ -310,8 +311,14 @@ def request(method, date, query, header, ak, sk, token, action, body):
     return r.json()
 
 
-def signed_request(ak: str, sk: str, target: str, body: dict):
+def signed_request(
+    ak: str, sk: str, target: str, body: dict, session_token: str = ""
+):
     now = datetime.datetime.utcnow()
+
+    token = session_token or os.getenv(
+        "VOLCENGINE_SESSION_TOKEN", ""
+    ) or os.getenv("VOLC_SESSIONTOKEN", "")
 
     try:
         response_body = request(
@@ -321,7 +328,7 @@ def signed_request(ak: str, sk: str, target: str, body: dict):
             {},
             ak,
             sk,
-            "",
+            token,
             target,
             json.dumps(body),
         )
@@ -334,9 +341,17 @@ def signed_request(ak: str, sk: str, target: str, body: dict):
 
 
 def create_api_gateway_trigger(
-    ak, sk, function_id: str, api_gateway_id: str, service_id: str, region: str = None
+    ak,
+    sk,
+    function_id: str,
+    api_gateway_id: str,
+    service_id: str,
+    region: str = None,
+    session_token: str = "",
 ):
-    token = ""
+    token = session_token or os.getenv(
+        "VOLCENGINE_SESSION_TOKEN", ""
+    ) or os.getenv("VOLC_SESSIONTOKEN", "")
 
     now = datetime.datetime.utcnow()
 
@@ -396,9 +411,11 @@ def create_api_gateway_trigger(
     return response_body
 
 
-def list_routes(ak, sk, upstream_id: str):
+def list_routes(ak, sk, upstream_id: str, session_token: str = ""):
     now = datetime.datetime.utcnow()
-    token = ""
+    token = session_token or os.getenv(
+        "VOLCENGINE_SESSION_TOKEN", ""
+    ) or os.getenv("VOLC_SESSIONTOKEN", "")
 
     body = {"UpstreamId": upstream_id}
 

--- a/veadk/integrations/ve_tls/ve_tls.py
+++ b/veadk/integrations/ve_tls/ve_tls.py
@@ -25,9 +25,11 @@ class VeTLS:
         self,
         access_key: str | None = None,
         secret_key: str | None = None,
+        session_token: str | None = None,
         region: str = "cn-beijing",
     ):
         try:
+            from veadk.auth.veauth.utils import refresh_ak_sk
             from veadk.integrations.ve_tls.utils import ve_tls_request
             from volcengine.tls.TLSService import TLSService
         except ImportError:
@@ -37,20 +39,23 @@ class VeTLS:
 
         self._ve_tls_request = ve_tls_request
 
-        self.access_key = (
-            access_key if access_key else os.getenv("VOLCENGINE_ACCESS_KEY", "")
-        )
-        self.secret_key = (
-            secret_key if secret_key else os.getenv("VOLCENGINE_SECRET_KEY", "")
-        )
+        ak = access_key or os.getenv("VOLCENGINE_ACCESS_KEY", "")
+        sk = secret_key or os.getenv("VOLCENGINE_SECRET_KEY", "")
+        cred = refresh_ak_sk(ak, sk, session_token or "")
+        self.access_key = cred.access_key_id
+        self.secret_key = cred.secret_access_key
+        self.session_token = cred.session_token
         self.region = region
 
-        self._client = TLSService(
+        tls_kwargs = dict(
             endpoint=f"https://tls-{self.region}.volces.com",
             access_key_id=self.access_key,
             access_key_secret=self.secret_key,
             region=self.region,
         )
+        if self.session_token:
+            tls_kwargs["security_token"] = self.session_token
+        self._client = TLSService(**tls_kwargs)
 
     def get_project_id_by_name(self, project_name: str) -> str:
         """Get the ID of a log project by its name.

--- a/veadk/utils/volcengine_sign.py
+++ b/veadk/utils/volcengine_sign.py
@@ -32,6 +32,7 @@ Region = ""
 Host = ""
 ContentType = ""
 Scheme = "https"
+SessionToken = ""
 
 
 def norm_query(params):
@@ -268,23 +269,23 @@ def request(
         "Content-Type": request_param["content_type"],
     }
     # 第五步：计算 Signature 签名。
-    signed_headers_str = ";".join(
-        ["content-type", "host", "x-content-sha256", "x-date"]
-    )
-    # signed_headers_str = signed_headers_str + ";x-security-token"
+    canonical_header_rows = [
+        "content-type:" + request_param["content_type"],
+        "host:" + request_param["host"],
+        "x-content-sha256:" + x_content_sha256,
+        "x-date:" + x_date,
+    ]
+    signed_headers_list = ["content-type", "host", "x-content-sha256", "x-date"]
+    if SessionToken:
+        canonical_header_rows.append("x-security-token:" + SessionToken)
+        signed_headers_list.append("x-security-token")
+    signed_headers_str = ";".join(signed_headers_list)
     canonical_request_str = "\n".join(
         [
             request_param["method"].upper(),
             request_param["path"],
             norm_query(request_param["query"]),
-            "\n".join(
-                [
-                    "content-type:" + request_param["content_type"],
-                    "host:" + request_param["host"],
-                    "x-content-sha256:" + x_content_sha256,
-                    "x-date:" + x_date,
-                ]
-            ),
+            "\n".join(canonical_header_rows),
             "",
             signed_headers_str,
             x_content_sha256,
@@ -320,9 +321,10 @@ def request(
         )
     )
     header = {**header, **sign_result}
+    if SessionToken:
+        header["X-Security-Token"] = SessionToken
     if "X-Security-Token" in header and header["X-Security-Token"] == "":
         del header["X-Security-Token"]
-    # header = {**header, **{"X-Security-Token": SessionToken}}
     # 第六步：将 Signature 签名写入 HTTP Header 中，并发送 HTTP 请求。
     r = requests.request(
         method=method,
@@ -352,6 +354,7 @@ def ve_request(
     query: dict = {},
     method: Literal["GET", "POST", "PUT", "DELETE"] = "POST",
     scheme: Literal["http", "https"] = "https",
+    session_token: str = "",
 ):
     global Service
     Service = service
@@ -365,6 +368,8 @@ def ve_request(
     ContentType = content_type
     global Scheme
     Scheme = scheme
+    global SessionToken
+    SessionToken = session_token
     AK = ak
     SK = sk
     now = datetime.datetime.utcnow()


### PR DESCRIPTION
Add end-to-end support for VOLCENGINE_SESSION_TOKEN (with legacy VOLC_SESSIONTOKEN fallback) so that temporary/STS credentials — intern temp AK/SK, CI roles, SSO logins, VeFaaS IAM — are accepted and correctly included in SigV4-signed requests.

Key fixes:
- volcengine_sign.py: ve_request() now accepts session_token param; the SigV4 signer includes x-security-token in canonical signed headers (was previously commented out / added after signing)
- refresh_ak_sk(): accept session_token param, read from env instead of hardcoding empty string
- BaseVeAuth and all subclasses (VesearchVeAuth, PromptPilotVeAuth, OpensearchVeAuth, PostgreSqlVeAuth): add session_token field with env+IAM credential resolution; rename internal _token cache to _api_token to avoid collision with STS session_token
- registry_client.py: fix SigV4 signing-order bug — X-Security-Token was added after signing, now included in canonical headers
- Integration clients (VeFaaS, VeCR, VeCodePipeline, VeTLS, APIGateway, ve_faas_utils, ve_apig_utils): add session_token parameter, resolve from env/IAM, forward to all ve_request calls and SDK constructors; fix duplicated SigV4 signers to include x-security-token in signed headers
- CloudAgentEngine: forward volcengine_session_token to VeFaaS and APIGateway clients
- CLI: add --volcengine-session-token to `veadk deploy` command

All changes are backward-compatible (session_token defaults to empty).