### PR TITLE
fix(agentkit): surface cloud build failure details

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ app = create_agentkit_app(root_agent)
 See [`examples/generated_agentkit_project`](examples/generated_agentkit_project)
 for a complete generated project.
 
+When a cloud image build fails from the bundled Web UI, the deployment error
+includes a credential-safe excerpt from the build log so dependency and
+Dockerfile failures can be diagnosed directly.
+
 ## Feishu bot channel
 
 VeADK now provides `veadk.extensions.FeishuChannelExtension` for bridging a Feishu bot with a `Runner`. It maps `union_id` to `user_id`, and `thread_id` / `chat_id` to `session_id`, so VeADK memory and tracing can work directly in Feishu conversations.

--- a/docs/content/docs/framework/agentkit.en.mdx
+++ b/docs/content/docs/framework/agentkit.en.mdx
@@ -68,4 +68,8 @@ veadk agentkit launch
 
 </Steps>
 
+When deploying from the bundled Web UI, cloud image build failures include a
+credential-safe build-log excerpt so dependency resolution and Dockerfile
+errors can be diagnosed directly.
+
 `veadk agentkit` passes through all of AgentKit's subcommands (such as `build`, `deploy`, `status`, and `destroy`). For the full command list and descriptions, see [AgentKit-Compatible Commands](/en/docs/cli/agentkit-cli); for more detailed platform deployment steps, see the [AgentKit documentation](https://volcengine.github.io/agentkit-sdk-python/content/2.agentkit-cli/1.overview.html).

--- a/docs/content/docs/framework/agentkit.mdx
+++ b/docs/content/docs/framework/agentkit.mdx
@@ -65,4 +65,7 @@ veadk agentkit launch
 
 </Steps>
 
+通过内置 Web UI 部署时，如果云端镜像构建失败，部署错误会显示经过凭据脱敏的
+构建日志关键片段，便于直接定位依赖解析或 Dockerfile 执行错误。
+
 `veadk agentkit` 透传了 AgentKit 的全部子命令（如 `build`、`deploy`、`status`、`destroy` 等）。完整命令列表与说明见 [AgentKit 命令兼容](/cn/docs/cli/agentkit-cli)，更详细的平台部署步骤见 [AgentKit 官方文档](https://volcengine.github.io/agentkit-sdk-python/content/2.agentkit-cli/1.overview.html)。

--- a/tests/cli/test_frontend_deploy_errors.py
+++ b/tests/cli/test_frontend_deploy_errors.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from veadk.cli.cli_frontend import _extract_build_error_excerpt
+
+
+def test_extract_build_error_excerpt_keeps_dependency_resolution_cause() -> None:
+    lines = [
+        "#10 0.1 Using Python 3.12",
+        "\x1b[31m× No solution found when resolving dependencies:\x1b[0m",
+        "╰─▶ Because only veadk-python<=1.0.4 is available",
+        "    and you require veadk-python>=1.0.5,",
+        "    your requirements are unsatisfiable.",
+        "#10 ERROR: process did not complete successfully",
+    ]
+
+    excerpt = _extract_build_error_excerpt(lines)
+
+    assert "\x1b" not in excerpt
+    assert "veadk-python<=1.0.4" in excerpt
+    assert "veadk-python>=1.0.5" in excerpt
+    assert "requirements are unsatisfiable" in excerpt
+
+
+def test_extract_build_error_excerpt_removes_credentials() -> None:
+    lines = [
+        "VOLCENGINE_ACCESS_KEY=temporary-access-key",
+        "VOLCENGINE_SECRET_KEY=temporary-secret-key",
+        "Authorization: Bearer temporary.jwt.token",
+        "X-Tos-Security-Token=temporary-session-token",
+        "CR_TOKEN=temporary-registry-token",
+        "API_KEY=temporary-api-key",
+        "No solution found when resolving dependencies:",
+        "Because only veadk-python<=1.0.4 is available",
+        "and you require veadk-python>=1.0.5",
+        "docker login --password temporary-registry-token registry.example.com",
+    ]
+
+    excerpt = _extract_build_error_excerpt(lines)
+
+    assert "temporary" not in excerpt
+    assert "veadk-python>=1.0.5" in excerpt
+
+
+def test_extract_build_error_excerpt_ignores_successful_logs() -> None:
+    lines = [
+        "Step 1/2: Building image",
+        "Successfully built image",
+        "Step 2/2: Deploying service",
+        "Runtime status: Ready",
+    ]
+
+    assert _extract_build_error_excerpt(lines) == ""

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -26,8 +26,10 @@ runtimes (the UI is still served).
 import asyncio
 import json
 import os
+import re
 import sys
 
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -36,6 +38,66 @@ import click
 from veadk.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_BUILD_ERROR_MARKERS = (
+    "no solution found",
+    "unsatisfiable",
+    "failed to solve",
+    "did not complete successfully",
+    "no matching distribution",
+    "modulenotfounderror",
+    "command not found",
+    "permission denied",
+    "traceback (most recent call last)",
+)
+_SENSITIVE_LOG_PATTERNS = (
+    re.compile(r"authorization\s*[:=]", re.IGNORECASE),
+    re.compile(r"\bbearer\s+\S+", re.IGNORECASE),
+    re.compile(
+        r"(?:access[_ -]?key(?:[_ -]?id)?|secret[_ -]?key|api[_ -]?key|"
+        r"client[_ -]?secret|private[_ -]?key|(?:access|session|security|refresh|"
+        r"id|jwt|cr)[_ -]?token|password|credential|signature)"
+        r"\s*(?:=|:|\s)\s*\S+",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\."
+        r"[A-Za-z0-9_-]{10,}\b"
+    ),
+)
+
+
+def _extract_build_error_excerpt(
+    lines: Iterable[object] | str, max_lines: int = 30
+) -> str:
+    """Return a credential-safe excerpt around high-signal build errors."""
+    if max_lines <= 0:
+        return ""
+    raw_lines = lines.splitlines() if isinstance(lines, str) else lines
+    clean_lines = []
+    for raw_line in raw_lines:
+        line = _ANSI_ESCAPE_RE.sub("", str(raw_line)).strip()
+        if not line or any(pattern.search(line) for pattern in _SENSITIVE_LOG_PATTERNS):
+            continue
+        clean_lines.append(line[:1000])
+
+    error_indexes = [
+        index
+        for index, line in enumerate(clean_lines)
+        if any(marker in line.lower() for marker in _BUILD_ERROR_MARKERS)
+    ]
+    if not error_indexes:
+        return ""
+
+    selected_indexes = set()
+    for index in error_indexes:
+        selected_indexes.update(
+            range(max(0, index - 3), min(len(clean_lines), index + 4))
+        )
+    return "\n".join(
+        clean_lines[index] for index in sorted(selected_indexes)[:max_lines]
+    )
 
 
 def _claims_from_forwarded_jwt(authorization: str | None) -> dict | None:
@@ -1747,7 +1809,7 @@ def _run_frontend_server(
             "destroying": False,
         }
         events: "_queue.Queue" = _queue.Queue()
-        state = {"phase": "build"}
+        state = {"phase": "build", "build_error_excerpt": ""}
 
         _PHASE_ORDER = {"build": 0, "deploy": 1, "publish": 2}
 
@@ -1779,6 +1841,13 @@ def _run_frontend_server(
                     "已自动重试一次仍失败，请稍后重新点击部署。"
                 )
             return error_text
+
+        def _error_with_build_excerpt(error_text: str) -> str:
+            error_text = _friendly_error(error_text)
+            excerpt = state["build_error_excerpt"]
+            if not excerpt or excerpt in error_text:
+                return error_text
+            return f"{error_text}\n\n构建日志关键错误：\n{excerpt}"
 
         def _classify(message: str) -> str:
             """Map a reporter message to a deploy phase, monotonically.
@@ -1866,6 +1935,10 @@ def _run_frontend_server(
 
             def show_logs(self, title, lines, max_lines=100):
                 _emit("info", str(title))
+                excerpt = _extract_build_error_excerpt(lines, min(max_lines, 30))
+                if excerpt:
+                    state["build_error_excerpt"] = excerpt
+                    _emit("error", excerpt)
 
         result_box: dict = {}
 
@@ -1930,6 +2003,7 @@ def _run_frontend_server(
                 try:
                     result = None
                     for attempt in range(1, 3):
+                        state["build_error_excerpt"] = ""
                         if attempt > 1:
                             state["phase"] = "build"
                             _emit(
@@ -1998,7 +2072,7 @@ def _run_frontend_server(
                     final.update(
                         {
                             "success": False,
-                            "error": _friendly_error(error_text),
+                            "error": _error_with_build_excerpt(error_text),
                             "phase": state["phase"],
                         }
                     )
@@ -2045,7 +2119,7 @@ def _run_frontend_server(
                         final.update(
                             {
                                 "success": False,
-                                "error": _friendly_error(err_text)
+                                "error": _error_with_build_excerpt(err_text)
                                 or err
                                 or "Deployment failed",
                                 "phase": state["phase"],


### PR DESCRIPTION
## Summary

- extract high-signal diagnostics from failed cloud build logs
- remove credential-bearing lines and ANSI control sequences before returning log excerpts
- append the sanitized root cause to the final deployment error shown by the Web UI
- document the behavior and add regression coverage for dependency failures and credential filtering

## Testing

- `.venv/bin/pytest -q tests/cli/test_frontend_deploy_errors.py tests/cli/test_frontend_trace.py`
- `.venv/bin/ruff check veadk/cli/cli_frontend.py tests/cli/test_frontend_deploy_errors.py`
- `.venv/bin/ruff format --check veadk/cli/cli_frontend.py tests/cli/test_frontend_deploy_errors.py`
- `.venv/bin/pre-commit run gitleaks --files veadk/cli/cli_frontend.py tests/cli/test_frontend_deploy_errors.py README.md docs/content/docs/framework/agentkit.mdx docs/content/docs/framework/agentkit.en.mdx`