### PR TITLE
feat(studio): support regional cloud deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,10 @@ VeADK provides several useful command line tools for faster deployment and optim
   `--site-title` and `--site-logo` (omitting the title keeps `VeADK Studio`)
 - `veadk studio deploy`: deploy Studio and ensure its default IAM role has the
   required model, observability, search, security, memory, and identity system
-  policies; custom local or remote logo images are bundled into the deployment
+  policies; target `cn-beijing` (default) or `cn-shanghai` with
+  `--region`, automatically locate the Identity user pool across Beijing and
+  Shanghai, and select the VeFaaS project with `--project` (default `default`);
+  custom local or remote logo images are bundled into the deployment
 
 ## Contribution
 

--- a/docs/content/docs/framework/frontend.en.mdx
+++ b/docs/content/docs/framework/frontend.en.mdx
@@ -153,9 +153,17 @@ veadk studio deploy \
   --user-pool-id <pool-id> \
   --allowed-client-id <client-id> \
   --vefaas-app-name <app-name> \
+  --region cn-beijing \
+  --project default \
   --site-title 火山助手 \
   --site-logo ./logo.png
 ```
+
+`--region` selects the Studio deployment region, defaults to `cn-beijing`, and
+also supports `cn-shanghai`. Deployment checks the deployment region first and
+then searches the Beijing and Shanghai Identity regions. A cross-region match
+emits a warning and continues. `--project` selects the VeFaaS function project
+and defaults to `default`.
 
 ### IAM permissions for `veadk studio deploy`
 

--- a/docs/content/docs/framework/frontend.mdx
+++ b/docs/content/docs/framework/frontend.mdx
@@ -143,9 +143,16 @@ veadk studio deploy \
   --user-pool-id <pool-id> \
   --allowed-client-id <client-id> \
   --vefaas-app-name <app-name> \
+  --region cn-beijing \
+  --project default \
   --site-title 火山助手 \
   --site-logo ./logo.png
 ```
+
+`--region` 指定 Studio 部署地域，默认为 `cn-beijing`，也支持
+`cn-shanghai`。部署时会先查询部署地域，再跨地域查询北京、上海的 Identity
+用户池；跨地域命中时会显示 warning 并继续。`--project` 指定 VeFaaS 函数
+所属项目，默认为 `default`。
 
 ### `veadk studio deploy` 的 IAM 权限
 

--- a/tests/cli/test_frontend_branding.py
+++ b/tests/cli/test_frontend_branding.py
@@ -138,6 +138,10 @@ def test_studio_deploy_bundles_logo_and_optional_title(
     monkeypatch.setattr(
         "veadk.cloud.cloud_agent_engine.CloudAgentEngine", _FakeCloudAgentEngine
     )
+    monkeypatch.setattr(
+        "veadk.cli.cli_frontend._resolve_studio_identity_region",
+        lambda **kwargs: kwargs["deployment_region"],
+    )
 
     args = [
         "deploy",

--- a/tests/cli/test_studio_deploy_target.py
+++ b/tests/cli/test_studio_deploy_target.py
@@ -1,0 +1,264 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from click.testing import CliRunner
+from volcenginesdkcore.rest import ApiException
+
+from veadk.cli.cli_frontend import _resolve_studio_identity_region, studio
+from veadk.config import veadk_environments
+from veadk.integrations.ve_identity.identity_client import IdentityClient
+
+
+@pytest.mark.parametrize(
+    ("target_args", "expected_region", "expected_identity_region", "expected_project"),
+    [
+        ([], "cn-beijing", "cn-beijing", "default"),
+        (
+            [
+                "--region",
+                "cn-shanghai",
+                "--project",
+                "studio-project",
+            ],
+            "cn-shanghai",
+            "cn-beijing",
+            "studio-project",
+        ),
+    ],
+)
+def test_studio_deploy_passes_region_and_project_to_cloud_engine(
+    monkeypatch: pytest.MonkeyPatch,
+    target_args: list[str],
+    expected_region: str,
+    expected_identity_region: str,
+    expected_project: str,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeCloudAgentEngine:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        def deploy(self, **kwargs: object) -> SimpleNamespace:
+            return SimpleNamespace(
+                vefaas_endpoint="",
+                vefaas_application_id="app-id",
+                vefaas_function_id="",
+            )
+
+    monkeypatch.setattr(
+        "veadk.cloud.cloud_agent_engine.CloudAgentEngine", _FakeCloudAgentEngine
+    )
+    monkeypatch.setattr(
+        "veadk.cli.cli_frontend._resolve_studio_identity_region",
+        lambda **_: expected_identity_region,
+    )
+
+    result = CliRunner().invoke(
+        studio,
+        [
+            "deploy",
+            "--user-pool-id",
+            "pool-id",
+            "--allowed-client-id",
+            "client-id",
+            "--vefaas-app-name",
+            "studio-app",
+            "--iam-role",
+            "trn:iam::role/test",
+            "--gateway-name",
+            "gateway",
+            "--volcengine-access-key",
+            "ak",
+            "--volcengine-secret-key",
+            "sk",
+            *target_args,
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["region"] == expected_region
+    assert captured["project"] == expected_project
+    assert veadk_environments["VEIDENTITY_REGION"] == expected_identity_region
+    assert f"{expected_region}/{expected_project}" in result.output
+    assert ("Warning:" in result.output) == (
+        expected_identity_region != expected_region
+    )
+
+
+def test_studio_identity_region_searches_deployment_region_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checked_regions: list[str] = []
+
+    class _FakeIdentityClient:
+        def __init__(self, **kwargs: str) -> None:
+            self.region = kwargs["region"]
+
+        def user_pool_client_exists(self, **_: str) -> bool:
+            checked_regions.append(self.region)
+            return self.region == "cn-beijing"
+
+    monkeypatch.setattr(
+        "veadk.integrations.ve_identity.identity_client.IdentityClient",
+        _FakeIdentityClient,
+    )
+
+    resolved = _resolve_studio_identity_region(
+        access_key="ak",
+        secret_key="sk",
+        user_pool_id="pool-id",
+        client_id="client-id",
+        deployment_region="cn-shanghai",
+    )
+
+    assert resolved == "cn-beijing"
+    assert checked_regions == ["cn-shanghai", "cn-beijing"]
+
+
+def test_identity_region_probe_only_swallows_not_found() -> None:
+    identity_client = IdentityClient(
+        access_key="test_access_key",
+        secret_key="test_secret_key",
+    )
+    identity_client._api_client = Mock()
+    identity_client._api_client.get_user_pool_client.side_effect = ApiException(
+        status=404,
+        reason="Not Found",
+    )
+
+    assert not identity_client.user_pool_client_exists("pool-id", "client-id")
+
+    identity_client._api_client.get_user_pool_client.side_effect = ApiException(
+        status=403,
+        reason="Forbidden",
+    )
+    with pytest.raises(ApiException):
+        identity_client.user_pool_client_exists("pool-id", "client-id")
+
+
+def test_studio_deploy_rejects_unsupported_region() -> None:
+    result = CliRunner().invoke(
+        studio,
+        [
+            "deploy",
+            "--user-pool-id",
+            "pool-id",
+            "--allowed-client-id",
+            "client-id",
+            "--vefaas-app-name",
+            "studio-app",
+            "--region",
+            "cn-guangzhou",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "Invalid value for '--region'" in result.output
+
+
+def test_studio_deploy_from_source_bundles_unmirrored_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str] = {}
+
+    class _FakeCloudAgentEngine:
+        def __init__(self, **_: object) -> None:
+            pass
+
+        def deploy(self, **kwargs: object) -> SimpleNamespace:
+            deploy_path = Path(str(kwargs["path"]))
+            captured["requirements"] = (deploy_path / "requirements.txt").read_text()
+            return SimpleNamespace(
+                vefaas_endpoint="",
+                vefaas_application_id="app-id",
+                vefaas_function_id="",
+            )
+
+    def _fake_build(command: list[str], check: bool) -> None:
+        assert check is True
+        output_dir = Path(command[-1])
+        (output_dir / "veadk_python-test-py3-none-any.whl").write_bytes(b"wheel")
+
+    class _FakeWheelResponse:
+        def __enter__(self) -> "_FakeWheelResponse":
+            return self
+
+        def __exit__(self, *_: object) -> None:
+            pass
+
+        def read(self) -> bytes:
+            return b"dependency-wheel"
+
+    monkeypatch.setattr(
+        "veadk.cloud.cloud_agent_engine.CloudAgentEngine", _FakeCloudAgentEngine
+    )
+    monkeypatch.setattr(
+        "veadk.cli.cli_frontend._resolve_studio_identity_region",
+        lambda **kwargs: kwargs["deployment_region"],
+    )
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/uv")
+    monkeypatch.setattr("subprocess.run", _fake_build)
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda *_args, **_kwargs: _FakeWheelResponse()
+    )
+    wheel_hashes = iter(
+        [
+            "3e89f6c9f5fb17cb70aaaa37df21a6e01722ccb1eec6cb8fc2e61417016986d4",
+            "3a74fa7a7baa5d5f604b175f967660cd0aa4c7057ce44d98c4041fbaf7944b5b",
+            "369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67",
+            "1e9f23332b1b687dd7f272e660953992de60ad3e9d07d62f7460fd4aedb99616",
+        ]
+    )
+    monkeypatch.setattr(
+        "hashlib.sha256",
+        lambda _: SimpleNamespace(hexdigest=lambda: next(wheel_hashes)),
+    )
+
+    result = CliRunner().invoke(
+        studio,
+        [
+            "deploy",
+            "--user-pool-id",
+            "pool-id",
+            "--allowed-client-id",
+            "client-id",
+            "--vefaas-app-name",
+            "studio-app",
+            "--iam-role",
+            "trn:iam::role/test",
+            "--gateway-name",
+            "gateway",
+            "--volcengine-access-key",
+            "ak",
+            "--volcengine-secret-key",
+            "sk",
+            "--from-source",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["requirements"] == (
+        "./trustedmcp-0.0.5-py3-none-any.whl\n"
+        "./volcengine_python_sdk-5.0.36-py2.py3-none-any.whl\n"
+        "./tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64."
+        "manylinux2014_x86_64.whl\n"
+        "./openviking_sdk-0.1.4-py3-none-any.whl\n"
+        "./veadk_python-test-py3-none-any.whl\n"
+    )

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -22,6 +22,56 @@ os.environ["VOLCENGINE_ACCESS_KEY"] = "test_access_key"
 os.environ["VOLCENGINE_SECRET_KEY"] = "test_secret_key"
 
 from veadk.cloud.cloud_agent_engine import CloudAgentEngine
+from veadk.integrations.ve_faas.ve_faas import VeFaaS
+
+
+def test_vefaas_create_function_uses_configured_project() -> None:
+    service = VeFaaS(
+        access_key="test_access_key",
+        secret_key="test_secret_key",
+        project_name="studio-project",
+    )
+    service.client = Mock()
+    service.client.create_function.return_value = Mock(
+        id="function-id", project_name="studio-project"
+    )
+    service._upload_and_mount_code = Mock()
+
+    service._create_function("studio-function", ".")
+
+    request = service.client.create_function.call_args.args[0]
+    assert request.project_name == "studio-project"
+
+
+def test_vefaas_code_upload_callback_uses_configured_region() -> None:
+    service = VeFaaS(
+        access_key="test_access_key",
+        secret_key="test_secret_key",
+        region="cn-shanghai",
+    )
+    service.client = Mock()
+    service.client.get_code_upload_address.return_value = Mock(
+        upload_address="https://example.com/upload"
+    )
+
+    with (
+        patch(
+            "veadk.integrations.ve_faas.ve_faas.zip_and_encode_folder",
+            return_value=(b"archive", 7, None),
+        ),
+        patch("veadk.integrations.ve_faas.ve_faas.requests.put") as upload,
+        patch("veadk.integrations.ve_faas.ve_faas.signed_request") as callback,
+    ):
+        upload.return_value = Mock(status_code=200)
+        service._upload_and_mount_code("function-id", ".")
+
+    callback.assert_called_once_with(
+        ak="test_access_key",
+        sk="test_secret_key",
+        target="CodeUploadCallback",
+        body={"FunctionId": "function-id"},
+        region="cn-shanghai",
+    )
 
 
 @pytest.mark.asyncio
@@ -68,7 +118,13 @@ async def test_cloud():
                 )
 
                 # Test CloudAgentEngine creation and deploy functionality
-                engine = CloudAgentEngine()
+                engine = CloudAgentEngine(project="studio-project")
+                mock_vefaas_class.assert_called_once_with(
+                    access_key="test_access_key",
+                    secret_key="test_secret_key",
+                    region="cn-beijing",
+                    project_name="studio-project",
+                )
 
                 # Test deploy operation
                 cloud_app = engine.deploy(application_name=app_name, path=temp_dir)

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -3032,6 +3032,37 @@ def _studio_deploy_run_script(site_logo_filename: str | None = None) -> str:
     )
 
 
+def _resolve_studio_identity_region(
+    *,
+    access_key: str,
+    secret_key: str,
+    user_pool_id: str,
+    client_id: str,
+    deployment_region: str,
+) -> str:
+    """Locate a Studio user-pool client across supported Identity regions."""
+    from veadk.integrations.ve_identity.identity_client import IdentityClient
+
+    supported_regions = ("cn-beijing", "cn-shanghai")
+    candidate_regions = (deployment_region,) + tuple(
+        region for region in supported_regions if region != deployment_region
+    )
+    for candidate_region in candidate_regions:
+        identity_client = IdentityClient(
+            access_key=access_key,
+            secret_key=secret_key,
+            region=candidate_region,
+        )
+        if identity_client.user_pool_client_exists(
+            user_pool_uid=user_pool_id,
+            client_uid=client_id,
+        ):
+            return candidate_region
+    raise click.ClickException(
+        "VeIdentity user pool/client not found in cn-beijing or cn-shanghai."
+    )
+
+
 @studio.command("deploy")
 @click.option(
     "--user-pool-id",
@@ -3053,7 +3084,19 @@ def _studio_deploy_run_script(site_logo_filename: str | None = None) -> str:
     required=True,
     help="VeFaaS application/function name (4-64 chars, letters/digits/-, no underscore).",
 )
-@click.option("--region", default="cn-beijing", show_default=True)
+@click.option(
+    "--region",
+    default="cn-beijing",
+    show_default=True,
+    type=click.Choice(["cn-beijing", "cn-shanghai"]),
+    help="Volcengine region for Studio deployment.",
+)
+@click.option(
+    "--project",
+    default="default",
+    show_default=True,
+    help="Volcengine project for the VeFaaS function.",
+)
 @click.option(
     "--iam-role",
     default=None,
@@ -3101,6 +3144,7 @@ def frontend_deploy(
     client_secret: str,
     vefaas_app_name: str,
     region: str,
+    project: str,
     iam_role: str | None,
     gateway_name: str,
     gateway_service_name: str,
@@ -3138,6 +3182,21 @@ def frontend_deploy(
             "or pass --volcengine-access-key/--volcengine-secret-key."
         )
 
+    identity_region = _resolve_studio_identity_region(
+        access_key=ak,
+        secret_key=sk,
+        user_pool_id=user_pool_id,
+        client_id=allowed_client_id,
+        deployment_region=region,
+    )
+    if identity_region != region:
+        click.secho(
+            f"Warning: Studio deploys to {region}, but the VeIdentity user "
+            f"pool/client was found in {identity_region}. Continuing with "
+            f"Identity region {identity_region}.",
+            fg="yellow",
+        )
+
     # 1) Ensure the IAM role the function runs as (auto-create unless provided).
     if iam_role:
         role_trn = iam_role
@@ -3169,6 +3228,7 @@ def frontend_deploy(
     veadk_environments["OAUTH2_USER_POOL_ID"] = user_pool_id
     veadk_environments["OAUTH2_USER_POOL_CLIENT_ID"] = allowed_client_id
     veadk_environments["OAUTH2_PROVIDER"] = "veidentity"
+    veadk_environments["VEIDENTITY_REGION"] = identity_region
     if site_title is not None:
         veadk_environments["VEADK_SITE_TITLE"] = branding_title
     if client_secret:
@@ -3211,9 +3271,12 @@ def frontend_deploy(
         # uncommitted changes + the current veadk/webui) and install it instead
         # of the PyPI release, so the deployed frontend runs this branch's code.
         if from_source:
+            import hashlib
             import shutil as _shutil
             import subprocess
             import sys
+            from urllib.request import urlopen
+
             import veadk
 
             repo_root = Path(veadk.__file__).resolve().parent.parent
@@ -3244,8 +3307,55 @@ def frontend_deploy(
                 )
             wheel_name = wheels[0].name
             click.echo(f"Shipping local wheel: {wheel_name}")
-            # Install the bundled wheel; deps still resolve from PyPI.
-            requirements = f"./{wheel_name}\n"
+            # VeFaaS's package mirror can lag public PyPI, while its build
+            # environment cannot reliably reach public PyPI. Bundle the pinned
+            # dependencies currently missing or stale in that mirror.
+            bundled_wheels = [
+                (
+                    "trustedmcp-0.0.5-py3-none-any.whl",
+                    "https://files.pythonhosted.org/packages/e0/5b/"
+                    "9d60a8633f4ab94c9ec0621b51a74d866086b4cb6579882fa4fb9186023b/"
+                    "trustedmcp-0.0.5-py3-none-any.whl",
+                    "3e89f6c9f5fb17cb70aaaa37df21a6e01722ccb1eec6cb8fc2e61417016986d4",
+                ),
+                (
+                    "volcengine_python_sdk-5.0.36-py2.py3-none-any.whl",
+                    "https://files.pythonhosted.org/packages/00/a1/"
+                    "9e246023bb847329bda43e516c64aa10d77b2d98c662f0e1179689020c23/"
+                    "volcengine_python_sdk-5.0.36-py2.py3-none-any.whl",
+                    "3a74fa7a7baa5d5f604b175f967660cd0aa4c7057ce44d98c4041fbaf7944b5b",
+                ),
+                (
+                    "tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64."
+                    "manylinux2014_x86_64.whl",
+                    "https://files.pythonhosted.org/packages/2e/76/"
+                    "932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/"
+                    "tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64."
+                    "manylinux2014_x86_64.whl",
+                    "369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67",
+                ),
+                (
+                    "openviking_sdk-0.1.4-py3-none-any.whl",
+                    "https://files.pythonhosted.org/packages/fe/af/"
+                    "4ca139b05f39c8ed04339d7c8aa56550df80f97d39768d2df9bd72fdbbb9/"
+                    "openviking_sdk-0.1.4-py3-none-any.whl",
+                    "1e9f23332b1b687dd7f272e660953992de60ad3e9d07d62f7460fd4aedb99616",
+                ),
+            ]
+            for dependency_name, dependency_url, dependency_sha256 in bundled_wheels:
+                with urlopen(dependency_url, timeout=60) as response:
+                    dependency_wheel = response.read()
+                if hashlib.sha256(dependency_wheel).hexdigest() != dependency_sha256:
+                    raise click.ClickException(
+                        f"--from-source: {dependency_name} checksum verification failed"
+                    )
+                (Path(tmp) / dependency_name).write_bytes(dependency_wheel)
+            requirements = (
+                "".join(
+                    f"./{dependency_name}\n" for dependency_name, _, _ in bundled_wheels
+                )
+                + f"./{wheel_name}\n"
+            )
 
         (Path(tmp) / "requirements.txt").write_text(requirements, encoding="utf-8")
 
@@ -3257,8 +3367,12 @@ def frontend_deploy(
             volcengine_access_key=ak,
             volcengine_secret_key=sk,
             region=region,
+            project=project,
         )
-        click.echo(f"Deploying frontend to VeFaaS as '{vefaas_app_name}'…")
+        click.echo(
+            f"Deploying frontend to VeFaaS as '{vefaas_app_name}' "
+            f"in {region}/{project}…"
+        )
         app = engine.deploy(
             application_name=vefaas_app_name,
             path=tmp,
@@ -3282,7 +3396,7 @@ def frontend_deploy(
                 )
 
                 IdentityClient(
-                    access_key=ak, secret_key=sk, region=region
+                    access_key=ak, secret_key=sk, region=identity_region
                 ).register_callback_for_user_pool_client(
                     user_pool_uid=user_pool_id,
                     client_uid=allowed_client_id,

--- a/veadk/cloud/cloud_agent_engine.py
+++ b/veadk/cloud/cloud_agent_engine.py
@@ -45,6 +45,8 @@ class CloudAgentEngine(BaseModel):
         volcengine_secret_key (str): Secret key for Volcengine authentication.
             Defaults to VOLCENGINE_SECRET_KEY environment variable.
         region (str): Region for Volcengine services. Defaults to "cn-beijing".
+        project (str): Volcengine project for the VeFaaS function. Defaults to
+            "default".
         _vefaas_service (VeFaaS): Internal VeFaaS client instance, initialized post-creation.
         _veapig_service (APIGateway): Internal VeAPIG client instance, initialized post-creation.
         _veidentity_service (IdentityClient): Internal Identity client instance, initialized post-creation.
@@ -69,6 +71,7 @@ class CloudAgentEngine(BaseModel):
         "VOLCENGINE_SECRET_KEY", "", allow_false_values=True
     )
     region: str = "cn-beijing"
+    project: str = "default"
 
     def model_post_init(self, context: Any, /) -> None:
         """Initializes the internal VeFaaS service after Pydantic model validation.
@@ -89,6 +92,7 @@ class CloudAgentEngine(BaseModel):
             access_key=self.volcengine_access_key,
             secret_key=self.volcengine_secret_key,
             region=self.region,
+            project_name=self.project,
         )
         self._veapig_service = APIGateway(
             access_key=self.volcengine_access_key,

--- a/veadk/integrations/ve_faas/ve_faas.py
+++ b/veadk/integrations/ve_faas/ve_faas.py
@@ -44,10 +44,17 @@ logger = get_logger(__name__)
 
 
 class VeFaaS:
-    def __init__(self, access_key: str, secret_key: str, region: str = "cn-beijing"):
+    def __init__(
+        self,
+        access_key: str,
+        secret_key: str,
+        region: str = "cn-beijing",
+        project_name: str = "default",
+    ):
         self.ak = access_key
         self.sk = secret_key
         self.region = region
+        self.project_name = project_name
 
         configuration = volcenginesdkcore.Configuration()
         configuration.ak = self.ak
@@ -99,6 +106,7 @@ class VeFaaS:
             sk=self.sk,
             target="CodeUploadCallback",
             body={"FunctionId": function_id},
+            region=self.region,
         )
 
         return res
@@ -124,6 +132,7 @@ class VeFaaS:
                 envs=envs,
                 memory_mb=2048,
                 role=getenv("IAM_ROLE", None, allow_false_values=True),
+                project_name=self.project_name,
             )
         )
 

--- a/veadk/integrations/ve_faas/ve_faas_utils.py
+++ b/veadk/integrations/ve_faas/ve_faas_utils.py
@@ -204,12 +204,12 @@ def norm_query(params):
     return query.replace("+", "%20")
 
 
-def request(method, date, query, header, ak, sk, token, action, body):
+def request(method, date, query, header, ak, sk, token, action, body, region=Region):
     credential = {
         "access_key_id": ak,
         "secret_access_key": sk,
         "service": Service,
-        "region": Region,
+        "region": region,
     }
 
     if token is not None:
@@ -310,7 +310,7 @@ def request(method, date, query, header, ak, sk, token, action, body):
     return r.json()
 
 
-def signed_request(ak: str, sk: str, target: str, body: dict):
+def signed_request(ak: str, sk: str, target: str, body: dict, region: str = Region):
     now = datetime.datetime.utcnow()
 
     try:
@@ -324,6 +324,7 @@ def signed_request(ak: str, sk: str, target: str, body: dict):
             "",
             target,
             json.dumps(body),
+            region=region,
         )
         return response_body
     except Exception as e:

--- a/veadk/integrations/ve_identity/identity_client.py
+++ b/veadk/integrations/ve_identity/identity_client.py
@@ -866,6 +866,33 @@ class IdentityClient:
         self._api_client.update_user_pool_client(request2)
 
     @refresh_credentials
+    def user_pool_client_exists(
+        self,
+        user_pool_uid: str,
+        client_uid: str,
+    ) -> bool:
+        """Return whether a user-pool client exists in this client's region.
+
+        Only a not-found response becomes ``False``. Permission, credential,
+        and transport failures are raised so callers do not silently search a
+        different region and hide the real problem.
+        """
+        from volcenginesdkcore.rest import ApiException
+        from volcenginesdkid import GetUserPoolClientRequest
+
+        request = GetUserPoolClientRequest(
+            user_pool_uid=user_pool_uid,
+            client_uid=client_uid,
+        )
+        try:
+            self._api_client.get_user_pool_client(request)
+        except ApiException as error:
+            if error.status == 404:
+                return False
+            raise
+        return True
+
+    @refresh_credentials
     def get_user_pool_client(
         self,
         user_pool_uid: str,


### PR DESCRIPTION
## Summary

- add `--region` and `--project` support to `veadk studio deploy` and propagate the selected project to VeFaaS
- discover the VeIdentity user-pool client across Beijing and Shanghai, warning on cross-region matches while preserving non-404 failures
- sign VeFaaS code-upload callbacks with the deployment region
- make `--from-source` deployment work with the VeFaaS package mirror by bundling checksum-verified missing dependencies
- document regional deployment and project selection in Chinese and English

## Testing

- `pytest -q tests/cli tests/test_cloud.py` (117 passed)
- `pre-commit run --files <changed files>`
- `npm run types:check` in `docs/`
- deployed from source to `cn-shanghai` / `test-fyz`; verified Studio HTML, SSO redirect, and callback registration