### PR TITLE
feat: add Studio in-place update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ VeADK provides several useful command line tools for faster deployment and optim
   Shanghai, and select the VeFaaS project with `--project` (default `default`);
   custom local or remote logo images are bundled into the deployment; the
   deployed client skips the second OAuth consent confirmation after login
+- `veadk studio update --vefaas-app-name <app-name>`: build the frontend from a
+  local VeADK source checkout and release it through the existing VeFaaS
+  Application and Function. Omit `--region` and `--project` to search Beijing,
+  Shanghai, and all visible projects. Existing URL, SSO, IAM, gateway,
+  environment variables, title, and logo are preserved; pass `--site-title` or
+  `--site-logo` only when those branding values should be replaced
 
 ## Contribution
 

--- a/docs/content/docs/framework/frontend.en.mdx
+++ b/docs/content/docs/framework/frontend.en.mdx
@@ -182,6 +182,24 @@ then searches the Beijing and Shanghai Identity regions. A cross-region match
 emits a warning and continues. `--project` selects the VeFaaS function project
 and defaults to `default`.
 
+To update an existing Studio deployment, run this command from a VeADK source
+checkout:
+
+```bash
+veadk studio update --vefaas-app-name <app-name>
+```
+
+The command rebuilds the local frontend, replaces the existing VeFaaS
+Function's code, and releases the original Application. When `--region` and
+`--project` are omitted, it searches Beijing, Shanghai, and all visible
+projects. If the Application name is ambiguous, it lists the candidates and
+requires a narrower scope. The update preserves the Application and Function
+IDs, URL, SSO, IAM, gateway, and existing environment variables. `--site-title`
+and `--site-logo` replace cloud branding only when explicitly provided;
+otherwise the current values are retained. Use `--path` to select a source
+checkout; it defaults to the current directory. Node.js and npm must be
+installed locally.
+
 When deployment registers the callback URL, it keeps the VeIdentity login page
 enabled and enables skip-consent for that client. This avoids showing a second
 authorization confirmation after login.

--- a/docs/content/docs/framework/frontend.mdx
+++ b/docs/content/docs/framework/frontend.mdx
@@ -167,6 +167,19 @@ veadk studio deploy \
 用户池；跨地域命中时会显示 warning 并继续。`--project` 指定 VeFaaS 函数
 所属项目，默认为 `default`。
 
+更新已部署的 Studio 时，在 VeADK 源码目录执行：
+
+```bash
+veadk studio update --vefaas-app-name <app-name>
+```
+
+该命令重新构建本地前端并更新已有 VeFaaS Function 的代码，然后发布原
+Application。未指定 `--region` 和 `--project` 时，会在北京、上海以及所有可见
+项目中查找；若同名 Application 不唯一，命令会列出候选项并要求缩小范围。
+更新不会改变 Application/Function ID、访问 URL、SSO、IAM、网关或已有环境
+变量。`--site-title` 和 `--site-logo` 仅在显式传入时覆盖，省略时保留云上品牌
+设置。可用 `--path` 指定源码目录，默认为当前目录；本地需安装 Node.js 与 npm。
+
 部署注册回调地址时会保留 VeIdentity 登录页，并为该客户端开启跳过授权确认，
 避免用户登录后再次确认授权。
 

--- a/tests/cli/test_studio_update.py
+++ b/tests/cli/test_studio_update.py
@@ -1,0 +1,478 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import subprocess
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from click.testing import CliRunner
+
+from veadk.cli.cli_frontend import studio
+from veadk.cli.frontend_branding import SiteLogo
+from veadk.cli.studio_update import (
+    StudioDeploymentTarget,
+    find_studio_deployments,
+    load_deployed_site_logo,
+)
+from veadk.cli.studio_package import build_frontend_assets
+from veadk.integrations.ve_faas.ve_faas import VeFaaS
+
+_PNG = b"\x89PNG\r\n\x1a\n" + b"0" * 32
+
+
+def _target(
+    *,
+    region: str = "cn-beijing",
+    project: str = "default",
+    application_id: str = "app-id",
+) -> StudioDeploymentTarget:
+    return StudioDeploymentTarget(
+        application_name="studio-app",
+        application_id=application_id,
+        function_id=f"function-{application_id}",
+        region=region,
+        project=project,
+        url="https://studio.example.com",
+    )
+
+
+def test_build_frontend_assets_runs_clean_install_and_production_build(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_root = tmp_path / "source"
+    frontend_root = source_root / "frontend"
+    frontend_root.mkdir(parents=True)
+    (source_root / "pyproject.toml").write_text("", encoding="utf-8")
+    (source_root / "README.md").write_text("", encoding="utf-8")
+    (source_root / "LICENSE").write_text("", encoding="utf-8")
+    (frontend_root / "package.json").write_text("{}", encoding="utf-8")
+    (frontend_root / "package-lock.json").write_text("{}", encoding="utf-8")
+    (source_root / "veadk").mkdir()
+    output_dir = tmp_path / "built"
+    commands: list[list[str]] = []
+
+    def _run(
+        command: list[str], *, cwd: Path, check: bool
+    ) -> subprocess.CompletedProcess:
+        commands.append(command)
+        assert cwd == frontend_root
+        assert check is True
+        if "build" in command:
+            output_dir.mkdir()
+            (output_dir / "index.html").write_text("built", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("veadk.cli.studio_package.shutil.which", lambda _: "/bin/npm")
+    monkeypatch.setattr("veadk.cli.studio_package.subprocess.run", _run)
+
+    build_frontend_assets(source_root, output_dir)
+
+    assert commands == [
+        ["/bin/npm", "ci"],
+        ["/bin/npm", "run", "build", "--", "--outDir", str(output_dir)],
+    ]
+
+
+def test_find_studio_deployments_searches_regions_and_filters_project(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checked_regions: list[str] = []
+
+    class _FakeVeFaaS:
+        def __init__(self, **kwargs: str) -> None:
+            self.region = kwargs["region"]
+            checked_regions.append(self.region)
+            self.client = SimpleNamespace(get_function=self._get_function)
+
+        def _list_application(self, app_name: str) -> list[dict[str, object]]:
+            assert app_name == "studio-app"
+            return [
+                {
+                    "Name": "studio-app",
+                    "Id": f"app-{self.region}",
+                    "CloudResource": json.dumps(
+                        {
+                            "framework": {
+                                "function": {"Id": f"fn-{self.region}"},
+                                "url": {
+                                    "system_url": f"https://{self.region}.example.com"
+                                },
+                            }
+                        }
+                    ),
+                }
+            ]
+
+        def _get_function(self, _: object) -> SimpleNamespace:
+            project = "wanted" if self.region == "cn-shanghai" else "other"
+            return SimpleNamespace(project_name=project)
+
+    monkeypatch.setattr("veadk.cli.studio_update.VeFaaS", _FakeVeFaaS)
+
+    targets = find_studio_deployments(
+        access_key="ak",
+        secret_key="sk",
+        application_name="studio-app",
+        region=None,
+        project="wanted",
+    )
+
+    assert checked_regions == ["cn-beijing", "cn-shanghai"]
+    assert targets == [
+        StudioDeploymentTarget(
+            application_name="studio-app",
+            application_id="app-cn-shanghai",
+            function_id="fn-cn-shanghai",
+            region="cn-shanghai",
+            project="wanted",
+            url="https://cn-shanghai.example.com",
+        )
+    ]
+
+
+def test_list_applications_uses_client_region(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested_regions: list[str] = []
+
+    def _request(**kwargs: object) -> dict[str, object]:
+        requested_regions.append(str(kwargs["region"]))
+        return {"Result": {"Items": [], "Total": 0}}
+
+    service = object.__new__(VeFaaS)
+    service.ak = "ak"
+    service.sk = "sk"
+    service.region = "cn-shanghai"
+    monkeypatch.setattr("veadk.integrations.ve_faas.ve_faas.ve_request", _request)
+
+    assert service._list_application(app_name="studio-app") == []
+    assert requested_regions == ["cn-shanghai"]
+
+
+def test_load_deployed_site_logo_uses_current_branding_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = SimpleNamespace(
+        raise_for_status=lambda: None,
+        json=lambda: {"branding": {"logoUrl": "/web/site-logo"}},
+    )
+    monkeypatch.setattr("veadk.cli.studio_update.httpx.get", lambda *_a, **_k: response)
+    resolved_urls: list[str] = []
+    expected = SiteLogo(content=_PNG, media_type="image/png", extension="png")
+
+    def _resolve(url: str) -> SiteLogo:
+        resolved_urls.append(url)
+        return expected
+
+    monkeypatch.setattr("veadk.cli.studio_update.resolve_site_logo", _resolve)
+
+    assert load_deployed_site_logo(_target()) == expected
+    assert resolved_urls == ["https://studio.example.com/web/site-logo"]
+
+
+def test_studio_update_preserves_branding_and_updates_existing_ids(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    target = _target()
+    logo = SiteLogo(content=_PNG, media_type="image/png", extension="png")
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "veadk.cli.studio_update.find_studio_deployments", lambda **_: [target]
+    )
+    monkeypatch.setattr(
+        "veadk.cli.studio_update.load_deployed_site_logo", lambda _: logo
+    )
+
+    def _build_frontend(_: Path, output_dir: Path) -> None:
+        output_dir.mkdir(parents=True)
+        (output_dir / "index.html").write_text("built", encoding="utf-8")
+
+    def _build_requirements(
+        _: Path, package_dir: Path, *, frontend_assets: Path
+    ) -> str:
+        captured["frontend"] = (frontend_assets / "index.html").read_text()
+        return "./veadk.whl\n"
+
+    def _write_package(
+        package_dir: Path, *, requirements: str, site_logo: SiteLogo | None
+    ) -> None:
+        package_dir.mkdir(parents=True, exist_ok=True)
+        (package_dir / "run.sh").write_text("run", encoding="utf-8")
+        captured["requirements"] = requirements
+        captured["logo"] = site_logo
+
+    monkeypatch.setattr(
+        "veadk.cli.studio_package.build_frontend_assets", _build_frontend
+    )
+    monkeypatch.setattr(
+        "veadk.cli.studio_package.build_local_studio_requirements",
+        _build_requirements,
+    )
+    monkeypatch.setattr("veadk.cli.studio_package.write_studio_package", _write_package)
+
+    class _FakeVeFaaS:
+        def __init__(self, **kwargs: str) -> None:
+            captured["scope"] = kwargs
+
+        def update_application_code_bundle(self, **kwargs: object) -> str:
+            captured["update"] = kwargs
+            assert (Path(str(kwargs["path"])) / "run.sh").is_file()
+            return target.url
+
+    monkeypatch.setattr("veadk.integrations.ve_faas.ve_faas.VeFaaS", _FakeVeFaaS)
+
+    result = CliRunner().invoke(
+        studio,
+        [
+            "update",
+            "--vefaas-app-name",
+            "studio-app",
+            "--path",
+            str(tmp_path),
+            "--volcengine-access-key",
+            "ak",
+            "--volcengine-secret-key",
+            "sk",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["frontend"] == "built"
+    assert captured["requirements"] == "./veadk.whl\n"
+    assert captured["logo"] == logo
+    assert captured["scope"] == {
+        "access_key": "ak",
+        "secret_key": "sk",
+        "region": "cn-beijing",
+        "project_name": "default",
+    }
+    update = captured["update"]
+    assert isinstance(update, dict)
+    assert update["application_id"] == "app-id"
+    assert update["function_id"] == "function-app-id"
+    assert update["environment_overrides"] is None
+
+
+def test_studio_update_rejects_ambiguous_name_before_build(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "veadk.cli.studio_update.find_studio_deployments",
+        lambda **_: [
+            _target(),
+            _target(
+                region="cn-shanghai",
+                project="other",
+                application_id="other-app-id",
+            ),
+        ],
+    )
+    build = pytest.fail
+    monkeypatch.setattr("veadk.cli.studio_package.build_frontend_assets", build)
+
+    result = CliRunner().invoke(
+        studio,
+        [
+            "update",
+            "--vefaas-app-name",
+            "studio-app",
+            "--volcengine-access-key",
+            "ak",
+            "--volcengine-secret-key",
+            "sk",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Multiple VeFaaS Applications" in result.output
+    assert "cn-beijing/default" in result.output
+    assert "cn-shanghai/other" in result.output
+
+
+def test_studio_update_missing_target_does_not_build(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "veadk.cli.studio_update.find_studio_deployments", lambda **_: []
+    )
+    monkeypatch.setattr(
+        "veadk.cli.studio_package.build_frontend_assets",
+        lambda *_: pytest.fail("frontend should not be built"),
+    )
+
+    result = CliRunner().invoke(
+        studio,
+        [
+            "update",
+            "--vefaas-app-name",
+            "missing-studio",
+            "--volcengine-access-key",
+            "ak",
+            "--volcengine-secret-key",
+            "sk",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "was not found" in result.output
+
+
+def test_studio_update_explicit_branding_overrides_cloud_values(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    target = _target()
+    logo_path = tmp_path / "logo.png"
+    logo_path.write_bytes(_PNG)
+    captured: dict[str, object] = {}
+
+    def _find(**kwargs: object) -> list[StudioDeploymentTarget]:
+        captured["search"] = kwargs
+        return [target]
+
+    monkeypatch.setattr(
+        "veadk.cli.studio_update.find_studio_deployments",
+        _find,
+    )
+    monkeypatch.setattr(
+        "veadk.cli.studio_update.load_deployed_site_logo",
+        lambda _: pytest.fail("cloud logo should not be loaded"),
+    )
+    monkeypatch.setattr(
+        "veadk.cli.studio_package.build_frontend_assets", lambda *_: None
+    )
+    monkeypatch.setattr(
+        "veadk.cli.studio_package.build_local_studio_requirements",
+        lambda *_a, **_k: "./veadk.whl\n",
+    )
+
+    def _write_package(
+        package_dir: Path, *, requirements: str, site_logo: SiteLogo | None
+    ) -> None:
+        package_dir.mkdir(parents=True, exist_ok=True)
+        captured["logo"] = site_logo
+
+    monkeypatch.setattr("veadk.cli.studio_package.write_studio_package", _write_package)
+
+    class _FakeVeFaaS:
+        def __init__(self, **_: str) -> None:
+            pass
+
+        def update_application_code_bundle(self, **kwargs: object) -> str:
+            captured["update"] = kwargs
+            return target.url
+
+    monkeypatch.setattr("veadk.integrations.ve_faas.ve_faas.VeFaaS", _FakeVeFaaS)
+
+    result = CliRunner().invoke(
+        studio,
+        [
+            "update",
+            "--vefaas-app-name",
+            "studio-app",
+            "--path",
+            str(tmp_path),
+            "--region",
+            "cn-beijing",
+            "--project",
+            "default",
+            "--site-logo",
+            str(logo_path),
+            "--site-title",
+            "新标题",
+            "--volcengine-access-key",
+            "ak",
+            "--volcengine-secret-key",
+            "sk",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    logo = captured["logo"]
+    assert isinstance(logo, SiteLogo)
+    assert logo.content == _PNG
+    search = captured["search"]
+    assert isinstance(search, dict)
+    assert search["region"] == "cn-beijing"
+    assert search["project"] == "default"
+    update = captured["update"]
+    assert isinstance(update, dict)
+    assert update["environment_overrides"] == {"VEADK_SITE_TITLE": "新标题"}
+
+
+def test_update_application_code_bundle_merges_only_explicit_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    updated_requests: list[Any] = []
+    service = object.__new__(VeFaaS)
+    cast(Any, service).client = SimpleNamespace(
+        get_function=lambda _: SimpleNamespace(
+            envs=[
+                SimpleNamespace(key="EXISTING", value="kept"),
+                SimpleNamespace(key="VEADK_SITE_TITLE", value="old"),
+            ]
+        ),
+        update_function=updated_requests.append,
+    )
+    monkeypatch.setattr(service, "_upload_and_mount_code", lambda *_: None)
+    monkeypatch.setattr(service, "_release_application", lambda _: "https://same")
+
+    url = service.update_application_code_bundle(
+        application_id="app-id",
+        function_id="function-id",
+        path=str(tmp_path),
+        environment_overrides={"VEADK_SITE_TITLE": "新标题"},
+    )
+
+    assert url == "https://same"
+    request = updated_requests[0]
+    assert request.id == "function-id"
+    assert {item.key: item.value for item in request.envs} == {
+        "EXISTING": "kept",
+        "VEADK_SITE_TITLE": "新标题",
+    }
+
+
+def test_update_application_code_bundle_does_not_read_or_replace_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    updated_requests: list[Any] = []
+    service = object.__new__(VeFaaS)
+    cast(Any, service).client = SimpleNamespace(
+        get_function=lambda _: pytest.fail("environment should not be read"),
+        update_function=updated_requests.append,
+    )
+    monkeypatch.setattr(service, "_upload_and_mount_code", lambda *_: None)
+    monkeypatch.setattr(service, "_release_application", lambda _: "https://same")
+
+    service.update_application_code_bundle(
+        application_id="app-id",
+        function_id="function-id",
+        path=str(tmp_path),
+    )
+
+    request = updated_requests[0]
+    assert request.id == "function-id"
+    assert request.envs is None
+    assert request.request_timeout is None

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -3026,21 +3026,9 @@ def _run_frontend_server(
 
 def _studio_deploy_run_script(site_logo_filename: str | None = None) -> str:
     """Return the authenticated VeFaaS entrypoint used by ``studio deploy``."""
-    command = "exec python3 -m veadk.cli.cli studio --auth-mode frontend"
-    if site_logo_filename:
-        command += f' --site-logo "$ROOT_DIR/{site_logo_filename}"'
-    command += ' --host "$HOST" --port "$PORT"\n'
-    return (
-        "#!/bin/bash\n"
-        "set -ex\n"
-        'ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"\n'
-        'cd "$ROOT_DIR"\n'
-        'if [ -d "output" ]; then cd ./output/; fi\n'
-        "HOST=0.0.0.0\n"
-        "PORT=${_FAAS_RUNTIME_PORT:-8000}\n"
-        "export PYTHONPATH=$PYTHONPATH:./site-packages\n"
-        f"{command}"
-    )
+    from veadk.cli.studio_package import studio_run_script
+
+    return studio_run_script(site_logo_filename)
 
 
 def _resolve_studio_identity_region(
@@ -3257,10 +3245,6 @@ def frontend_deploy(
     requirements = (
         f"veadk-python=={veadk_version}\n" if veadk_version else "veadk-python\n"
     )
-    logo_filename = (
-        f"site-logo.{branding_logo.extension}" if branding_logo is not None else None
-    )
-    run_sh = _studio_deploy_run_script(logo_filename)
     # 3b) Resolve the serverless APIG gateway: use --gateway-name if given, else
     #     reuse an existing serverless gateway, creating one only if none exists.
     #     (VeFaaS applications can only attach to a serverless gateway; reusing
@@ -3281,101 +3265,28 @@ def frontend_deploy(
 
     tmp = tempfile.mkdtemp(prefix=f"veadk_frontend_deploy_{vefaas_app_name}_")
     try:
-        (Path(tmp) / "run.sh").write_text(run_sh, encoding="utf-8")
-        if branding_logo is not None and logo_filename is not None:
-            (Path(tmp) / logo_filename).write_bytes(branding_logo.content)
-
         # When --from-source, build a wheel from this checkout (picks up
         # uncommitted changes + the current veadk/webui) and install it instead
         # of the PyPI release, so the deployed frontend runs this branch's code.
         if from_source:
-            import hashlib
-            import shutil as _shutil
-            import subprocess
-            import sys
-            from urllib.request import urlopen
-
             import veadk
 
-            repo_root = Path(veadk.__file__).resolve().parent.parent
-            if not (repo_root / "pyproject.toml").is_file():
-                raise click.ClickException(
-                    f"--from-source: no pyproject.toml at {repo_root}; run from a "
-                    "veadk source checkout."
-                )
-            click.echo(f"Building wheel from source at {repo_root}…")
-            uv = _shutil.which("uv")
-            if uv:
-                cmd = [uv, "build", "--wheel", str(repo_root), "-o", tmp]
-            else:
-                cmd = [
-                    sys.executable,
-                    "-m",
-                    "build",
-                    "--wheel",
-                    "-o",
-                    tmp,
-                    str(repo_root),
-                ]
-            subprocess.run(cmd, check=True)
-            wheels = list(Path(tmp).glob("veadk*.whl"))
-            if not wheels:
-                raise click.ClickException(
-                    "--from-source: wheel build produced no .whl"
-                )
-            wheel_name = wheels[0].name
-            click.echo(f"Shipping local wheel: {wheel_name}")
-            # VeFaaS's package mirror can lag public PyPI, while its build
-            # environment cannot reliably reach public PyPI. Bundle the pinned
-            # dependencies currently missing or stale in that mirror.
-            bundled_wheels = [
-                (
-                    "trustedmcp-0.0.5-py3-none-any.whl",
-                    "https://files.pythonhosted.org/packages/e0/5b/"
-                    "9d60a8633f4ab94c9ec0621b51a74d866086b4cb6579882fa4fb9186023b/"
-                    "trustedmcp-0.0.5-py3-none-any.whl",
-                    "3e89f6c9f5fb17cb70aaaa37df21a6e01722ccb1eec6cb8fc2e61417016986d4",
-                ),
-                (
-                    "volcengine_python_sdk-5.0.36-py2.py3-none-any.whl",
-                    "https://files.pythonhosted.org/packages/00/a1/"
-                    "9e246023bb847329bda43e516c64aa10d77b2d98c662f0e1179689020c23/"
-                    "volcengine_python_sdk-5.0.36-py2.py3-none-any.whl",
-                    "3a74fa7a7baa5d5f604b175f967660cd0aa4c7057ce44d98c4041fbaf7944b5b",
-                ),
-                (
-                    "tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64."
-                    "manylinux2014_x86_64.whl",
-                    "https://files.pythonhosted.org/packages/2e/76/"
-                    "932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/"
-                    "tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64."
-                    "manylinux2014_x86_64.whl",
-                    "369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67",
-                ),
-                (
-                    "openviking_sdk-0.1.4-py3-none-any.whl",
-                    "https://files.pythonhosted.org/packages/fe/af/"
-                    "4ca139b05f39c8ed04339d7c8aa56550df80f97d39768d2df9bd72fdbbb9/"
-                    "openviking_sdk-0.1.4-py3-none-any.whl",
-                    "1e9f23332b1b687dd7f272e660953992de60ad3e9d07d62f7460fd4aedb99616",
-                ),
-            ]
-            for dependency_name, dependency_url, dependency_sha256 in bundled_wheels:
-                with urlopen(dependency_url, timeout=60) as response:
-                    dependency_wheel = response.read()
-                if hashlib.sha256(dependency_wheel).hexdigest() != dependency_sha256:
-                    raise click.ClickException(
-                        f"--from-source: {dependency_name} checksum verification failed"
-                    )
-                (Path(tmp) / dependency_name).write_bytes(dependency_wheel)
-            requirements = (
-                "".join(
-                    f"./{dependency_name}\n" for dependency_name, _, _ in bundled_wheels
-                )
-                + f"./{wheel_name}\n"
-            )
+            from veadk.cli.studio_package import build_local_studio_requirements
 
-        (Path(tmp) / "requirements.txt").write_text(requirements, encoding="utf-8")
+            repo_root = Path(veadk.__file__).resolve().parent.parent
+            click.echo(f"Building wheel from source at {repo_root}…")
+            try:
+                requirements = build_local_studio_requirements(repo_root, Path(tmp))
+            except ValueError as error:
+                raise click.ClickException(f"--from-source: {error}") from error
+
+        from veadk.cli.studio_package import write_studio_package
+
+        write_studio_package(
+            Path(tmp),
+            requirements=requirements,
+            site_logo=branding_logo,
+        )
 
         # 3) Deploy the function + a plain public APIG trigger on the serverless
         #    gateway (auth_method="none" — no gateway SSO plugin / domain upstream).
@@ -3443,5 +3354,159 @@ def frontend_deploy(
         click.echo(f"✅ Frontend deployed: {url}")
         click.echo(f"   application id: {app.vefaas_application_id}")
         click.echo("   (open the URL — you'll be redirected through SSO login)")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+@studio.command("update")
+@click.option(
+    "--vefaas-app-name",
+    required=True,
+    help="Existing VeFaaS Application name to update.",
+)
+@click.option(
+    "--region",
+    default=None,
+    type=click.Choice(["cn-beijing", "cn-shanghai"]),
+    help="Limit Application lookup to one region (default: search both).",
+)
+@click.option(
+    "--project",
+    default=None,
+    help="Limit Application lookup to one project (default: search all visible projects).",
+)
+@click.option(
+    "--path",
+    default=".",
+    show_default=True,
+    type=click.Path(file_okay=False, path_type=Path),
+    help="VeADK source checkout whose frontend will be built and uploaded.",
+)
+@click.option(
+    "--site-logo",
+    default=None,
+    help="Replace the deployed Studio logo with a local image or HTTP(S) URL.",
+)
+@click.option(
+    "--site-title",
+    default=None,
+    help="Replace the deployed Studio title, at most 6 characters.",
+)
+@click.option("--volcengine-access-key", default=None)
+@click.option("--volcengine-secret-key", default=None)
+def frontend_update(
+    vefaas_app_name: str,
+    region: str | None,
+    project: str | None,
+    path: Path,
+    site_logo: str | None,
+    site_title: str | None,
+    volcengine_access_key: str | None,
+    volcengine_secret_key: str | None,
+) -> None:
+    """Build local Studio sources and update an existing VeFaaS Application."""
+    import shutil
+    import tempfile
+
+    from veadk.cli.studio_package import (
+        build_frontend_assets,
+        build_local_studio_requirements,
+        write_studio_package,
+    )
+    from veadk.cli.studio_update import (
+        find_studio_deployments,
+        load_deployed_site_logo,
+    )
+    from veadk.config import getenv
+    from veadk.integrations.ve_faas.ve_faas import VeFaaS
+
+    ak = volcengine_access_key or getenv("VOLCENGINE_ACCESS_KEY")
+    sk = volcengine_secret_key or getenv("VOLCENGINE_SECRET_KEY")
+    if not ak or not sk:
+        raise click.ClickException(
+            "Volcengine credentials required: set VOLCENGINE_ACCESS_KEY/SECRET_KEY "
+            "or pass --volcengine-access-key/--volcengine-secret-key."
+        )
+
+    targets = find_studio_deployments(
+        access_key=ak,
+        secret_key=sk,
+        application_name=vefaas_app_name,
+        region=region,
+        project=project,
+    )
+    if not targets:
+        scope = "/".join(value for value in (region, project) if value) or (
+            "cn-beijing and cn-shanghai across all visible projects"
+        )
+        raise click.ClickException(
+            f"VeFaaS Application '{vefaas_app_name}' was not found in {scope}."
+        )
+    if len(targets) > 1:
+        candidates = "\n".join(
+            f"  - {target.region}/{target.project} "
+            f"(Application ID: {target.application_id})"
+            for target in targets
+        )
+        raise click.ClickException(
+            f"Multiple VeFaaS Applications named '{vefaas_app_name}' were found. "
+            "Specify --region and/or --project:\n"
+            f"{candidates}"
+        )
+    target = targets[0]
+
+    try:
+        branding_logo = (
+            resolve_site_logo(site_logo)
+            if site_logo is not None
+            else load_deployed_site_logo(target)
+        )
+        branding_title = (
+            normalize_site_title(site_title) if site_title is not None else None
+        )
+    except ValueError as error:
+        raise click.ClickException(str(error)) from error
+
+    source_root = path.expanduser().resolve()
+    tmp = Path(tempfile.mkdtemp(prefix=f"veadk_studio_update_{vefaas_app_name}_"))
+    package_dir = tmp / "package"
+    try:
+        click.echo(f"Building Studio frontend from {source_root}…")
+        frontend_assets = tmp / "frontend"
+        try:
+            build_frontend_assets(source_root, frontend_assets)
+            requirements = build_local_studio_requirements(
+                source_root,
+                package_dir,
+                frontend_assets=frontend_assets,
+            )
+        except ValueError as error:
+            raise click.ClickException(str(error)) from error
+        write_studio_package(
+            package_dir,
+            requirements=requirements,
+            site_logo=branding_logo,
+        )
+
+        click.echo(f"Updating '{vefaas_app_name}' in {target.region}/{target.project}…")
+        service = VeFaaS(
+            access_key=ak,
+            secret_key=sk,
+            region=target.region,
+            project_name=target.project,
+        )
+        environment_overrides = (
+            {"VEADK_SITE_TITLE": branding_title} if branding_title is not None else None
+        )
+        url = service.update_application_code_bundle(
+            application_id=target.application_id,
+            function_id=target.function_id,
+            path=str(package_dir),
+            environment_overrides=environment_overrides,
+        )
+        click.echo("")
+        click.echo(f"✅ Studio updated: {url}")
+        click.echo(f"   application id: {target.application_id}")
+        click.echo(f"   function id: {target.function_id}")
     finally:
         shutil.rmtree(tmp, ignore_errors=True)

--- a/veadk/cli/studio_package.py
+++ b/veadk/cli/studio_package.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build the source bundle used by a VeFaaS-hosted Studio."""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+from veadk.cli.frontend_branding import SiteLogo
+
+_BUNDLED_WHEELS = (
+    (
+        "trustedmcp-0.0.5-py3-none-any.whl",
+        "https://files.pythonhosted.org/packages/e0/5b/"
+        "9d60a8633f4ab94c9ec0621b51a74d866086b4cb6579882fa4fb9186023b/"
+        "trustedmcp-0.0.5-py3-none-any.whl",
+        "3e89f6c9f5fb17cb70aaaa37df21a6e01722ccb1eec6cb8fc2e61417016986d4",
+    ),
+    (
+        "volcengine_python_sdk-5.0.36-py2.py3-none-any.whl",
+        "https://files.pythonhosted.org/packages/00/a1/"
+        "9e246023bb847329bda43e516c64aa10d77b2d98c662f0e1179689020c23/"
+        "volcengine_python_sdk-5.0.36-py2.py3-none-any.whl",
+        "3a74fa7a7baa5d5f604b175f967660cd0aa4c7057ce44d98c4041fbaf7944b5b",
+    ),
+    (
+        "tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        "https://files.pythonhosted.org/packages/2e/76/"
+        "932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/"
+        "tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64."
+        "manylinux2014_x86_64.whl",
+        "369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67",
+    ),
+    (
+        "openviking_sdk-0.1.4-py3-none-any.whl",
+        "https://files.pythonhosted.org/packages/fe/af/"
+        "4ca139b05f39c8ed04339d7c8aa56550df80f97d39768d2df9bd72fdbbb9/"
+        "openviking_sdk-0.1.4-py3-none-any.whl",
+        "1e9f23332b1b687dd7f272e660953992de60ad3e9d07d62f7460fd4aedb99616",
+    ),
+)
+
+
+def studio_run_script(site_logo_filename: str | None = None) -> str:
+    """Return the authenticated VeFaaS entrypoint used by Studio."""
+    command = "exec python3 -m veadk.cli.cli studio --auth-mode frontend"
+    if site_logo_filename:
+        command += f' --site-logo "$ROOT_DIR/{site_logo_filename}"'
+    command += ' --host "$HOST" --port "$PORT"\n'
+    return (
+        "#!/bin/bash\n"
+        "set -ex\n"
+        'ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"\n'
+        'cd "$ROOT_DIR"\n'
+        'if [ -d "output" ]; then cd ./output/; fi\n'
+        "HOST=0.0.0.0\n"
+        "PORT=${_FAAS_RUNTIME_PORT:-8000}\n"
+        "export PYTHONPATH=$PYTHONPATH:./site-packages\n"
+        f"{command}"
+    )
+
+
+def build_frontend_assets(source_root: Path, output_dir: Path) -> None:
+    """Build the checkout's React frontend into an isolated directory."""
+    _validate_source_checkout(source_root)
+    npm = shutil.which("npm")
+    if npm is None:
+        raise ValueError("npm is required to build the Studio frontend.")
+    frontend_root = source_root / "frontend"
+    try:
+        subprocess.run([npm, "ci"], cwd=frontend_root, check=True)
+        subprocess.run(
+            [npm, "run", "build", "--", "--outDir", str(output_dir)],
+            cwd=frontend_root,
+            check=True,
+        )
+    except subprocess.CalledProcessError as error:
+        raise ValueError(
+            f"Studio frontend build failed with exit code {error.returncode}."
+        ) from error
+    if not (output_dir / "index.html").is_file():
+        raise ValueError("Studio frontend build produced no index.html.")
+
+
+def write_studio_package(
+    package_dir: Path,
+    *,
+    requirements: str,
+    site_logo: SiteLogo | None,
+) -> None:
+    """Write the Studio entrypoint, requirements, and optional logo."""
+    package_dir.mkdir(parents=True, exist_ok=True)
+    logo_filename = (
+        f"site-logo.{site_logo.extension}" if site_logo is not None else None
+    )
+    (package_dir / "run.sh").write_text(
+        studio_run_script(logo_filename), encoding="utf-8"
+    )
+    if site_logo is not None and logo_filename is not None:
+        (package_dir / logo_filename).write_bytes(site_logo.content)
+    (package_dir / "requirements.txt").write_text(requirements, encoding="utf-8")
+
+
+def build_local_studio_requirements(
+    source_root: Path,
+    package_dir: Path,
+    *,
+    frontend_assets: Path | None = None,
+) -> str:
+    """Build a local VeADK wheel and return its offline requirements."""
+    _validate_source_checkout(source_root)
+    package_dir.mkdir(parents=True, exist_ok=True)
+    wheel_source = source_root
+    if frontend_assets is not None:
+        wheel_source = package_dir / "wheel-source"
+        _stage_wheel_source(source_root, frontend_assets, wheel_source)
+
+    uv = shutil.which("uv")
+    if uv:
+        command = [uv, "build", "--wheel", str(wheel_source), "-o", str(package_dir)]
+    else:
+        command = [
+            sys.executable,
+            "-m",
+            "build",
+            "--wheel",
+            "-o",
+            str(package_dir),
+            str(wheel_source),
+        ]
+    try:
+        subprocess.run(command, check=True)
+    except subprocess.CalledProcessError as error:
+        raise ValueError(
+            f"Local VeADK wheel build failed with exit code {error.returncode}."
+        ) from error
+    wheels = list(package_dir.glob("veadk*.whl"))
+    if not wheels:
+        raise ValueError("Local source build produced no veadk wheel.")
+
+    dependency_names = []
+    for dependency_name, dependency_url, dependency_sha256 in _BUNDLED_WHEELS:
+        with urllib.request.urlopen(dependency_url, timeout=60) as response:
+            dependency_wheel = response.read()
+        if hashlib.sha256(dependency_wheel).hexdigest() != dependency_sha256:
+            raise ValueError(f"{dependency_name} checksum verification failed.")
+        (package_dir / dependency_name).write_bytes(dependency_wheel)
+        dependency_names.append(dependency_name)
+
+    shutil.rmtree(package_dir / "wheel-source", ignore_errors=True)
+    return "".join(f"./{name}\n" for name in (*dependency_names, wheels[0].name))
+
+
+def _validate_source_checkout(source_root: Path) -> None:
+    """Require the files needed to build Studio from a source checkout."""
+    required_paths = (
+        source_root / "pyproject.toml",
+        source_root / "README.md",
+        source_root / "LICENSE",
+        source_root / "frontend" / "package.json",
+        source_root / "frontend" / "package-lock.json",
+        source_root / "veadk",
+    )
+    if not all(path.exists() for path in required_paths):
+        raise ValueError(
+            f"Not a VeADK source checkout: {source_root}. Expected pyproject.toml, "
+            "README.md, LICENSE, frontend/package.json, frontend/package-lock.json, "
+            "and veadk/."
+        )
+
+
+def _stage_wheel_source(
+    source_root: Path, frontend_assets: Path, wheel_source: Path
+) -> None:
+    """Copy package sources and substitute freshly built frontend assets."""
+    wheel_source.mkdir(parents=True)
+    for filename in ("pyproject.toml", "README.md", "LICENSE"):
+        shutil.copy2(source_root / filename, wheel_source / filename)
+    git_metadata = source_root / ".git"
+    if git_metadata.is_file():
+        shutil.copy2(git_metadata, wheel_source / ".git")
+    elif git_metadata.is_dir():
+        (wheel_source / ".git").write_text(
+            f"gitdir: {git_metadata.resolve()}\n", encoding="utf-8"
+        )
+    shutil.copytree(
+        source_root / "veadk",
+        wheel_source / "veadk",
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "webui"),
+    )
+    shutil.copytree(frontend_assets, wheel_source / "veadk" / "webui")

--- a/veadk/cli/studio_update.py
+++ b/veadk/cli/studio_update.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Locate and update an existing cloud-hosted Studio."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, cast
+from urllib.parse import urljoin
+
+import httpx
+import volcenginesdkvefaas
+
+from veadk.cli.frontend_branding import SiteLogo, resolve_site_logo
+from veadk.integrations.ve_faas.ve_faas import VeFaaS
+
+SUPPORTED_STUDIO_REGIONS = ("cn-beijing", "cn-shanghai")
+
+
+@dataclass(frozen=True)
+class StudioDeploymentTarget:
+    """Identifiers and scope of an existing Studio deployment."""
+
+    application_name: str
+    application_id: str
+    function_id: str
+    region: str
+    project: str
+    url: str
+
+
+def find_studio_deployments(
+    *,
+    access_key: str,
+    secret_key: str,
+    application_name: str,
+    region: str | None,
+    project: str | None,
+) -> list[StudioDeploymentTarget]:
+    """Find exact-name Studio Applications in the requested cloud scopes."""
+    regions = (region,) if region is not None else SUPPORTED_STUDIO_REGIONS
+    targets = []
+    for candidate_region in regions:
+        service = VeFaaS(
+            access_key=access_key,
+            secret_key=secret_key,
+            region=candidate_region,
+            project_name=project or "default",
+        )
+        applications = service._list_application(app_name=application_name)
+        for application in applications:
+            if application.get("Name") != application_name:
+                continue
+            target = _deployment_target(service, candidate_region, application)
+            if project is None or target.project == project:
+                targets.append(target)
+    return targets
+
+
+def load_deployed_site_logo(target: StudioDeploymentTarget) -> SiteLogo | None:
+    """Read the current logo so a code update does not reset branding."""
+    if not target.url:
+        raise ValueError(
+            "The existing Studio URL is unavailable; cannot safely preserve its logo."
+        )
+    config_url = urljoin(f"{target.url.rstrip('/')}/", "web/ui-config")
+    try:
+        response = httpx.get(config_url, follow_redirects=True, timeout=10.0)
+        response.raise_for_status()
+        payload = response.json()
+    except (httpx.HTTPError, ValueError) as error:
+        raise ValueError(
+            f"Could not read existing Studio branding from {config_url}: {error}"
+        ) from error
+    branding = payload.get("branding") if isinstance(payload, dict) else None
+    if not isinstance(branding, dict) or "logoUrl" not in branding:
+        raise ValueError(
+            "The existing Studio did not return a recognizable branding configuration."
+        )
+    logo_url = branding.get("logoUrl")
+    if not logo_url:
+        return None
+    return resolve_site_logo(urljoin(f"{target.url.rstrip('/')}/", str(logo_url)))
+
+
+def _deployment_target(
+    service: VeFaaS,
+    region: str,
+    application: dict[str, Any],
+) -> StudioDeploymentTarget:
+    """Convert a VeFaaS Application response into an update target."""
+    cloud_resource = application.get("CloudResource")
+    if not cloud_resource:
+        _, response = service._get_application_status(application["Id"])
+        cloud_resource = response["Result"]["CloudResource"]
+    resource = json.loads(cloud_resource)
+    framework = resource["framework"]
+    function_id = framework["function"]["Id"]
+    function = cast(
+        Any,
+        service.client.get_function(
+            volcenginesdkvefaas.GetFunctionRequest(id=function_id)
+        ),
+    )
+    return StudioDeploymentTarget(
+        application_name=application["Name"],
+        application_id=application["Id"],
+        function_id=function_id,
+        region=region,
+        project=function.project_name,
+        url=framework.get("url", {}).get("system_url", ""),
+    )

--- a/veadk/integrations/ve_faas/ve_faas.py
+++ b/veadk/integrations/ve_faas/ve_faas.py
@@ -17,6 +17,7 @@ import time
 import shutil
 import tempfile
 from pathlib import Path
+from typing import Any, cast
 from cookiecutter.main import cookiecutter
 import veadk.integrations.ve_faas as vefaas
 from veadk.version import VERSION
@@ -198,7 +199,7 @@ class VeFaaS:
             sk=self.sk,
             service="vefaas",
             version="2021-03-03",
-            region="cn-beijing",
+            region=self.region,
             host="open.volcengineapi.com",
         )
 
@@ -239,7 +240,7 @@ class VeFaaS:
             sk=self.sk,
             service="vefaas",
             version="2021-03-03",
-            region="cn-beijing",
+            region=self.region,
             host="open.volcengineapi.com",
         )
         return response["Result"]["Status"], response
@@ -272,7 +273,7 @@ class VeFaaS:
                     sk=self.sk,
                     service="vefaas",
                     version="2021-03-03",
-                    region="cn-beijing",
+                    region=self.region,
                     host="open.volcengineapi.com",
                 )
                 result = response.get("Result", {})
@@ -291,6 +292,52 @@ class VeFaaS:
                     f"List application failed. Error: {str(e)}. Response: {response}."
                 )
         return all_items
+
+    def update_application_code_bundle(
+        self,
+        *,
+        application_id: str,
+        function_id: str,
+        path: str,
+        environment_overrides: dict[str, str] | None = None,
+    ) -> str:
+        """Replace an application's function bundle and release it.
+
+        Existing function settings are left untouched. When environment overrides
+        are provided, they are merged with the complete current environment before
+        updating the function.
+
+        Args:
+            application_id: Existing VeFaaS Application ID.
+            function_id: Function ID referenced by the Application.
+            path: Prepared function bundle directory.
+            environment_overrides: Environment values to explicitly replace.
+
+        Returns:
+            The existing Application URL after the new revision is released.
+        """
+        request_options: dict[str, Any] = {"id": function_id}
+        if environment_overrides:
+            function = cast(
+                Any,
+                self.client.get_function(
+                    volcenginesdkvefaas.GetFunctionRequest(id=function_id)
+                ),
+            )
+            environment = {
+                item.key: item.value for item in (getattr(function, "envs", None) or [])
+            }
+            environment.update(environment_overrides)
+            request_options["envs"] = [
+                volcenginesdkvefaas.EnvForUpdateFunctionInput(key=key, value=value)
+                for key, value in environment.items()
+            ]
+
+        self._upload_and_mount_code(function_id, path)
+        self.client.update_function(
+            volcenginesdkvefaas.UpdateFunctionRequest(**request_options)
+        )
+        return self._release_application(application_id)
 
     def _update_function_code(
         self,


### PR DESCRIPTION
## Summary

- add `veadk studio update --vefaas-app-name` for updating an existing Studio deployment from local source
- discover exact-name Applications across Beijing/Shanghai and visible projects, failing safely on ambiguous matches
- preserve the existing URL, Function/Application IDs, SSO, IAM, gateway, environment variables, title, and logo unless branding overrides are explicitly passed
- share Studio bundle construction with deploy and release only the existing Function/Application

## Validation

- 29 related CLI tests passed
- Ruff, focused Pyright, Markdown lint, pre-commit, and secret scanning passed
- cloud end-to-end deploy and update passed in cn-beijing/default
- verified Application ID, Function ID, URL, IAM role, command, timeout, environment keys, title, and logo hash remained unchanged
- verified root, UI config, logo, auth config, and SSO redirect after update