### PR TITLE
fix(release): avoid vendoring PiAgent binary

### DIFF
--- a/.github/workflows/publish-tag-to-pypi.yaml
+++ b/.github/workflows/publish-tag-to-pypi.yaml
@@ -23,6 +23,14 @@ jobs:
         run: python3 -m pip install build --user --upgrade
       - name: Build wheel and source distribution
         run: python3 -m build
+      - name: Reject distributions over the PyPI file-size limit
+        run: |
+          oversized_file="$(find dist -type f -size +100M -print -quit)"
+          if [ -n "${oversized_file}" ]; then
+            bytes="$(stat -c%s "${oversized_file}")"
+            echo "Distribution exceeds PyPI's 100 MiB limit: ${oversized_file} (${bytes} bytes)"
+            exit 1
+          fi
       - name: Upload distributables as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,6 @@ cython_debug/
 agentkit.yaml
 agentkit*.yaml
 .agentkit/
+
+# PiAgent release archives are downloaded and verified during image builds.
+examples/piagent_with_mcp/vendor/pi-*.tar.gz

--- a/examples/piagent_with_mcp/Dockerfile
+++ b/examples/piagent_with_mcp/Dockerfile
@@ -5,48 +5,26 @@ ARG PIAGENT_SHA256=f7c383b3dbf336b97174249ef40baed86e295416af77a81ff5288ac17cb71
 
 ENV UV_SYSTEM_PYTHON=1
 ENV PYTHONUNBUFFERED=1
-ENV PIAGENT_BINARY=/opt/piagent/pi/pi
 ENV PIAGENT_INSTALL_DIR=/opt/piagent
 ENV PIAGENT_AGENT_DIR=/tmp/veadk-piagent-home
 ENV OTEL_SDK_DISABLED=true
 
 WORKDIR /app
 
-COPY vendor/pi-linux-x64.tar.gz /tmp/pi-linux-x64.tar.gz
 COPY vendor/veadk_python-*.whl /tmp/
 
-RUN PIAGENT_VERSION="${PIAGENT_VERSION}" PIAGENT_SHA256="${PIAGENT_SHA256}" python - <<'PY'
-import hashlib
-import os
-import tarfile
-from pathlib import Path
+RUN uv pip install --system /tmp/veadk_python-*.whl
 
-version = os.environ["PIAGENT_VERSION"]
-sha256 = os.environ["PIAGENT_SHA256"]
-archive = Path("/tmp/pi-linux-x64.tar.gz")
-target = Path("/opt/piagent")
+RUN PIAGENT_BINARY_VERSION="${PIAGENT_VERSION}" \
+    PIAGENT_BINARY_SHA256="${PIAGENT_SHA256}" \
+    python - <<'PY'
+from veadk.runtime.piagent.installer import resolve_or_install_piagent_binary
 
-print(f"Installing vendored Pi binary archive for version {version}")
-digest = hashlib.sha256(archive.read_bytes()).hexdigest()
-if digest != sha256:
-    raise SystemExit(f"Pi binary sha256 mismatch: expected {sha256}, got {digest}")
-
-target.mkdir(parents=True, exist_ok=True)
-with tarfile.open(archive) as tar:
-    for member in tar.getmembers():
-        destination = (target / member.name).resolve()
-        if not str(destination).startswith(str(target.resolve()) + "/"):
-            raise SystemExit(f"Refusing unsafe tar member: {member.name}")
-    tar.extractall(target)
-
-binary = target / "pi" / "pi"
-if not binary.exists():
-    raise SystemExit(f"Pi binary not found after extraction: {binary}")
-binary.chmod(0o755)
+binary = resolve_or_install_piagent_binary()
 print(f"Installed Pi binary to {binary}")
 PY
 
-RUN uv pip install --system /tmp/veadk_python-*.whl
+ENV PIAGENT_BINARY=/opt/piagent/pi/pi
 
 COPY requirements.txt ./
 RUN uv pip install --system -r requirements.txt

--- a/examples/piagent_with_mcp/README.md
+++ b/examples/piagent_with_mcp/README.md
@@ -36,7 +36,6 @@ piagent_with_mcp/
 ├── requirements.txt
 ├── piagent-mcp-agentkit.yaml        # veadk agentkit launch config
 ├── vendor/
-│   ├── pi-linux-x64.tar.gz          # Pi Linux binary archive for cloud image
 │   └── veadk_python-*.whl           # local VeADK build installed by Dockerfile
 └── agents/
     └── piagent_mcp_agent/
@@ -74,7 +73,9 @@ veadk frontend --agents-dir examples
 Select `piagent_with_mcp` in the app dropdown and ask:
 
 ```text
-Please check Beijing weather, Beijing air quality, and order A10086 status. You must call the relevant tools before answering. Also use the PiAgent E2E skill and include the skill marker.
+Please check Beijing weather, Beijing air quality, and order A10086
+status. You must call the relevant tools before answering. Also use the
+PiAgent E2E skill and include the skill marker.
 ```
 
 You can also test each MCP independently:
@@ -92,13 +93,10 @@ parent directory that contains agent app folders.
 ## Deploy To AgentKit
 
 This example is structured like `examples/piagent_runtime_basic`: AgentKit runs
-`app.py`, which serves the ADK API from the `agents/` directory.
-
-The Dockerfile expects a Linux Pi binary archive at:
-
-```text
-vendor/pi-linux-x64.tar.gz
-```
+`app.py`, which serves the ADK API from the `agents/` directory. During the
+image build, the Dockerfile uses VeADK's PiAgent installer to download Pi
+`v0.80.6` from its GitHub release, verify its SHA256 checksum, and install it
+under `/opt/piagent`.
 
 It also expects exactly one local VeADK wheel at:
 
@@ -118,16 +116,9 @@ cp dist/veadk_python-*.whl examples/piagent_with_mcp/vendor/
 
 The AgentKit image installs this vendored wheel directly, so the cloud runtime
 uses the same local VeADK code that produced the wheel. Re-run `uv build` and
-copy the wheel again whenever the PiAgent runtime code changes.
-
-For local pre-release testing, this can be copied from the basic PiAgent
-example if both examples use the same Pi version:
-
-```bash
-mkdir -p examples/piagent_with_mcp/vendor
-cp examples/piagent_runtime_basic/vendor/pi-linux-x64.tar.gz \
-  examples/piagent_with_mcp/vendor/pi-linux-x64.tar.gz
-```
+copy the wheel again whenever the PiAgent runtime code changes. Override the
+Docker build arguments `PIAGENT_VERSION` and `PIAGENT_SHA256` together when
+testing another Pi release.
 
 Then launch from this example directory:
 
@@ -141,7 +132,9 @@ Invoke after the runtime is ready:
 
 ```bash
 veadk agentkit invoke --config-file piagent-mcp-agentkit.yaml \
-  -m "Please check Beijing weather, Beijing air quality, and order A10086 status. You must call the relevant tools before answering. Also use the PiAgent E2E skill and include the skill marker."
+  -m "Please check Beijing weather, Beijing air quality, and order A10086 \
+status. You must call the relevant tools before answering. Also use the \
+PiAgent E2E skill and include the skill marker."
 ```
 
 Expected runtime logs should include lines similar to:


### PR DESCRIPTION
## Summary

- remove the 46.9 MB Pi Linux release archive from the repository
- install pinned Pi v0.80.6 during the example image build through the existing installer and verify its SHA256 checksum
- reject distributions over the PyPI 100 MiB file-size limit before uploading artifacts
- update the PiAgent MCP deployment documentation and ignore downloaded Pi archives

## Validation

- 40 PiAgent runtime tests passed
- Ruff and Pyright passed for the PiAgent installer
- Markdown lint passed for the updated example README
- wheel and sdist passed twine check
- sdist reduced from 105,411,022 bytes to 59,929,252 bytes and no longer contains the Pi archive
- pinned Pi release downloaded, checksum-verified, and extracted successfully