### PR TITLE
fix(studio): skip duplicate OAuth consent

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ VeADK provides several useful command line tools for faster deployment and optim
   policies; target `cn-beijing` (default) or `cn-shanghai` with
   `--region`, automatically locate the Identity user pool across Beijing and
   Shanghai, and select the VeFaaS project with `--project` (default `default`);
-  custom local or remote logo images are bundled into the deployment
+  custom local or remote logo images are bundled into the deployment; the
+  deployed client skips the second OAuth consent confirmation after login
 
 ## Contribution
 

--- a/docs/content/docs/framework/frontend.en.mdx
+++ b/docs/content/docs/framework/frontend.en.mdx
@@ -182,6 +182,10 @@ then searches the Beijing and Shanghai Identity regions. A cross-region match
 emits a warning and continues. `--project` selects the VeFaaS function project
 and defaults to `default`.
 
+When deployment registers the callback URL, it keeps the VeIdentity login page
+enabled and enables skip-consent for that client. This avoids showing a second
+authorization confirmation after login.
+
 ### IAM permissions for `veadk studio deploy`
 
 The deploy command first checks `ServerlessApplicationRole`. If the role is

--- a/docs/content/docs/framework/frontend.mdx
+++ b/docs/content/docs/framework/frontend.mdx
@@ -167,6 +167,9 @@ veadk studio deploy \
 用户池；跨地域命中时会显示 warning 并继续。`--project` 指定 VeFaaS 函数
 所属项目，默认为 `default`。
 
+部署注册回调地址时会保留 VeIdentity 登录页，并为该客户端开启跳过授权确认，
+避免用户登录后再次确认授权。
+
 ### `veadk studio deploy` 的 IAM 权限
 
 部署命令会先检查 `ServerlessApplicationRole`。如果该 Role 不存在，终端会显示

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -123,6 +123,10 @@ Non-streaming frontend API requests use a 30-second deadline, while file
 transfers use 120 seconds. Chat, debug, and deployment progress streams remain
 open until the server finishes or the caller explicitly cancels them.
 
+`veadk studio deploy` keeps the VeIdentity login page enabled and enables the
+client's skip-consent setting when it registers the deployed callback URL. This
+avoids presenting a second authorization confirmation after login.
+
 ## Multimodal media
 
 The composer accepts PNG, JPEG, WebP, GIF, TXT, Markdown, PDF, MP4, WebM, and

--- a/tests/cli/test_studio_deploy_target.py
+++ b/tests/cli/test_studio_deploy_target.py
@@ -19,6 +19,9 @@ from unittest.mock import Mock
 import pytest
 from click.testing import CliRunner
 from volcenginesdkcore.rest import ApiException
+from volcenginesdkcore.interceptor.interceptors.build_request_interceptor import (
+    sanitize_for_serialization,
+)
 
 from veadk.cli.cli_frontend import _resolve_studio_identity_region, studio
 from veadk.config import veadk_environments
@@ -65,10 +68,17 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
 
         def deploy(self, **kwargs: object) -> SimpleNamespace:
             return SimpleNamespace(
-                vefaas_endpoint="",
+                vefaas_endpoint="https://studio.example.com",
                 vefaas_application_id="app-id",
                 vefaas_function_id="",
             )
+
+    class _FakeIdentityClient:
+        def __init__(self, **_: object) -> None:
+            pass
+
+        def register_callback_for_user_pool_client(self, **kwargs: object) -> None:
+            captured["callback"] = kwargs
 
     monkeypatch.setattr(
         "veadk.cloud.cloud_agent_engine.CloudAgentEngine", _FakeCloudAgentEngine
@@ -76,6 +86,10 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
     monkeypatch.setattr(
         "veadk.cli.cli_frontend._resolve_studio_identity_region",
         lambda **_: expected_identity_region,
+    )
+    monkeypatch.setattr(
+        "veadk.integrations.ve_identity.identity_client.IdentityClient",
+        _FakeIdentityClient,
     )
 
     result = CliRunner().invoke(
@@ -108,6 +122,10 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
     assert ("Warning:" in result.output) == (
         expected_identity_region != expected_region
     )
+    callback = captured["callback"]
+    assert isinstance(callback, dict)
+    assert callback["dismiss_login_page_enabled"] is False
+    assert callback["skip_consent_enabled"] is True
 
 
 def test_studio_identity_region_searches_deployment_region_first(
@@ -159,6 +177,71 @@ def test_identity_region_probe_only_swallows_not_found() -> None:
     )
     with pytest.raises(ApiException):
         identity_client.user_pool_client_exists("pool-id", "client-id")
+
+
+@pytest.mark.parametrize(
+    ("switches", "expected_switches"),
+    [
+        ({}, {}),
+        (
+            {
+                "dismiss_login_page_enabled": False,
+                "skip_consent_enabled": True,
+            },
+            {
+                "DismissLoginPageEnabled": False,
+                "SkipConsentEnabled": True,
+            },
+        ),
+    ],
+)
+def test_register_callback_only_sends_requested_login_switches(
+    switches: dict[str, bool],
+    expected_switches: dict[str, bool],
+) -> None:
+    identity_client = IdentityClient(
+        access_key="test_access_key",
+        secret_key="test_secret_key",
+    )
+    identity_client._api_client = Mock()
+    identity_client._api_client.get_user_pool_client.return_value = SimpleNamespace(
+        allowed_callback_urls=["https://existing.example.com/oauth2/callback"],
+        allowed_web_origins=["https://existing.example.com"],
+        name="studio-client",
+        description=None,
+        allowed_logout_urls=None,
+        allowed_cors=None,
+        id_token=None,
+        refresh_token=None,
+    )
+
+    identity_client.register_callback_for_user_pool_client(
+        user_pool_uid="pool-id",
+        client_uid="client-id",
+        callback_url="https://studio.example.com/oauth2/callback",
+        web_origin="https://studio.example.com",
+        **switches,
+    )
+
+    update_request = identity_client._api_client.update_user_pool_client.call_args.args[
+        0
+    ]
+    assert update_request.user_pool_uid == "pool-id"
+    assert update_request.client_uid == "client-id"
+    assert update_request.allowed_callback_urls == [
+        "https://existing.example.com/oauth2/callback",
+        "https://studio.example.com/oauth2/callback",
+    ]
+    assert update_request.allowed_web_origins == [
+        "https://existing.example.com",
+        "https://studio.example.com",
+    ]
+    serialized_request = sanitize_for_serialization(update_request)
+    for key in ("DismissLoginPageEnabled", "SkipConsentEnabled"):
+        assert (key in serialized_request) == (key in expected_switches)
+    assert {
+        key: serialized_request[key] for key in expected_switches
+    } == expected_switches
 
 
 def test_studio_deploy_rejects_unsupported_region() -> None:

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -3420,6 +3420,8 @@ def frontend_deploy(
                     client_uid=allowed_client_id,
                     callback_url=redirect_uri,
                     web_origin=url,
+                    dismiss_login_page_enabled=False,
+                    skip_consent_enabled=True,
                 )
                 click.echo(f"Registered SSO callback: {redirect_uri}")
             except Exception as e:

--- a/veadk/integrations/ve_identity/identity_client.py
+++ b/veadk/integrations/ve_identity/identity_client.py
@@ -827,6 +827,9 @@ class IdentityClient:
         client_uid: str,
         callback_url: str,
         web_origin: str,
+        *,
+        dismiss_login_page_enabled: bool | None = None,
+        skip_consent_enabled: bool | None = None,
     ):
         from volcenginesdkid import (
             GetUserPoolClientRequest,
@@ -862,6 +865,8 @@ class IdentityClient:
             allowed_cors=response.allowed_cors,
             id_token=response.id_token,
             refresh_token=response.refresh_token,
+            dismiss_login_page_enabled=dismiss_login_page_enabled,
+            skip_consent_enabled=skip_consent_enabled,
         )
         self._api_client.update_user_pool_client(request2)
 


### PR DESCRIPTION
## Summary

- configure Studio-deployed VeIdentity clients with the login page enabled and consent confirmation skipped
- keep the new client switches optional so existing callback-registration callers retain their current behavior
- document the Studio SSO behavior and cover both SDK serialization and deploy wiring

## Verification

- 23 focused tests passed
- Ruff check and format passed
- pre-commit and secret scan passed locally
- deployed from source to cn-beijing/default
- verified DismissLoginPageEnabled=false and SkipConsentEnabled=true via GetUserPoolClient
- verified the deployed login flow reaches the configured Feishu identity provider without a second consent page

## Cloud smoke test

- application: veadk-studio-consent-0721
- application ID: 0cbfa32d68c9
- URL: https://ssmsfndh6m3d00jtl5l4f.apigateway-cn-beijing.volceapi.com/