### PR TITLE
fix(deps): require AgentKit SDK CORS defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "pypdfium2>=4.30.0", # Frontend PDF attachments are rendered as page images
     "pillow>=10.0.0", # Encode rendered PDF pages as PNG
     "vikingdb-python-sdk>=0.1.3", # For Viking DB
-    "agentkit-sdk-python>=0.2.0",
+    "agentkit-sdk-python>=0.5.10",
     "openviking-sdk>=0.1.3",
     "python-frontmatter==1.1.0",
     "tos>=2.8.4",   # For TOS storage and Viking DB


### PR DESCRIPTION
## Summary

- raise the minimum `agentkit-sdk-python` version from 0.2.0 to 0.5.10
- guarantee `AgentkitAgentServerApp` uses the wildcard CORS default required after the Google ADK upgrade
- retain compatibility handling for Google ADK versions with different `get_fast_api_app` CORS support

## Validation

- `uv lock --check`
- `uv pip check`
- built the wheel and verified its metadata contains `Requires-Dist: agentkit-sdk-python>=0.5.10`

Upstream AgentKit SDK change: https://github.com/volcengine/agentkit-sdk-python/commit/f2745a04cd34d0224202fa3faf76604a7d7b7111
