### PR TITLE
fix(frontend): forward OAuth token to JWT runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ VeADK provides several useful command line tools for faster deployment and optim
 - `veadk deploy`: deploy your project to [Volcengine VeFaaS platform](https://www.volcengine.com/product/vefaas) (you can use `veadk init` to init a demo project first)
 - `veadk prompt`: otpimize the system prompt of your agent by [PromptPilot](https://promptpilot.volcengine.com)
 - `veadk frontend`: serve the A2UI web UI together with the ADK agent API server
+  and forward its validated OAuth access token when connecting to an AgentKit
+  runtime protected by `custom_jwt`
 - `veadk studio deploy`: deploy Studio and ensure its default IAM role has the
   required model, observability, search, security, memory, and identity system
   policies

--- a/docs/content/docs/framework/frontend.en.mdx
+++ b/docs/content/docs/framework/frontend.en.mdx
@@ -100,6 +100,11 @@ protects the API while exempting the SPA shell and `GET /web/auth-config`, so th
 app loads and shows its own login page instead of being bounced to the IdP. The
 login button's label/icon is config-driven (`--oauth2-provider` / `-label`).
 
+When connecting to an AgentKit Runtime protected by `custom_jwt`, the
+server-side proxy forwards the OAuth access token already validated for the
+current session. The token issuer must match the Runtime discovery URL, and its
+client ID must be included in the Runtime `allowed_clients` list.
+
 **Third-party / custom OAuth2 (env vars)** — without a VeIdentity user pool, set
 `OAUTH2_CLIENT_ID` (and secret) to enable GitHub, Google, or any OAuth2/OIDC
 login. Endpoints are resolved in this order: a built-in preset

--- a/docs/content/docs/framework/frontend.mdx
+++ b/docs/content/docs/framework/frontend.mdx
@@ -94,6 +94,8 @@ veadk frontend --agents-dir examples \
 
 需要进程能拿到火山引擎凭证（AK/SK）。中间件保护 API、放行 SPA 外壳与 `GET /web/auth-config`，因此应用能加载并展示自己的登录页（而不是被直接重定向到 IdP）。登录按钮的文案/图标由配置驱动（`--oauth2-provider` / `--oauth2-provider-label`）。
 
+连接使用 `custom_jwt` 鉴权的 AgentKit Runtime 时，服务端代理会转发当前会话中已经验证的 OAuth access token。前端所用 token 的 issuer 必须匹配 Runtime 的 discovery URL，并且 client ID 必须包含在 Runtime 的 `allowed_clients` 中。
+
 **第三方 / 自定义 OAuth2（环境变量）** —— 不依赖 VeIdentity 用户池时，只要设置 `OAUTH2_CLIENT_ID`（及密钥），即可接入 GitHub、Google 或任意 OAuth2/OIDC 登录。端点来源按以下顺序确定：内置预设（`OAUTH2_PROVIDER=github` / `google`）→ OIDC 自动发现（设置 `OAUTH2_ISSUER`）→ 显式端点（`OAUTH2_AUTHORIZE_URL` 等）。
 
 | 环境变量 | 说明 |

--- a/tests/cli/test_frontend_runtime_proxy.py
+++ b/tests/cli/test_frontend_runtime_proxy.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from veadk.cli.cli_frontend import (
+    _build_agentkit_proxy_headers,
+    _run_frontend_server,
+)
+
+
+def _create_frontend_app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> FastAPI:
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr("dotenv.find_dotenv", lambda: "")
+    monkeypatch.setattr(
+        "uvicorn.run",
+        lambda app, **kwargs: captured.setdefault("app", app),
+    )
+    monkeypatch.setenv("VOLCENGINE_ACCESS_KEY", "ak")
+    monkeypatch.setenv("VOLCENGINE_SECRET_KEY", "sk")
+
+    _run_frontend_server(
+        agents_dir=str(tmp_path),
+        frontend_dir=None,
+        host="127.0.0.1",
+        port=8765,
+        dev=True,
+        vite=True,
+        oauth2_user_pool=None,
+        oauth2_user_pool_client=None,
+        oauth2_user_pool_uid=None,
+        oauth2_user_pool_client_uid=None,
+        oauth2_redirect_uri=None,
+        oauth2_provider=None,
+        oauth2_provider_label=None,
+        auth_mode="frontend",
+        generated_agent_test_run_ttl=60,
+        open_browser=False,
+    )
+    return captured["app"]
+
+
+def test_proxy_headers_do_not_forward_unvalidated_authorization() -> None:
+    headers = _build_agentkit_proxy_headers(
+        {
+            "Authorization": "Bearer unvalidated.jwt.token",
+            "Cookie": "session=secret",
+            "Accept": "application/json",
+        },
+        api_key=None,
+    )
+
+    assert headers == {"Accept": "application/json"}
+
+
+@pytest.mark.parametrize(
+    ("authorizer", "expected_authorization"),
+    [
+        (
+            SimpleNamespace(
+                key_auth=None,
+                custom_jwt_authorizer=SimpleNamespace(
+                    discovery_url="https://issuer.example/.well-known/openid-configuration",
+                    allowed_clients=["frontend-client"],
+                ),
+            ),
+            "Bearer validated.jwt.token",
+        ),
+        (
+            SimpleNamespace(
+                key_auth=SimpleNamespace(api_key="runtime-api-key"),
+                custom_jwt_authorizer=None,
+            ),
+            "Bearer runtime-api-key",
+        ),
+    ],
+)
+def test_runtime_proxy_uses_authorizer_credential(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    authorizer: SimpleNamespace,
+    expected_authorization: str,
+) -> None:
+    app = _create_frontend_app(monkeypatch, tmp_path)
+
+    @app.middleware("http")
+    async def _mark_validated_oauth_token(request: Request, call_next):
+        request.state.oauth2_access_token_validated = True
+        request.state.oauth2_access_token = "validated.jwt.token"
+        return await call_next(request)
+
+    class _FakeRuntimeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        def get_runtime(self, request: Any) -> SimpleNamespace:
+            return SimpleNamespace(
+                network_configurations=[
+                    SimpleNamespace(
+                        endpoint="https://runtime.example", network_type="public"
+                    )
+                ],
+                authorizer_configuration=authorizer,
+            )
+
+    monkeypatch.setattr(
+        "agentkit.sdk.runtime.client.AgentkitRuntimeClient",
+        _FakeRuntimeClient,
+    )
+
+    upstream_headers: dict[str, str] = {}
+
+    class _FakeUpstreamResponse:
+        status_code = 200
+        headers = {"content-type": "application/json"}
+
+        async def aiter_raw(self):
+            yield b'["demo_agent"]'
+
+        async def aclose(self) -> None:
+            pass
+
+    class _FakeAsyncClient:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        def build_request(
+            self,
+            method: str,
+            url: str,
+            *,
+            params: dict[str, str],
+            headers: dict[str, str],
+            content: bytes,
+        ) -> object:
+            upstream_headers.update(headers)
+            return object()
+
+        async def send(self, request: object, *, stream: bool) -> _FakeUpstreamResponse:
+            return _FakeUpstreamResponse()
+
+        async def aclose(self) -> None:
+            pass
+
+    monkeypatch.setattr("httpx.AsyncClient", _FakeAsyncClient)
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/web/runtime-proxy/runtime-1/list-apps?region=cn-beijing"
+        )
+
+    assert response.status_code == 200
+    assert response.json() == ["demo_agent"]
+    assert upstream_headers["Authorization"] == expected_authorization

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -151,9 +151,15 @@ def _agentkit_authorization_header(api_key: str) -> str:
 
 
 def _build_agentkit_proxy_headers(
-    incoming_headers: dict[str, str], api_key: str | None
+    incoming_headers: dict[str, str],
+    api_key: str | None,
+    validated_authorization: str | None = None,
 ) -> dict[str, str]:
-    """Return headers safe to forward from the local proxy to AgentKit."""
+    """Return headers safe to forward from the local proxy to AgentKit.
+
+    ``validated_authorization`` must only contain a credential already validated
+    by the frontend OAuth middleware or its trusted upstream gateway.
+    """
     excluded_headers = {
         # Host/proxy control.
         "host",
@@ -179,6 +185,10 @@ def _build_agentkit_proxy_headers(
     }
     if api_key and api_key.strip():
         headers["Authorization"] = _agentkit_authorization_header(api_key)
+    elif validated_authorization and validated_authorization.strip():
+        headers["Authorization"] = _agentkit_authorization_header(
+            validated_authorization
+        )
     return headers
 
 
@@ -2090,16 +2100,16 @@ def _run_frontend_server(
             logger.error(f"list runtimes failed: {e}", exc_info=True)
             raise HTTPException(status_code=502, detail=str(e))
 
-    # Cache resolved (endpoint, apikey) per runtime so the data-plane proxy does
-    # not call GetRuntime on every request. Short TTL; cleared on a 401.
-    _rt_conn_cache: dict[str, tuple] = {}
+    # Cache resolved (endpoint, apikey, auth type) per runtime so the data-plane
+    # proxy does not call GetRuntime on every request. Short TTL; cleared on a 401.
+    _rt_conn_cache: dict[str, tuple[str, str, str, float]] = {}
 
-    def _resolve_runtime_conn(runtime_id: str, region: str) -> tuple[str, str]:
+    def _resolve_runtime_conn(runtime_id: str, region: str) -> tuple[str, str, str]:
         import time as _time
 
         cached = _rt_conn_cache.get(runtime_id)
-        if cached and cached[2] > _time.time():
-            return cached[0], cached[1]
+        if cached and cached[3] > _time.time():
+            return cached[0], cached[1], cached[2]
         ak, sk, token = _resolve_ve_credentials()
         from agentkit.sdk.runtime.client import AgentkitRuntimeClient
         from agentkit.sdk.runtime import types as _rt
@@ -2118,25 +2128,37 @@ def _run_frontend_server(
         apikey = ""
         auth = getattr(r, "authorizer_configuration", None)
         key_auth = getattr(auth, "key_auth", None) if auth else None
+        custom_jwt_auth = getattr(auth, "custom_jwt_authorizer", None) if auth else None
+        auth_type = "none"
         if key_auth:
             apikey = getattr(key_auth, "api_key", "") or ""
+            auth_type = "key_auth"
+        elif custom_jwt_auth:
+            auth_type = "custom_jwt"
         if not endpoint:
             raise HTTPException(
                 status_code=502, detail="runtime has no public endpoint"
             )
-        _rt_conn_cache[runtime_id] = (endpoint, apikey, _time.time() + 300)
-        return endpoint, apikey
+        _rt_conn_cache[runtime_id] = (
+            endpoint,
+            apikey,
+            auth_type,
+            _time.time() + 300,
+        )
+        return endpoint, apikey, auth_type
 
     @app.api_route(
         "/web/runtime-proxy/{runtime_id}/{path:path}",
         methods=["GET", "POST", "DELETE"],
     )
     async def _runtime_proxy(runtime_id: str, path: str, request: Request):
-        """Proxy a data-plane call to a runtime, injecting its apikey server-side
-        (the browser never sees it). Streams the response so /run_sse works."""
+        """Proxy a data-plane call with its runtime credential injected server-side.
+
+        The browser never sees an API key. Streams the response so /run_sse works.
+        """
         region = request.query_params.get("region", "cn-beijing")
         try:
-            endpoint, apikey = _resolve_runtime_conn(runtime_id, region)
+            endpoint, apikey, auth_type = _resolve_runtime_conn(runtime_id, region)
         except HTTPException:
             raise
         except Exception as e:
@@ -2149,7 +2171,26 @@ def _run_frontend_server(
         # Use the shared proxy header builder so Origin/Referer and other
         # browser-only headers are stripped (the ADK server rejects them with
         # "origin not allowed" / 403 otherwise).
-        headers = _build_agentkit_proxy_headers(dict(request.headers), apikey)
+        validated_authorization = None
+        if auth_type == "custom_jwt":
+            access_token = getattr(request.state, "oauth2_access_token", None)
+            if (
+                getattr(request.state, "oauth2_access_token_validated", False)
+                and access_token
+            ):
+                validated_authorization = access_token
+            elif auth_mode == "gateway":
+                incoming_authorization = request.headers.get("authorization")
+                if _claims_from_forwarded_jwt(incoming_authorization):
+                    validated_authorization = incoming_authorization
+            if not validated_authorization:
+                raise HTTPException(
+                    status_code=401,
+                    detail="OAuth runtime requires an authenticated frontend session",
+                )
+        headers = _build_agentkit_proxy_headers(
+            dict(request.headers), apikey, validated_authorization
+        )
         body = await request.body()
 
         from fastapi.responses import StreamingResponse


### PR DESCRIPTION
## Summary

- detect AgentKit runtimes protected by custom JWT authorizers
- forward only OAuth access tokens already validated by the frontend or trusted gateway
- preserve API-key behavior and continue stripping unvalidated browser credentials
- document issuer and allowed-client requirements

## Testing

- uv run pytest -q tests/cli/test_generated_agent_backend_codegen_extended.py tests/cli/test_frontend_runtime_proxy.py
- uv run ruff check veadk/cli/cli_frontend.py tests/cli/test_frontend_runtime_proxy.py
- uv run ruff format --check veadk/cli/cli_frontend.py tests/cli/test_frontend_runtime_proxy.py
- uv run pyright tests/cli/test_frontend_runtime_proxy.py
- Markdown lint for the updated README and frontend documentation