### PR TITLE
fix(frontend): harden identity and stream handling

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -110,6 +110,15 @@ Login state is cached: SSO via the `veadk_session` cookie, local mode via
 `localStorage`. The session itself is created lazily on the first message or
 attachment upload.
 
+Identity and provider discovery failures are shown as retryable errors. The UI
+only offers local username login after `/web/auth-config` successfully returns
+an empty provider list; network and gateway failures never silently change the
+authentication mode.
+
+Non-streaming frontend API requests use a 30-second deadline, while file
+transfers use 120 seconds. Chat, debug, and deployment progress streams remain
+open until the server finishes or the caller explicitly cancels them.
+
 ## Multimodal media
 
 The composer accepts PNG, JPEG, WebP, GIF, TXT, Markdown, PDF, MP4, WebM, and

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -210,6 +210,16 @@ function turnAwaitingAuth(turn: Turn): boolean {
  *  falls back to asking the user to paste the callback URL. */
 function runOAuthPopup(authUri: string): Promise<string> {
   return new Promise((resolve, reject) => {
+    let protocol = "";
+    try {
+      protocol = new URL(authUri, window.location.href).protocol;
+    } catch {
+      // Invalid URLs are rejected with unsupported schemes below.
+    }
+    if (protocol !== "http:" && protocol !== "https:") {
+      reject(new Error("授权链接不是 http/https 地址，已阻止打开。"));
+      return;
+    }
     const popup = window.open(authUri, "veadk_oauth", "width=520,height=720");
     if (!popup) {
       reject(new Error("弹窗被拦截，请允许弹窗后重试。"));
@@ -540,6 +550,7 @@ export default function App() {
   const [traceOpen, setTraceOpen] = useState(false);
   const [greeting, setGreeting] = useState(pickGreeting);
   const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null);
+  const [authError, setAuthError] = useState<string | null>(null);
   const [userId, setUserId] = useState("");
   const [userInfo, setUserInfo] = useState<Record<string, unknown> | undefined>();
   // Per-module feature gates (studio mode disables chat-centric modules).
@@ -757,14 +768,22 @@ export default function App() {
   const { ref: scrollRef, onScroll } = useStickToBottom<HTMLDivElement>(turns);
 
   // Resolve SSO identity first; it provides the ADK user_id.
-  useEffect(() => {
-    resolveIdentity().then((id) => {
-      setUserId(id.userId);
-      setUserInfo(id.info);
-      setLocalMode(!!id.local);
-      setAuthStatus(id.status);
-    });
+  const resolveAuth = useCallback(() => {
+    setAuthError(null);
+    resolveIdentity()
+      .then((id) => {
+        setUserId(id.userId);
+        setUserInfo(id.info);
+        setLocalMode(!!id.local);
+        setAuthStatus(id.status);
+      })
+      .catch((error) => {
+        setAuthError(error instanceof Error ? error.message : String(error));
+      });
   }, []);
+  useEffect(() => {
+    resolveAuth();
+  }, [resolveAuth]);
 
   // Load per-module feature gates; studio mode lands on the add-agent page.
   useEffect(() => {
@@ -797,12 +816,14 @@ export default function App() {
 
   // Check whether the server has Volcengine AK/SK (needed by the workbench).
   useEffect(() => {
-    fetch("/web/runtime-config")
+    fetch("/web/runtime-config", { signal: AbortSignal.timeout(10_000) })
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => {
         if (d) setHasCreds(!!d.credentials);
       })
-      .catch(() => {});
+      .catch((error) => {
+        console.warn("[app] /web/runtime-config probe failed; workbench stays hidden:", error);
+      });
   }, []);
 
   function onUsername(name: string) {
@@ -1278,6 +1299,16 @@ export default function App() {
     }
   }
 
+  if (authError) {
+    return (
+      <div className="boot boot-error">
+        <p>{authError}</p>
+        <button type="button" onClick={resolveAuth}>
+          重试
+        </button>
+      </div>
+    );
+  }
   if (authStatus === null) {
     return <div className="boot" />; // resolving identity
   }

--- a/frontend/src/adk/client.ts
+++ b/frontend/src/adk/client.ts
@@ -5,6 +5,11 @@
 import { withAuth } from "./auth";
 import { formatRunSseError } from "./runSseError";
 import { parseSSE } from "./sse";
+import {
+  DEFAULT_REQUEST_TIMEOUT_MS,
+  requestSignal,
+  TRANSFER_REQUEST_TIMEOUT_MS,
+} from "./timeout";
 import type { AgentProject } from "../create/project";
 import type { AgentDraft } from "../create/types";
 
@@ -165,19 +170,25 @@ function resolve(appName: string): { app: string; ep: AdkEndpoint } {
  *     the apikey; apikey never reaches the browser).
  *  2. `base` + `apiKey` → backend `/agentkit-proxy` (legacy, key in header).
  *  3. neither → the local same-origin server. */
-function apiFetch(path: string, init: RequestInit = {}, ep: AdkEndpoint = {}): Promise<Response> {
+function apiFetch(
+  path: string,
+  init: RequestInit = {},
+  ep: AdkEndpoint = {},
+  timeoutMs: number = DEFAULT_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  const opts = { ...init, signal: requestSignal(init.signal, timeoutMs) };
   if (ep.runtimeId) {
     const rq = ep.region ? `${path.includes("?") ? "&" : "?"}region=${encodeURIComponent(ep.region)}` : "";
-    return fetch(withAuth(`${API_BASE}/web/runtime-proxy/${ep.runtimeId}${path}${rq}`), init);
+    return fetch(withAuth(`${API_BASE}/web/runtime-proxy/${ep.runtimeId}${path}${rq}`), opts);
   }
   if (ep.base) {
     // Use backend proxy to avoid CORS issues with remote AgentKit
     const headers: Record<string, string> = { ...(init.headers as Record<string, string>) };
     headers["X-AgentKit-Base"] = ep.base;
     if (ep.apiKey) headers["X-AgentKit-Key"] = ep.apiKey;
-    return fetch(withAuth(`${API_BASE}/agentkit-proxy${path}`), { ...init, headers });
+    return fetch(withAuth(`${API_BASE}/agentkit-proxy${path}`), { ...opts, headers });
   }
-  return fetch(withAuth(`${API_BASE}${path}`), init);
+  return fetch(withAuth(`${API_BASE}${path}`), opts);
 }
 
 function formatErrorDetail(detail: unknown): string {
@@ -310,7 +321,12 @@ export async function uploadMedia(
   body.set("user_id", userId);
   body.set("session_id", sessionId);
   body.set("file", file);
-  const res = await apiFetch("/web/media", { method: "POST", body });
+  const res = await apiFetch(
+    "/web/media",
+    { method: "POST", body },
+    {},
+    TRANSFER_REQUEST_TIMEOUT_MS,
+  );
   if (!res.ok) throw new Error(await httpErrorMessage(res, "文件上传失败"));
   const media = (await res.json()) as {
     id: string;
@@ -561,6 +577,7 @@ export async function* runSSE({
       signal,
     },
     ep,
+    0,
   );
   if (!res.ok) throw new Error(formatRunSseError(`run_sse failed: ${res.status}`));
   for await (const evt of parseSSE(res)) {
@@ -647,20 +664,25 @@ export async function deployAgentkitProject(
 
   let res: Response;
   try {
-    res = await apiFetch("/web/deploy-agentkit", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      signal: controller?.signal,
-      body: JSON.stringify({
-        name,
-        files,
-        config,
-        taskId,
-        author: opts?.author ?? "",
-        im: opts?.im,
-        envs: opts?.envs,
-      }),
-    });
+    res = await apiFetch(
+      "/web/deploy-agentkit",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: controller?.signal,
+        body: JSON.stringify({
+          name,
+          files,
+          config,
+          taskId,
+          author: opts?.author ?? "",
+          im: opts?.im,
+          envs: opts?.envs,
+        }),
+      },
+      {},
+      0,
+    );
   } catch (error) {
     clearController();
     throw error;
@@ -1004,17 +1026,22 @@ export async function* runGeneratedAgentTestSSE({
   signal?: AbortSignal;
 }): AsyncGenerator<AdkEvent, void, unknown> {
   const parts: Record<string, unknown>[] = text.trim() ? [{ text }] : [];
-  const res = await apiFetch(`/web/generated-agent-test-runs/${runId}/run_sse`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      user_id: userId,
-      session_id: sessionId,
-      new_message: { role: "user", parts },
-      streaming: true,
-    }),
-    signal,
-  });
+  const res = await apiFetch(
+    `/web/generated-agent-test-runs/${runId}/run_sse`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        user_id: userId,
+        session_id: sessionId,
+        new_message: { role: "user", parts },
+        streaming: true,
+      }),
+      signal,
+    },
+    {},
+    0,
+  );
   if (!res.ok) throw new Error(await httpErrorMessage(res, "调试运行失败"));
   for await (const evt of parseSSE(res)) {
     yield evt as AdkEvent;

--- a/frontend/src/adk/identity.ts
+++ b/frontend/src/adk/identity.ts
@@ -5,7 +5,9 @@
 // loads and shows its own login page. `/oauth2/userinfo` tells us the state:
 //   200 -> authenticated (use the returned identity)
 //   401 -> SSO enabled but not signed in (show the login page)
-//   404/err -> SSO not configured (local dev; use a default id)
+//   404 -> SSO not configured on legacy servers (local username mode)
+
+import { BOOT_REQUEST_TIMEOUT_MS, requestSignal } from "./timeout";
 
 const LOCAL_USER_KEY = "veadk_local_user";
 
@@ -54,13 +56,28 @@ export interface Provider {
 
 /** Fetch the SSO providers the server has configured (unauthenticated). */
 export async function fetchProviders(): Promise<Provider[]> {
+  let res: Response;
   try {
-    const res = await fetch("/web/auth-config", { headers: { Accept: "application/json" } });
-    if (!res.ok) return [];
-    const data = (await res.json()) as { providers?: Provider[] };
-    return Array.isArray(data.providers) ? data.providers : [];
-  } catch {
-    return [];
+    res = await fetch("/web/auth-config", {
+      headers: { Accept: "application/json" },
+      signal: requestSignal(undefined, BOOT_REQUEST_TIMEOUT_MS),
+    });
+  } catch (error) {
+    console.warn("[identity] /web/auth-config is unreachable:", error);
+    throw new Error("无法加载登录配置，请检查网络后重试。");
+  }
+  if (!res.ok) {
+    throw new Error(`登录配置服务异常（HTTP ${res.status}），请稍后重试。`);
+  }
+  try {
+    const data = (await res.json()) as { providers?: unknown };
+    if (!Array.isArray(data.providers)) {
+      throw new TypeError("providers is not an array");
+    }
+    return data.providers as Provider[];
+  } catch (error) {
+    console.warn("[identity] /web/auth-config returned an invalid response:", error);
+    throw new Error("登录配置服务返回了无法解析的响应，请稍后重试。");
   }
 }
 
@@ -81,27 +98,44 @@ export function logout(): void {
 }
 
 /** Resolve identity. With SSO: via /oauth2/userinfo. Without SSO (endpoint 404):
- *  use a locally chosen username, or prompt for one on the login page. */
+ *  use a locally chosen username, or prompt for one on the login page.
+ *
+ *  Network and server failures reject instead of silently changing identity
+ *  mode. The caller can then show a retryable error. */
 export async function resolveIdentity(): Promise<Identity> {
-  let res: Response | null = null;
+  let res: Response;
   try {
-    res = await fetch("/oauth2/userinfo", { headers: { Accept: "application/json" } });
-  } catch {
-    res = null;
+    res = await fetch("/oauth2/userinfo", {
+      headers: { Accept: "application/json" },
+      signal: requestSignal(undefined, BOOT_REQUEST_TIMEOUT_MS),
+    });
+  } catch (error) {
+    console.warn("[identity] /oauth2/userinfo is unreachable:", error);
+    throw new Error("无法连接身份服务，请检查网络后重试。");
   }
 
   // SSO enabled, signed in.
-  if (res && res.ok) {
-    const info = (await res.json()) as Record<string, unknown>;
+  if (res.ok) {
+    let info: Record<string, unknown>;
+    try {
+      info = (await res.json()) as Record<string, unknown>;
+    } catch (error) {
+      console.warn("[identity] /oauth2/userinfo returned a non-JSON response:", error);
+      throw new Error("身份服务返回了无法解析的响应，请稍后重试。");
+    }
     const userId = String(info.sub ?? info.user_id ?? info.email ?? "");
     return { status: "authenticated", userId, info };
   }
   // SSO enabled, not signed in -> provider login page.
-  if (res && res.status === 401) {
+  if (res.status === 401) {
     return { status: "unauthenticated", userId: "", local: false };
   }
 
-  // No SSO (404 / unreachable): local username mode.
+  if (res.status !== 404) {
+    throw new Error(`身份服务异常（HTTP ${res.status}），请稍后重试。`);
+  }
+
+  // Legacy server without the identity endpoint: local username mode.
   const saved = getLocalUser();
   if (saved) {
     return { status: "authenticated", userId: saved, info: { name: saved }, local: true };

--- a/frontend/src/adk/sse.ts
+++ b/frontend/src/adk/sse.ts
@@ -11,28 +11,44 @@ export async function* parseSSE(
   const decoder = new TextDecoder();
   let buffer = "";
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    buffer += decoder.decode(value, { stream: true });
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
 
-    // SSE frames are separated by a blank line.
-    let sep: number;
-    while ((sep = buffer.indexOf("\n\n")) !== -1) {
-      const frame = buffer.slice(0, sep);
-      buffer = buffer.slice(sep + 2);
-      const data = frame
-        .split("\n")
-        .filter((line) => line.startsWith("data:"))
-        .map((line) => line.slice(5).trimStart())
-        .join("\n");
-      if (data) {
-        try {
-          yield JSON.parse(data);
-        } catch {
-          // Ignore non-JSON keep-alive frames.
+      // SSE frames use a blank line separator. Accept both LF and CRLF.
+      let separator = buffer.match(/\r?\n\r?\n/);
+      while (separator?.index !== undefined) {
+        const frame = buffer.slice(0, separator.index);
+        buffer = buffer.slice(separator.index + separator[0].length);
+        const data = frame
+          .split(/\r?\n/)
+          .filter((line) => line.startsWith("data:"))
+          .map((line) => line.slice(5).trimStart())
+          .join("\n");
+        if (data) {
+          try {
+            yield JSON.parse(data);
+          } catch {
+            if (data !== "[DONE]" && data !== "ping") {
+              console.debug(
+                `parseSSE: dropping unparseable frame (${data.length} chars):`,
+                data.slice(0, 200),
+              );
+            }
+          }
         }
+        separator = buffer.match(/\r?\n\r?\n/);
       }
+    }
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // The response may already be closed; cleanup must not mask its result.
+    } finally {
+      reader.releaseLock();
     }
   }
 }

--- a/frontend/src/adk/timeout.ts
+++ b/frontend/src/adk/timeout.ts
@@ -1,0 +1,21 @@
+/** Default deadline for non-streaming API calls. */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+/** Deadline for uploads and downloads. */
+export const TRANSFER_REQUEST_TIMEOUT_MS = 120_000;
+
+/** Short deadline for identity and boot-time probes. */
+export const BOOT_REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Combine an optional caller cancellation signal with a request deadline.
+ * A non-positive timeout keeps long-lived streaming requests deadline-free.
+ */
+export function requestSignal(
+  signal: AbortSignal | null | undefined,
+  timeoutMs: number = DEFAULT_REQUEST_TIMEOUT_MS,
+): AbortSignal | undefined {
+  if (timeoutMs <= 0) return signal ?? undefined;
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+}

--- a/frontend/src/create/skills/skillhub.ts
+++ b/frontend/src/create/skills/skillhub.ts
@@ -7,6 +7,11 @@
 // Skills are downloaded as a zip and unpacked client-side into project files.
 
 import type { ProjectFile } from "../project";
+import {
+  DEFAULT_REQUEST_TIMEOUT_MS,
+  requestSignal,
+  TRANSFER_REQUEST_TIMEOUT_MS,
+} from "../../adk/timeout";
 import type { SkillHit, SelectedSkill } from "./types";
 import { unzip } from "./zip";
 
@@ -30,7 +35,10 @@ export async function searchSkills(
 ): Promise<SkillHit[]> {
   const q = query.trim();
   const url = `${BASE}?query=${encodeURIComponent(q)}&namespace=${encodeURIComponent(namespace)}`;
-  const res = await fetch(url, { headers: { accept: "application/json" } });
+  const res = await fetch(url, {
+    headers: { accept: "application/json" },
+    signal: requestSignal(undefined, DEFAULT_REQUEST_TIMEOUT_MS),
+  });
   if (!res.ok) throw new Error(`搜索失败 (${res.status})`);
   const data = (await res.json()) as { Skills?: RawSkill[] };
   return (data.Skills ?? []).map((s) => ({
@@ -53,7 +61,9 @@ export async function downloadSkillHubSkill(
   const slug = s.slug || "";
   const namespace = s.namespace || "public";
   const url = `${BASE}/download/${slug}?namespace=${encodeURIComponent(namespace)}`;
-  const res = await fetch(url);
+  const res = await fetch(url, {
+    signal: requestSignal(undefined, TRANSFER_REQUEST_TIMEOUT_MS),
+  });
   if (!res.ok) throw new Error(`下载技能失败 (${res.status})`);
   const buf = new Uint8Array(await res.arrayBuffer());
   const entries = await unzip(buf);

--- a/frontend/src/create/skills/skillspace.ts
+++ b/frontend/src/create/skills/skillspace.ts
@@ -3,6 +3,7 @@
 // (the browser never sees credentials) and are gated by SSO when enabled.
 
 import type { ProjectFile } from "../project";
+import { DEFAULT_REQUEST_TIMEOUT_MS, requestSignal } from "../../adk/timeout";
 import type { SkillHit } from "./types";
 
 export interface SkillSpaceRef {
@@ -30,7 +31,10 @@ export interface SkillDetail {
 }
 
 async function jfetch<T>(url: string): Promise<T> {
-  const res = await fetch(url, { headers: { accept: "application/json" } });
+  const res = await fetch(url, {
+    headers: { accept: "application/json" },
+    signal: requestSignal(undefined, DEFAULT_REQUEST_TIMEOUT_MS),
+  });
   if (res.status === 409) {
     throw new Error("服务端未配置 Volcengine AK/SK，无法访问 SkillSpace");
   }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1769,6 +1769,29 @@ body {
 
 /* ---------- boot (resolving identity) ---------- */
 .boot { height: 100vh; background: hsl(var(--background)); }
+.boot-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: hsl(var(--foreground));
+  font-size: 14px;
+}
+.boot-error p { margin: 0; }
+.boot-error button,
+.login-provider-error button {
+  padding: 7px 18px;
+  border: 1px solid hsl(var(--border));
+  border-radius: 8px;
+  background: hsl(var(--card));
+  color: hsl(var(--foreground));
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+.boot-error button:hover,
+.login-provider-error button:hover { background: hsl(var(--accent)); }
 
 /* ---------- main navbar (agent picker + account) ---------- */
 .navbar {
@@ -2714,6 +2737,15 @@ a.search-result { text-decoration: none; color: inherit; }
 }
 
 .login-providers { display: flex; flex-direction: column; gap: 10px; }
+.login-provider-error {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  color: hsl(var(--destructive));
+  font-size: 13px;
+}
+.login-provider-error p { margin: 0; }
 
 /* login: no-SSO username input */
 .login-name { display: flex; align-items: center; gap: 8px; }

--- a/frontend/src/ui/LoginPage.tsx
+++ b/frontend/src/ui/LoginPage.tsx
@@ -17,11 +17,27 @@ export interface LoginPageProps {
 
 export function LoginPage({ branding, onUsername }: LoginPageProps) {
   const [providers, setProviders] = useState<Provider[] | null>(null);
+  const [providerError, setProviderError] = useState("");
+  const [providerAttempt, setProviderAttempt] = useState(0);
   const [name, setName] = useState("");
 
   useEffect(() => {
-    fetchProviders().then(setProviders);
-  }, []);
+    let active = true;
+    setProviders(null);
+    setProviderError("");
+    fetchProviders()
+      .then((nextProviders) => {
+        if (active) setProviders(nextProviders);
+      })
+      .catch((error) => {
+        if (active) {
+          setProviderError(error instanceof Error ? error.message : String(error));
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [providerAttempt]);
 
   const valid = USERNAME_RE.test(name);
   const submit = () => {
@@ -48,7 +64,14 @@ export function LoginPage({ branding, onUsername }: LoginPageProps) {
         <div className="login-card">
           <h1 className="login-title">{branding.title}</h1>
 
-          {providers === null ? null : providers.length > 0 ? (
+          {providerError ? (
+            <div className="login-provider-error" role="alert">
+              <p>{providerError}</p>
+              <button type="button" onClick={() => setProviderAttempt((attempt) => attempt + 1)}>
+                重试
+              </button>
+            </div>
+          ) : providers === null ? null : providers.length > 0 ? (
             <>
               <p className="login-sub">登录以继续使用 {branding.title}</p>
               <div className="login-providers">

--- a/frontend/src/ui/ManageAgents.css
+++ b/frontend/src/ui/ManageAgents.css
@@ -357,6 +357,17 @@
   word-break: break-all;
 }
 
+.manage-env-masked {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: hsl(var(--muted-foreground));
+  font: inherit;
+  letter-spacing: 2px;
+  cursor: pointer;
+  user-select: none;
+}
+
 .manage-tree-note {
   font-size: 12px;
   color: hsl(var(--muted-foreground));

--- a/frontend/src/ui/ManageAgents.tsx
+++ b/frontend/src/ui/ManageAgents.tsx
@@ -280,6 +280,27 @@ export function ManageAgentsView({
   );
 }
 
+/** Env keys whose values are commonly credentials. */
+const SENSITIVE_ENV_RE = /KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL/i;
+
+function EnvValue({ envKey, value }: { envKey: string; value: string }) {
+  const [revealed, setRevealed] = useState(false);
+  if (!SENSITIVE_ENV_RE.test(envKey) || revealed) {
+    return <code className="manage-env-v">{value}</code>;
+  }
+  return (
+    <button
+      type="button"
+      className="manage-env-v manage-env-masked"
+      title="敏感值已隐藏，点击显示"
+      aria-label={`显示 ${envKey} 的值`}
+      onClick={() => setRevealed(true)}
+    >
+      ••••••••
+    </button>
+  );
+}
+
 /** Renders the control-plane detail fields (model, resources, envs, ids). */
 function RuntimeDetailCard({ detail }: { detail: RuntimeDetail }) {
   const r = detail.resources;
@@ -322,7 +343,7 @@ function RuntimeDetailCard({ detail }: { detail: RuntimeDetail }) {
           {detail.envs.map((e) => (
             <div key={e.key} className="manage-env">
               <code className="manage-env-k">{e.key}</code>
-              <code className="manage-env-v">{e.value}</code>
+              <EnvValue envKey={e.key} value={e.value} />
             </div>
           ))}
         </div>

--- a/frontend/tests/identity.test.mjs
+++ b/frontend/tests/identity.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import ts from "typescript";
+
+function transpileUrl(source) {
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+  });
+  return `data:text/javascript;base64,${Buffer.from(outputText).toString("base64")}`;
+}
+
+const timeoutSource = readFileSync(new URL("../src/adk/timeout.ts", import.meta.url), "utf8");
+const timeoutUrl = transpileUrl(timeoutSource);
+const identitySource = readFileSync(
+  new URL("../src/adk/identity.ts", import.meta.url),
+  "utf8",
+).replace('from "./timeout"', `from "${timeoutUrl}"`);
+const { fetchProviders, resolveIdentity } = await import(transpileUrl(identitySource));
+
+const originalFetch = globalThis.fetch;
+const originalWarn = console.warn;
+test.before(() => {
+  console.warn = () => {};
+});
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+  delete globalThis.localStorage;
+});
+test.after(() => {
+  console.warn = originalWarn;
+});
+
+test("identity 200 resolves as authenticated", async () => {
+  globalThis.fetch = async () => Response.json({ sub: "u-1", name: "Li" });
+  const identity = await resolveIdentity();
+  assert.equal(identity.status, "authenticated");
+  assert.equal(identity.userId, "u-1");
+  assert.equal(identity.local, undefined);
+});
+
+test("identity 401 keeps SSO mode unauthenticated", async () => {
+  globalThis.fetch = async () => new Response("", { status: 401 });
+  const identity = await resolveIdentity();
+  assert.deepEqual(identity, { status: "unauthenticated", userId: "", local: false });
+});
+
+test("identity 404 enters legacy local mode", async () => {
+  globalThis.fetch = async () => new Response("", { status: 404 });
+  const identity = await resolveIdentity();
+  assert.deepEqual(identity, { status: "unauthenticated", userId: "", local: true });
+});
+
+test("identity 404 restores a saved local username", async () => {
+  globalThis.localStorage = { getItem: () => "alice" };
+  globalThis.fetch = async () => new Response("", { status: 404 });
+  const identity = await resolveIdentity();
+  assert.equal(identity.status, "authenticated");
+  assert.equal(identity.userId, "alice");
+  assert.equal(identity.local, true);
+});
+
+test("identity network and server failures do not enter local mode", async (t) => {
+  globalThis.localStorage = { getItem: () => "alice" };
+  await t.test("network failure", async () => {
+    globalThis.fetch = async () => {
+      throw new TypeError("fetch failed");
+    };
+    await assert.rejects(resolveIdentity(), /无法连接身份服务/);
+  });
+  await t.test("gateway failure", async () => {
+    globalThis.fetch = async () => new Response("bad gateway", { status: 502 });
+    await assert.rejects(resolveIdentity(), /HTTP 502/);
+  });
+});
+
+test("identity rejects a non-JSON success response", async () => {
+  globalThis.fetch = async () => new Response("<!doctype html>", { status: 200 });
+  await assert.rejects(resolveIdentity(), /无法解析/);
+});
+
+test("provider lookup enables local mode only after a successful empty response", async () => {
+  globalThis.fetch = async () => Response.json({ providers: [] });
+  assert.deepEqual(await fetchProviders(), []);
+});
+
+test("provider lookup surfaces failures instead of returning an empty list", async (t) => {
+  await t.test("network failure", async () => {
+    globalThis.fetch = async () => {
+      throw new TypeError("fetch failed");
+    };
+    await assert.rejects(fetchProviders(), /无法加载登录配置/);
+  });
+  await t.test("server failure", async () => {
+    globalThis.fetch = async () => new Response("bad gateway", { status: 502 });
+    await assert.rejects(fetchProviders(), /HTTP 502/);
+  });
+  await t.test("non-JSON response", async () => {
+    globalThis.fetch = async () => new Response("<!doctype html>", { status: 200 });
+    await assert.rejects(fetchProviders(), /无法解析/);
+  });
+});

--- a/frontend/tests/parseSSE.test.mjs
+++ b/frontend/tests/parseSSE.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import ts from "typescript";
+
+const source = readFileSync(new URL("../src/adk/sse.ts", import.meta.url), "utf8");
+const { outputText } = ts.transpileModule(source, {
+  compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+});
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(outputText).toString("base64")}`;
+const { parseSSE } = await import(moduleUrl);
+
+function sseResponse(chunks, { hold = false, onCancel } = {}) {
+  const encoder = new TextEncoder();
+  let index = 0;
+  const stream = new ReadableStream({
+    pull(controller) {
+      if (index < chunks.length) {
+        controller.enqueue(encoder.encode(chunks[index++]));
+      } else if (!hold) {
+        controller.close();
+      }
+    },
+    cancel() {
+      onCancel?.();
+    },
+  });
+  return new Response(stream);
+}
+
+test("reassembles split chunks and parses LF frames", async () => {
+  const response = sseResponse(['data: {"a"', ':1}\n\ndata: {"b":2}\n\n']);
+  const events = [];
+  for await (const event of parseSSE(response)) events.push(event);
+  assert.deepEqual(events, [{ a: 1 }, { b: 2 }]);
+  assert.equal(response.body.locked, false);
+});
+
+test("parses CRLF frames", async () => {
+  const response = sseResponse(['data: {"ok":true}\r', "\n\r\n"]);
+  const events = [];
+  for await (const event of parseSSE(response)) events.push(event);
+  assert.deepEqual(events, [{ ok: true }]);
+});
+
+test("logs malformed data but ignores known terminators", async () => {
+  const messages = [];
+  const originalDebug = console.debug;
+  console.debug = (...args) => messages.push(args);
+  try {
+    const response = sseResponse([
+      "data: [DONE]\n\ndata: ping\n\ndata: malformed\n\ndata: {\"ok\":true}\n\n",
+    ]);
+    const events = [];
+    for await (const event of parseSSE(response)) events.push(event);
+    assert.deepEqual(events, [{ ok: true }]);
+    assert.equal(messages.length, 1);
+    assert.match(String(messages[0][0]), /dropping unparseable frame/);
+  } finally {
+    console.debug = originalDebug;
+  }
+});
+
+test("cancels and unlocks the stream when the consumer exits early", async () => {
+  let cancelled = false;
+  const response = sseResponse(['data: {"first":1}\n\n'], {
+    hold: true,
+    onCancel: () => {
+      cancelled = true;
+    },
+  });
+  for await (const event of parseSSE(response)) {
+    assert.deepEqual(event, { first: 1 });
+    break;
+  }
+  assert.equal(cancelled, true);
+  assert.equal(response.body.locked, false);
+});

--- a/frontend/tests/timeout.test.mjs
+++ b/frontend/tests/timeout.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import ts from "typescript";
+
+const source = readFileSync(new URL("../src/adk/timeout.ts", import.meta.url), "utf8");
+const { outputText } = ts.transpileModule(source, {
+  compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+});
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(outputText).toString("base64")}`;
+const { requestSignal } = await import(moduleUrl);
+const clientSource = readFileSync(new URL("../src/adk/client.ts", import.meta.url), "utf8");
+
+function functionSource(start, end) {
+  return clientSource.slice(clientSource.indexOf(start), clientSource.indexOf(end));
+}
+
+test("deadline aborts a normal request signal", async () => {
+  const signal = requestSignal(undefined, 5);
+  await new Promise((resolve) => setTimeout(resolve, 15));
+  assert.equal(signal.aborted, true);
+  assert.equal(signal.reason.name, "TimeoutError");
+});
+
+test("caller cancellation propagates through a deadline signal", () => {
+  const controller = new AbortController();
+  const signal = requestSignal(controller.signal, 10_000);
+  controller.abort("cancelled by caller");
+  assert.equal(signal.aborted, true);
+  assert.equal(signal.reason, "cancelled by caller");
+});
+
+test("non-positive deadlines leave streaming signals unchanged", () => {
+  const controller = new AbortController();
+  assert.equal(requestSignal(controller.signal, 0), controller.signal);
+  assert.equal(requestSignal(undefined, 0), undefined);
+});
+
+test("chat, deployment, and debug streams explicitly disable deadlines", () => {
+  const chat = functionSource("export async function* runSSE", "const deploymentControllers");
+  const deployment = functionSource(
+    "export async function deployAgentkitProject",
+    "export async function cancelAgentkitDeployment",
+  );
+  const debug = functionSource(
+    "export async function* runGeneratedAgentTestSSE",
+    "export async function deleteGeneratedAgentTestRun",
+  );
+  assert.match(chat, /ep,\s+0,/);
+  assert.match(deployment, /\{\},\s+0,/);
+  assert.match(debug, /\{\},\s+0,/);
+});


### PR DESCRIPTION
## Summary

- reject unsafe OAuth popup URLs and surface identity/provider failures with retry actions
- add 30-second API and 120-second transfer deadlines while keeping chat, debug, and deployment streams deadline-free
- make SSE parsing handle split CRLF frames, known terminators, malformed-frame diagnostics, and early stream cleanup
- mask credential-like runtime environment values until explicitly revealed
- document behavior and add focused identity, timeout, and SSE regression tests

## Regression safety

- npm test (46 tests)
- npx tsc --noEmit
- npx vite build --outDir /tmp/veadk-frontend-resilience-dist --emptyOutDir
- npx markdownlint-cli2 frontend/README.md
- pre-commit run on all changed files

## Scope

This change does not alter SSE heartbeat behavior or gateway timeout configuration.