### PR TITLE
fix(studio): preserve default title on deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ VeADK provides several useful command line tools for faster deployment and optim
 - `veadk frontend`: serve the A2UI web UI together with the ADK agent API server
   and forward its validated OAuth access token when connecting to an AgentKit
   runtime protected by `custom_jwt`; customize its browser/sidebar branding with
-  `--site-title` and `--site-logo`
+  `--site-title` and `--site-logo` (omitting the title keeps `VeADK Studio`)
 - `veadk studio deploy`: deploy Studio and ensure its default IAM role has the
   required model, observability, search, security, memory, and identity system
   policies; custom local or remote logo images are bundled into the deployment

--- a/docs/content/docs/framework/frontend.en.mdx
+++ b/docs/content/docs/framework/frontend.en.mdx
@@ -134,6 +134,8 @@ The frontend sends structured `veadkInvocation` metadata instead of inferring in
 Use `--site-title` for a system name of up to six characters and `--site-logo`
 for a local image or HTTP(S) image URL. The logo is used in the sidebar, login
 page, and browser favicon; the system name also becomes the browser page title.
+Omitting `--site-title` keeps the default `VeADK Studio` name; the six-character
+limit applies only to custom names.
 
 ```bash
 veadk studio --site-title 火山助手 --site-logo ./logo.png

--- a/docs/content/docs/framework/frontend.mdx
+++ b/docs/content/docs/framework/frontend.mdx
@@ -126,6 +126,7 @@ veadk frontend --agents-dir examples
 使用 `--site-title` 设置不超过 6 个字符的系统名称，使用
 `--site-logo` 指定本地图片或 HTTP(S) 图片地址。Logo 会同时用于
 侧边栏、登录页和浏览器 favicon，系统名称也会作为浏览器页面标题。
+不传 `--site-title` 时保留默认名称 `VeADK Studio`；6 字符限制只适用于自定义名称。
 
 ```bash
 veadk studio --site-title 火山助手 --site-logo ./logo.png

--- a/tests/cli/test_frontend_branding.py
+++ b/tests/cli/test_frontend_branding.py
@@ -102,8 +102,15 @@ def test_resolve_site_logo_downloads_network_image(
     assert logo.media_type == "image/png"
 
 
-def test_studio_deploy_bundles_logo_and_title(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+@pytest.mark.parametrize(
+    ("title_args", "expected_site_title"),
+    [([], None), (["--site-title", "火山助手"], "火山助手")],
+)
+def test_studio_deploy_bundles_logo_and_optional_title(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    title_args: list[str],
+    expected_site_title: str | None,
 ) -> None:
     logo_path = tmp_path / "logo.png"
     logo_path.write_bytes(_PNG)
@@ -132,32 +139,31 @@ def test_studio_deploy_bundles_logo_and_title(
         "veadk.cloud.cloud_agent_engine.CloudAgentEngine", _FakeCloudAgentEngine
     )
 
-    result = CliRunner().invoke(
-        studio,
-        [
-            "deploy",
-            "--user-pool-id",
-            "pool-id",
-            "--allowed-client-id",
-            "client-id",
-            "--vefaas-app-name",
-            "branded-studio",
-            "--iam-role",
-            "trn:iam::role/test",
-            "--gateway-name",
-            "gateway",
-            "--volcengine-access-key",
-            "ak",
-            "--volcengine-secret-key",
-            "sk",
-            "--site-title",
-            "火山助手",
-            "--site-logo",
-            str(logo_path),
-        ],
-    )
+    args = [
+        "deploy",
+        "--user-pool-id",
+        "pool-id",
+        "--allowed-client-id",
+        "client-id",
+        "--vefaas-app-name",
+        "branded-studio",
+        "--iam-role",
+        "trn:iam::role/test",
+        "--gateway-name",
+        "gateway",
+        "--volcengine-access-key",
+        "ak",
+        "--volcengine-secret-key",
+        "sk",
+        "--site-logo",
+        str(logo_path),
+    ]
+    result = CliRunner().invoke(studio, args + title_args)
 
     assert result.exit_code == 0, result.output
     assert captured["logo"] == _PNG
     assert '--site-logo "$ROOT_DIR/site-logo.png"' in str(captured["run_script"])
-    assert environments["VEADK_SITE_TITLE"] == "火山助手"
+    if expected_site_title is None:
+        assert "VEADK_SITE_TITLE" not in environments
+    else:
+        assert environments["VEADK_SITE_TITLE"] == expected_site_title

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -3169,7 +3169,8 @@ def frontend_deploy(
     veadk_environments["OAUTH2_USER_POOL_ID"] = user_pool_id
     veadk_environments["OAUTH2_USER_POOL_CLIENT_ID"] = allowed_client_id
     veadk_environments["OAUTH2_PROVIDER"] = "veidentity"
-    veadk_environments["VEADK_SITE_TITLE"] = branding_title
+    if site_title is not None:
+        veadk_environments["VEADK_SITE_TITLE"] = branding_title
     if client_secret:
         veadk_environments["OAUTH2_CLIENT_SECRET"] = client_secret
 


### PR DESCRIPTION
## Summary

- avoid exporting the built-in VeADK Studio title as a custom deployment title
- preserve the six-character limit for explicitly customized titles
- cover both default and customized deployment branding
- clarify default-title behavior in the README and frontend documentation

## Testing

- 11 Studio branding and deployment tests passed
- Ruff check and format check passed
- Pyright passed for the updated regression tests
- Markdown lint passed for the updated documentation