### PR TITLE
feat(studio): provision ServerlessApplicationRole on deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ renderer directory (`frontend/src/a2ui/components/<Name>/`). See
 
 ## Command line tools
 
+`veadk studio deploy` automatically provisions `ServerlessApplicationRole`
+when the required VeFaaS role is missing.
+
 VeADK provides several useful command line tools for faster deployment and optimization, such as:
 
 - `veadk deploy`: deploy your project to [Volcengine VeFaaS platform](https://www.volcengine.com/product/vefaas) (you can use `veadk init` to init a demo project first)

--- a/docs/content/docs/framework/frontend.en.mdx
+++ b/docs/content/docs/framework/frontend.en.mdx
@@ -159,6 +159,23 @@ veadk studio deploy \
 
 ### IAM permissions for `veadk studio deploy`
 
+The deploy command first checks `ServerlessApplicationRole`. If the role is
+missing, the terminal shows a yellow warning and creates it automatically. It
+also creates or reuses the custom `vefaas_full_access` policy and attaches these
+policies, all with Global scope:
+
+- `CloudMonitorReadOnlyAccess`
+- `vefaas_full_access`
+- `VPCFullAccess`
+- `TLSFullAccess`
+- `APIGFullAccess`
+- `ECSFullAccess`
+- `VeFaaSFullAccess`
+- `STSAssumeRoleAccess`
+
+This check runs even when `--iam-role` is provided. The deployment AK/SK must
+be allowed to inspect and create IAM roles and policies and to attach policies.
+
 When `--iam-role` is omitted, the deploy command creates or reuses `VeADKFrontendServiceRole` and ensures that the role has these Volcengine system policies:
 
 - `ArkReadOnlyAccess`

--- a/docs/content/docs/framework/frontend.mdx
+++ b/docs/content/docs/framework/frontend.mdx
@@ -149,6 +149,22 @@ veadk studio deploy \
 
 ### `veadk studio deploy` 的 IAM 权限
 
+部署命令会先检查 `ServerlessApplicationRole`。如果该 Role 不存在，终端会显示
+黄色提示并自动创建 Role，同时创建或复用自定义策略 `vefaas_full_access`，然后
+绑定以下策略（作用域均为 Global）：
+
+- `CloudMonitorReadOnlyAccess`
+- `vefaas_full_access`
+- `VPCFullAccess`
+- `TLSFullAccess`
+- `APIGFullAccess`
+- `ECSFullAccess`
+- `VeFaaSFullAccess`
+- `STSAssumeRoleAccess`
+
+该检查不受 `--iam-role` 影响；部署使用的 AK/SK 需要具备查询、创建 IAM
+Role/策略以及绑定策略的权限。
+
 未传入 `--iam-role` 时，部署命令会创建或复用 `VeADKFrontendServiceRole`，并确保该 Role 绑定以下火山引擎系统策略：
 
 - `ArkReadOnlyAccess`

--- a/tests/cli/test_frontend_branding.py
+++ b/tests/cli/test_frontend_branding.py
@@ -138,6 +138,10 @@ def test_studio_deploy_bundles_logo_and_optional_title(
     monkeypatch.setattr(
         "veadk.cloud.cloud_agent_engine.CloudAgentEngine", _FakeCloudAgentEngine
     )
+    monkeypatch.setattr(
+        "veadk.cli.studio_deploy_serverless_iam.ensure_serverless_application_role",
+        lambda *_: False,
+    )
 
     args = [
         "deploy",

--- a/tests/cli/test_studio_deploy_serverless_iam.py
+++ b/tests/cli/test_studio_deploy_serverless_iam.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+import pytest
+from click.testing import CliRunner
+
+from veadk.cli.cli_frontend import studio
+from veadk.cli.studio_deploy_serverless_iam import (
+    CUSTOM_POLICY_NAME,
+    ROLE_NAME,
+    SYSTEM_POLICIES,
+    ensure_serverless_application_role,
+)
+
+
+def _install_iam_service(monkeypatch: pytest.MonkeyPatch, service: MagicMock) -> None:
+    iam_module = importlib.import_module("volcengine.iam.IamService")
+    monkeypatch.setattr(iam_module, "IamService", lambda: service)
+
+
+def _iam_error(code: str, message: str) -> Exception:
+    return Exception(
+        json.dumps({"ResponseMetadata": {"Error": {"Code": code, "Message": message}}})
+    )
+
+
+def test_existing_role_is_reused(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = MagicMock()
+    service.get_role.return_value = {"Result": {"Role": {"RoleName": ROLE_NAME}}}
+    _install_iam_service(monkeypatch, service)
+
+    created = ensure_serverless_application_role("ak", "sk")
+
+    assert created is False
+    service.get_policy.assert_not_called()
+    service.create_policy.assert_not_called()
+    service.create_role.assert_not_called()
+    service.attach_role_policy.assert_not_called()
+
+
+def test_missing_role_is_created_with_all_policies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = MagicMock()
+    service.get_role.side_effect = _iam_error("RoleNotExist", "role not found")
+    service.get_policy.side_effect = _iam_error("PolicyNotExist", "policy not found")
+    service.create_policy.return_value = {"Result": {}}
+    service.create_role.return_value = {"Result": {"Role": {"RoleName": ROLE_NAME}}}
+    service.attach_role_policy.return_value = {"Result": {}}
+    _install_iam_service(monkeypatch, service)
+
+    role_module = importlib.import_module("veadk.cli.studio_deploy_serverless_iam")
+    warning = MagicMock()
+    monkeypatch.setattr(role_module.click, "secho", warning)
+
+    created = ensure_serverless_application_role("ak", "sk")
+
+    assert created is True
+    warning.assert_called_once()
+    assert "automatically" in warning.call_args.args[0]
+    assert warning.call_args.kwargs == {"fg": "yellow"}
+    service.create_policy.assert_called_once()
+    service.create_role.assert_called_once()
+    assert service.attach_role_policy.call_args_list == [
+        call(
+            {
+                "RoleName": ROLE_NAME,
+                "PolicyName": CUSTOM_POLICY_NAME,
+                "PolicyType": "Custom",
+            }
+        ),
+        *[
+            call(
+                {
+                    "RoleName": ROLE_NAME,
+                    "PolicyName": policy_name,
+                    "PolicyType": "System",
+                }
+            )
+            for policy_name in SYSTEM_POLICIES
+        ],
+    ]
+
+
+def test_existing_custom_policy_is_reused_when_role_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = MagicMock()
+    service.get_role.side_effect = _iam_error("RoleNotExist", "role not found")
+    service.get_policy.return_value = {
+        "Result": {"Policy": {"PolicyName": CUSTOM_POLICY_NAME}}
+    }
+    service.create_role.return_value = {"Result": {"Role": {"RoleName": ROLE_NAME}}}
+    service.attach_role_policy.return_value = {"Result": {}}
+    _install_iam_service(monkeypatch, service)
+
+    ensure_serverless_application_role("ak", "sk")
+
+    service.create_policy.assert_not_called()
+
+
+def test_role_lookup_permission_error_fails_fast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = MagicMock()
+    service.get_role.side_effect = _iam_error("AccessDenied", "permission denied")
+    _install_iam_service(monkeypatch, service)
+
+    with pytest.raises(Exception, match="permission denied"):
+        ensure_serverless_application_role("ak", "sk")
+
+    service.create_role.assert_not_called()
+
+
+def test_studio_deploy_checks_serverless_role_with_custom_function_role(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checked_credentials: list[tuple[str, str]] = []
+
+    class _FakeCloudAgentEngine:
+        def __init__(self, **_: object) -> None:
+            pass
+
+        def deploy(self, **_: object) -> SimpleNamespace:
+            return SimpleNamespace(
+                vefaas_endpoint="",
+                vefaas_application_id="app-id",
+                vefaas_function_id="",
+            )
+
+    monkeypatch.setattr(
+        "veadk.cli.studio_deploy_serverless_iam.ensure_serverless_application_role",
+        lambda access_key, secret_key: checked_credentials.append(
+            (access_key, secret_key)
+        ),
+    )
+    monkeypatch.setattr(
+        "veadk.cloud.cloud_agent_engine.CloudAgentEngine", _FakeCloudAgentEngine
+    )
+
+    result = CliRunner().invoke(
+        studio,
+        [
+            "deploy",
+            "--user-pool-id",
+            "pool-id",
+            "--allowed-client-id",
+            "client-id",
+            "--vefaas-app-name",
+            "studio-app",
+            "--iam-role",
+            "trn:iam::role/test",
+            "--gateway-name",
+            "gateway",
+            "--volcengine-access-key",
+            "ak",
+            "--volcengine-secret-key",
+            "sk",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert checked_credentials == [("ak", "sk")]

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -3138,7 +3138,14 @@ def frontend_deploy(
             "or pass --volcengine-access-key/--volcengine-secret-key."
         )
 
-    # 1) Ensure the IAM role the function runs as (auto-create unless provided).
+    # 1) Ensure VeFaaS has its service role before provisioning cloud resources.
+    from veadk.cli.studio_deploy_serverless_iam import (
+        ensure_serverless_application_role,
+    )
+
+    ensure_serverless_application_role(ak, sk)
+
+    # 2) Ensure the IAM role the function runs as (auto-create unless provided).
     if iam_role:
         role_trn = iam_role
         click.echo(f"Using provided IAM role: {role_trn}")
@@ -3174,7 +3181,7 @@ def frontend_deploy(
     if client_secret:
         veadk_environments["OAUTH2_CLIENT_SECRET"] = client_secret
 
-    # 2) Build the function project (zip): run.sh launches the frontend server on
+    # 3) Build the function project (zip): run.sh launches the frontend server on
     #    the FaaS-assigned port; requirements.txt pulls veadk-python (ships the UI).
     requirements = (
         f"veadk-python=={veadk_version}\n" if veadk_version else "veadk-python\n"
@@ -3183,7 +3190,7 @@ def frontend_deploy(
         f"site-logo.{branding_logo.extension}" if branding_logo is not None else None
     )
     run_sh = _studio_deploy_run_script(logo_filename)
-    # 2b) Resolve the serverless APIG gateway: use --gateway-name if given, else
+    # 3b) Resolve the serverless APIG gateway: use --gateway-name if given, else
     #     reuse an existing serverless gateway, creating one only if none exists.
     #     (VeFaaS applications can only attach to a serverless gateway; reusing
     #     avoids the per-account gateway quota.)

--- a/veadk/cli/studio_deploy_serverless_iam.py
+++ b/veadk/cli/studio_deploy_serverless_iam.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provision the IAM role required by Studio's VeFaaS deployment."""
+
+import json
+from typing import Any
+
+import click
+
+from veadk.cli.studio_deploy_serverless_policy import (
+    CUSTOM_POLICY,
+    SYSTEM_POLICIES,
+    TRUST_POLICY,
+)
+from veadk.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+ROLE_NAME = "ServerlessApplicationRole"
+CUSTOM_POLICY_NAME = "vefaas_full_access"
+
+
+def _result(response: dict) -> dict:
+    """Extract a successful IAM result and fail on an API error."""
+    error = (response.get("ResponseMetadata", {}) or {}).get("Error")
+    if error:
+        code = error.get("Code", "IAMError")
+        message = error.get("Message", str(error))
+        raise RuntimeError(f"{code}: {message}")
+    return response.get("Result", {}) or {}
+
+
+def _exception_error_code(error: Exception) -> str | None:
+    """Read the IAM error code exposed as JSON by the legacy SDK."""
+    try:
+        payload = json.loads(str(error))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    metadata = payload.get("ResponseMetadata", {}) or {}
+    iam_error = metadata.get("Error", {}) or {}
+    return iam_error.get("Code")
+
+
+def _get_role(service: Any) -> dict | None:
+    """Return the deployment role, or ``None`` when it does not exist."""
+    try:
+        response = service.get_role({"RoleName": ROLE_NAME})
+    except Exception as error:
+        # IamService exposes all HTTP failures as plain Exception instances.
+        if _exception_error_code(error) == "RoleNotExist":
+            return None
+        raise
+    return _result(response)
+
+
+def _get_custom_policy(service: Any) -> dict | None:
+    """Return the required custom policy, or ``None`` when absent."""
+    try:
+        response = service.get_policy(
+            {"PolicyName": CUSTOM_POLICY_NAME, "PolicyType": "Custom"}
+        )
+    except Exception as error:
+        # IamService exposes all HTTP failures as plain Exception instances.
+        if _exception_error_code(error) == "PolicyNotExist":
+            return None
+        raise
+    return _result(response)
+
+
+def _ensure_custom_policy(service: Any) -> None:
+    """Create the custom VeFaaS policy when it is missing."""
+    if _get_custom_policy(service) is not None:
+        return
+    _result(
+        service.create_policy(
+            {
+                "PolicyName": CUSTOM_POLICY_NAME,
+                "PolicyDocument": json.dumps(CUSTOM_POLICY),
+                "Description": "VeFaaS serverless application deployment permissions",
+            }
+        )
+    )
+    logger.info(f"Created IAM policy {CUSTOM_POLICY_NAME}.")
+
+
+def _attach_role_policies(service: Any) -> None:
+    """Attach all policies required by a newly created role."""
+    policies = ((CUSTOM_POLICY_NAME, "Custom"),) + tuple(
+        (policy_name, "System") for policy_name in SYSTEM_POLICIES
+    )
+    for policy_name, policy_type in policies:
+        _result(
+            service.attach_role_policy(
+                {
+                    "RoleName": ROLE_NAME,
+                    "PolicyName": policy_name,
+                    "PolicyType": policy_type,
+                }
+            )
+        )
+        logger.info(f"Attached IAM policy {policy_name} to {ROLE_NAME}.")
+
+
+def ensure_serverless_application_role(
+    access_key: str,
+    secret_key: str,
+) -> bool:
+    """Ensure Studio's VeFaaS deployment role has its required policies.
+
+    Args:
+        access_key: Volcengine access key used for IAM operations.
+        secret_key: Volcengine secret key used for IAM operations.
+
+    Returns:
+        Whether the role was created by this call.
+    """
+    from volcengine.iam.IamService import IamService
+
+    service = IamService()
+    service.set_ak(access_key)
+    service.set_sk(secret_key)
+
+    if _get_role(service) is not None:
+        logger.info(f"IAM role {ROLE_NAME} is ready.")
+        return False
+
+    click.secho(
+        f"IAM role {ROLE_NAME} was not found; creating it automatically.",
+        fg="yellow",
+    )
+
+    _ensure_custom_policy(service)
+    _result(
+        service.create_role(
+            {
+                "RoleName": ROLE_NAME,
+                "TrustPolicyDocument": json.dumps(TRUST_POLICY),
+                "Description": "VeFaaS serverless application role",
+                "MaxSessionDuration": 43200,
+            }
+        )
+    )
+    _attach_role_policies(service)
+    click.echo(
+        f"IAM role {ROLE_NAME} was created automatically with required policies."
+    )
+    return True

--- a/veadk/cli/studio_deploy_serverless_policy.py
+++ b/veadk/cli/studio_deploy_serverless_policy.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Policies required by Studio's VeFaaS ``ServerlessApplicationRole``."""
+
+SYSTEM_POLICIES: tuple[str, ...] = (
+    "CloudMonitorReadOnlyAccess",
+    "VPCFullAccess",
+    "TLSFullAccess",
+    "APIGFullAccess",
+    "ECSFullAccess",
+    "VeFaaSFullAccess",
+    "STSAssumeRoleAccess",
+)
+
+TRUST_POLICY: dict = {
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": ["sts:AssumeRole"],
+            "Principal": {"Service": ["vefaas_dev", "vefaas"]},
+        }
+    ]
+}
+
+CUSTOM_POLICY: dict = {
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": ["vefaas:*", "vefaas_dev:*"],
+            "Resource": ["*"],
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "apig:GetGateway",
+                "apig:ListGateways",
+                "apig:ListGatewayServices",
+                "apig:GetGatewayService",
+                "apig:DeleteGatewayService",
+                "apig:CreateUpstream",
+                "apig:CheckUpstreamSpecExist",
+                "apig:GetUpstream",
+                "apig:DeleteUpstream",
+                "apig:CreateRoute",
+                "apig:UpdateRoute",
+                "apig:ListRoutes",
+                "apig:DeleteRoute",
+            ],
+            "Resource": ["*"],
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "vpc:DescribeVpcs",
+                "vpc:DescribeVpcAttributes",
+                "vpc:DescribeSubnets",
+                "vpc:DescribeSubnetAttributes",
+                "vpc:DescribeSecurityGroups",
+                "vpc:DescribeSecurityGroupAttributes",
+            ],
+            "Resource": ["*"],
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "tls:DescribeProject",
+                "tls:DescribeProjects",
+                "tls:DescribeTopic",
+                "tls:DescribeTopics",
+                "tls:DescribeIndex",
+                "tls:DescribeIndexConfig",
+                "tls:DescribeHistogram",
+                "tls:DescribeHistogramV1",
+                "tls:DescribeSavedSearches",
+                "tls:SearchLogs",
+                "tls:Statistics",
+            ],
+            "Resource": ["*"],
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cr:ListRegistries",
+                "cr:ListRepositories",
+                "cr:ListNamespaces",
+                "cr:ListTags",
+            ],
+            "Resource": ["*"],
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kafka:DescribeKafkaInstances",
+                "kafka:DescribeInstanceDetail",
+                "kafka:DescribeTopics",
+                "kafka:DescribeUsers",
+            ],
+            "Resource": ["*"],
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rocketmq:ListInstances",
+                "rocketmq:ListTopics",
+                "rocketmq:ListGroups",
+                "rocketmq:GetInstance",
+            ],
+            "Resource": ["*"],
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "tos:PutBucketNotification",
+                "tos:GetBucketNotification",
+                "tos:ListBuckets",
+                "tos:ListBucket",
+                "tos:HeadBucket",
+                "tos:GetObject",
+            ],
+            "Resource": ["*"],
+        },
+        {
+            "Effect": "Allow",
+            "Action": ["apmplus_server:GetMetricsData", "apmplus_server:Draw"],
+            "Resource": ["*"],
+        },
+        {
+            "Effect": "Allow",
+            "Action": ["bill_volcano_engine:ListResourcePackage"],
+            "Resource": ["*"],
+        },
+        {
+            "Effect": "Allow",
+            "Action": ["iam:ListRoles"],
+            "Resource": ["*"],
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "filenas:DescribeFileSystems",
+                "filenas:DescribeMountPoints",
+                "filenas:DescribeMountedClients",
+            ],
+            "Resource": ["*"],
+        },
+    ]
+}


### PR DESCRIPTION
## Summary

- check ServerlessApplicationRole before veadk studio deploy provisions cloud resources
- show a yellow notice and create the role, trust policy, custom policy, and required system policies when missing
- leave existing roles unchanged and fail fast on unexpected IAM errors
- document the IAM behavior in Chinese and English

## Testing

- pytest -q tests/cli (113 passed in a clean worktree)
- Ruff check and format check
- Pyright on the new IAM modules and tests
- markdownlint on the updated README and frontend docs