### PR TITLE
feat: support per-execution env vars in execute_skills

### DIFF
--- a/tests/tools/builtin_tools/test_run_sandbox_agent.py
+++ b/tests/tools/builtin_tools/test_run_sandbox_agent.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _load_run_sandbox_agent_module():
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "veadk"
+        / "tools"
+        / "builtin_tools"
+        / "run_sandbox_agent.py"
+    )
+
+    fake_google = types.ModuleType("google")
+    fake_google.__path__ = []  # type: ignore[attr-defined]
+    fake_google_adk = types.ModuleType("google.adk")
+    fake_google_adk.__path__ = []  # type: ignore[attr-defined]
+    fake_google_adk_tools = types.ModuleType("google.adk.tools")
+    fake_google_adk_tools.ToolContext = object
+
+    fake_veadk = types.ModuleType("veadk")
+    fake_veadk.__path__ = []  # type: ignore[attr-defined]
+    fake_tools = types.ModuleType("veadk.tools")
+    fake_tools.__path__ = []  # type: ignore[attr-defined]
+    fake_builtin_tools = types.ModuleType("veadk.tools.builtin_tools")
+    fake_builtin_tools.__path__ = []  # type: ignore[attr-defined]
+    fake_agentkit = types.ModuleType("veadk.tools.builtin_tools._agentkit")
+    fake_agentkit.invoke_agentkit_run_code = lambda **_kwargs: {}
+    fake_utils = types.ModuleType("veadk.utils")
+    fake_utils.__path__ = []  # type: ignore[attr-defined]
+    fake_logger = types.ModuleType("veadk.utils.logger")
+    fake_logger.get_logger = lambda _name: types.SimpleNamespace(
+        debug=lambda *_args, **_kwargs: None,
+        warning=lambda *_args, **_kwargs: None,
+        error=lambda *_args, **_kwargs: None,
+    )
+
+    stub_modules = {
+        "google": fake_google,
+        "google.adk": fake_google_adk,
+        "google.adk.tools": fake_google_adk_tools,
+        "veadk": fake_veadk,
+        "veadk.tools": fake_tools,
+        "veadk.tools.builtin_tools": fake_builtin_tools,
+        "veadk.tools.builtin_tools._agentkit": fake_agentkit,
+        "veadk.utils": fake_utils,
+        "veadk.utils.logger": fake_logger,
+    }
+
+    with patch.dict(sys.modules, stub_modules):
+        spec = importlib.util.spec_from_file_location(
+            "test_run_sandbox_agent_module", module_path
+        )
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+
+def _load_execute_skills_module(run_sandbox_agent):
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "veadk"
+        / "tools"
+        / "builtin_tools"
+        / "execute_skills.py"
+    )
+
+    fake_google = types.ModuleType("google")
+    fake_google.__path__ = []  # type: ignore[attr-defined]
+    fake_google_adk = types.ModuleType("google.adk")
+    fake_google_adk.__path__ = []  # type: ignore[attr-defined]
+    fake_google_adk_tools = types.ModuleType("google.adk.tools")
+    fake_google_adk_tools.ToolContext = object
+
+    fake_veadk = types.ModuleType("veadk")
+    fake_veadk.__path__ = []  # type: ignore[attr-defined]
+    fake_tools = types.ModuleType("veadk.tools")
+    fake_tools.__path__ = []  # type: ignore[attr-defined]
+    fake_builtin_tools = types.ModuleType("veadk.tools.builtin_tools")
+    fake_builtin_tools.__path__ = []  # type: ignore[attr-defined]
+    fake_agentkit = types.ModuleType("veadk.tools.builtin_tools._agentkit")
+    fake_agentkit.get_agentkit_account_id = lambda _state: "test-account"
+    fake_agentkit.resolve_agentkit_tool_id = lambda _name: "test-tool"
+    fake_runner = types.ModuleType("veadk.tools.builtin_tools.run_sandbox_agent")
+    fake_runner.run_sandbox_agent = run_sandbox_agent
+    fake_utils = types.ModuleType("veadk.utils")
+    fake_utils.__path__ = []  # type: ignore[attr-defined]
+    fake_logger = types.ModuleType("veadk.utils.logger")
+    fake_logger.get_logger = lambda _name: object()
+
+    stub_modules = {
+        "google": fake_google,
+        "google.adk": fake_google_adk,
+        "google.adk.tools": fake_google_adk_tools,
+        "veadk": fake_veadk,
+        "veadk.tools": fake_tools,
+        "veadk.tools.builtin_tools": fake_builtin_tools,
+        "veadk.tools.builtin_tools._agentkit": fake_agentkit,
+        "veadk.tools.builtin_tools.run_sandbox_agent": fake_runner,
+        "veadk.utils": fake_utils,
+        "veadk.utils.logger": fake_logger,
+    }
+
+    with patch.dict(sys.modules, stub_modules):
+        spec = importlib.util.spec_from_file_location(
+            "test_execute_skills_module", module_path
+        )
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+
+class TestMergeExecutionEnvVars(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = _load_run_sandbox_agent_module()
+
+    def test_custom_values_override_defaults_and_preserve_empty_values(self):
+        base_env_vars = {"DEFAULT_VALUE": "default", "UNCHANGED": "value"}
+
+        result = self.module._merge_execution_env_vars(
+            base_env_vars,
+            {"DEFAULT_VALUE": "custom", "EMPTY_VALUE": ""},
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "DEFAULT_VALUE": "custom",
+                "UNCHANGED": "value",
+                "EMPTY_VALUE": "",
+            },
+        )
+        self.assertEqual(
+            base_env_vars, {"DEFAULT_VALUE": "default", "UNCHANGED": "value"}
+        )
+
+    def test_rejects_framework_managed_values(self):
+        for key in ["TOOL_USER_SESSION_ID", "USER_SESSION_ID"]:
+            with self.subTest(key=key):
+                with self.assertRaisesRegex(ValueError, "managed by VeADK"):
+                    self.module._merge_execution_env_vars({}, {key: "spoofed"})
+
+    def test_rejects_invalid_names(self):
+        for key in ["", "1INVALID", "INVALID-NAME", "INVALID=NAME"]:
+            with self.subTest(key=key):
+                with self.assertRaisesRegex(ValueError, "Invalid environment"):
+                    self.module._merge_execution_env_vars({}, {key: "value"})
+
+    def test_rejects_non_string_and_null_byte_values(self):
+        with self.assertRaisesRegex(TypeError, "must have a string value"):
+            self.module._merge_execution_env_vars({}, {"COUNT": 1})
+
+        with self.assertRaisesRegex(ValueError, "contains a null byte"):
+            self.module._merge_execution_env_vars({}, {"VALUE": "before\x00after"})
+
+    def test_runner_code_overrides_the_sandbox_process_environment(self):
+        code = self.module._build_agent_runner_code(
+            cmd=["python", "agent.py", "do work"],
+            timeout=30,
+            env_vars={"CUSTOM_VALUE": "custom"},
+        )
+
+        self.assertIn("env[key] = value", code)
+        self.assertNotIn("if key not in env", code)
+        self.assertIn('srv_pythonpath = env.get("SRV_PYTHONPATH")', code)
+
+
+class TestExecuteSkillsEnvVars(unittest.TestCase):
+    def test_passes_custom_env_vars_to_each_sandbox_execution(self):
+        captured_kwargs = {}
+
+        def fake_run_sandbox_agent(**kwargs):
+            captured_kwargs.update(kwargs)
+            return "done"
+
+        module = _load_execute_skills_module(fake_run_sandbox_agent)
+        tool_context = types.SimpleNamespace(state={})
+
+        result = module.execute_skills(
+            "do work",
+            tool_context=tool_context,
+            env_vars={"CUSTOM_VALUE": "custom", "TOS_SKILLS_DIR": ""},
+        )
+
+        self.assertEqual(result, "done")
+        self.assertEqual(
+            captured_kwargs["extra_env_vars"],
+            {"CUSTOM_VALUE": "custom", "TOS_SKILLS_DIR": ""},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/veadk/community/langchain_ai/tools/execute_skills.py
+++ b/veadk/community/langchain_ai/tools/execute_skills.py
@@ -21,9 +21,10 @@ from veadk.tools.builtin_tools._agentkit import (
     resolve_agentkit_tool_id,
 )
 from veadk.tools.builtin_tools.run_sandbox_agent import (
-    _format_execution_result,
     _build_agent_command,
     _build_agent_runner_code,
+    _format_execution_result,
+    _merge_execution_env_vars,
 )
 from veadk.utils.logger import get_logger
 from veadk.tools.builtin_tools._agentkit import (
@@ -40,6 +41,7 @@ def execute_skills(
     runtime: ToolRuntime,
     skills: Optional[List[str]] = None,
     timeout: int = 900,
+    env_vars: Optional[dict[str, str]] = None,
 ) -> str:
     """execute skills in a code sandbox and return the output.
     For C++ code, don't execute it directly, compile and execute via Python; write sources and object files to /tmp.
@@ -48,6 +50,8 @@ def execute_skills(
         workflow_prompt (str): instruction of workflow
         skills (Optional[List[str]]): The skills will be invoked
         timeout (int, optional): The timeout in seconds for the code execution, less than or equal to 900. Defaults to 900.
+        env_vars (Optional[dict[str, str]]): Environment variables passed to the
+            skill agent process for this execution only.
 
     Returns:
         str: The output of the code execution.
@@ -74,14 +78,17 @@ def execute_skills(
         logger.error(f"Error occurred while getting account id: {e}")
         return {"error": str(e)}
 
-    env_vars = {"TOOL_USER_SESSION_ID": tool_user_session_id}
+    base_env_vars = {"TOOL_USER_SESSION_ID": tool_user_session_id}
     if account_id:
-        env_vars["TOS_SKILLS_DIR"] = f"tos://agentkit-platform-{account_id}/skills/"
+        base_env_vars["TOS_SKILLS_DIR"] = (
+            f"tos://agentkit-platform-{account_id}/skills/"
+        )
+    execution_env_vars = _merge_execution_env_vars(base_env_vars, env_vars)
 
     code = _build_agent_runner_code(
         cmd=cmd,
         timeout=timeout,
-        env_vars=env_vars,
+        env_vars=execution_env_vars,
     )
 
     res = invoke_agentkit_run_code(
@@ -91,7 +98,8 @@ def execute_skills(
         timeout=timeout,
         kernel_name="python3",
     )
-    logger.debug(f"Invoke run code response: {res}")
+    # The response can echo the submitted runner code, including custom env values.
+    logger.debug("Invoke run code completed")
 
     try:
         return _format_execution_result(res["Result"]["Result"])

--- a/veadk/tools/builtin_tools/execute_skills.py
+++ b/veadk/tools/builtin_tools/execute_skills.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 from google.adk.tools import ToolContext
 
 from veadk.tools.builtin_tools._agentkit import (
@@ -27,6 +29,7 @@ logger = get_logger(__name__)
 def execute_skills(
     workflow_prompt: str,
     tool_context: ToolContext = None,
+    env_vars: Optional[dict[str, str]] = None,
 ) -> str:
     """Execute skills in a sandbox and return the output.
 
@@ -34,6 +37,8 @@ def execute_skills(
 
     Args:
         workflow_prompt (str): instruction of workflow
+        env_vars (Optional[dict[str, str]]): Environment variables passed to the
+            skill agent process for this execution only.
 
     Returns:
         str: The output of the code execution.
@@ -47,6 +52,8 @@ def execute_skills(
         extra_env_vars["TOS_SKILLS_DIR"] = (
             f"tos://agentkit-platform-{account_id}/skills/"
         )
+    if env_vars:
+        extra_env_vars.update(env_vars)
 
     return run_sandbox_agent(
         workflow_prompt=workflow_prompt,

--- a/veadk/tools/builtin_tools/run_sandbox_agent.py
+++ b/veadk/tools/builtin_tools/run_sandbox_agent.py
@@ -14,6 +14,7 @@
 
 import json
 import os
+import re
 from typing import Optional
 
 from google.adk.tools import ToolContext
@@ -23,11 +24,39 @@ from veadk.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+_ENV_VAR_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_PROTECTED_ENV_VARS = frozenset({"TOOL_USER_SESSION_ID", "USER_SESSION_ID"})
+
+
+def _merge_execution_env_vars(
+    base_env_vars: dict[str, str],
+    custom_env_vars: Optional[dict[str, str]] = None,
+) -> dict[str, str]:
+    """Validate and merge environment variables for one sandbox execution."""
+    merged_env_vars = dict(base_env_vars)
+    if not custom_env_vars:
+        return merged_env_vars
+
+    for key, value in custom_env_vars.items():
+        if not isinstance(key, str) or not _ENV_VAR_NAME_PATTERN.fullmatch(key):
+            raise ValueError(
+                f"Invalid environment variable name {key!r}. "
+                "Names must match [A-Za-z_][A-Za-z0-9_]*."
+            )
+        if key in _PROTECTED_ENV_VARS:
+            raise ValueError(f"Environment variable {key!r} is managed by VeADK.")
+        if not isinstance(value, str):
+            raise TypeError(f"Environment variable {key!r} must have a string value.")
+        if "\x00" in value:
+            raise ValueError(f"Environment variable {key!r} contains a null byte.")
+
+        merged_env_vars[key] = value
+
+    return merged_env_vars
+
 
 def _clean_ansi_codes(text: str) -> str:
     """Remove ANSI escape sequences (color codes, etc.)."""
-    import re
-
     ansi_escape = re.compile(r"\x1b\[[0-9;]*m")
     return ansi_escape.sub("", text)
 
@@ -89,9 +118,13 @@ import select
 import sys
 
 env = os.environ.copy()
+srv_pythonpath = env.get("SRV_PYTHONPATH")
+if srv_pythonpath:
+    env["PYTHONPATH"] = os.pathsep.join(
+        value for value in (srv_pythonpath, env.get("PYTHONPATH")) if value
+    )
 for key, value in {env_vars!r}.items():
-    if key not in env:
-        env[key] = value
+    env[key] = value
 
 process = subprocess.Popen(
     {cmd!r},
@@ -163,15 +196,13 @@ def run_sandbox_agent(
     tool_user_session_id = agent_name + "_" + user_id + "_" + session_id
     logger.debug(f"tool_user_session_id: {tool_user_session_id}")
 
-    env_vars = {
+    base_env_vars = {
         "TOOL_USER_SESSION_ID": tool_user_session_id,
-        "PYTHONPATH": "$SRV_PYTHONPATH:$PYTHONPATH",
     }
     skill_space_id = os.getenv("SKILL_SPACE_ID", "")
     if skill_space_id:
-        env_vars["SKILL_SPACE_ID"] = skill_space_id
-    if extra_env_vars:
-        env_vars.update({k: v for k, v in extra_env_vars.items() if v})
+        base_env_vars["SKILL_SPACE_ID"] = skill_space_id
+    env_vars = _merge_execution_env_vars(base_env_vars, extra_env_vars)
 
     logger.debug(
         f"Run sandbox agent in session_id={session_id}, tool_id={tool_id}, timeout={timeout}, skills={skills}"
@@ -192,7 +223,8 @@ def run_sandbox_agent(
         kernel_name="python3",
         tool_state=tool_context.state if tool_context else None,
     )
-    logger.debug(f"Invoke run sandbox agent response: {res}")
+    # The response can echo the submitted runner code, including custom env values.
+    logger.debug("Invoke run sandbox agent completed")
 
     try:
         return _format_execution_result(res["Result"]["Result"])


### PR DESCRIPTION
## Summary

- add optional env_vars support to the Google ADK and LangChain execute_skills tools
- validate custom environment variables, protect session identity variables, preserve empty values, and allow execution-level overrides
- inject variables only into the spawned skills agent process and avoid logging responses that can echo submitted values
- compose SRV_PYTHONPATH correctly before launching the child process

## Validation

- 27 related tests passed, including 6 subtests
- Ruff and git diff checks passed
- live AgentKit smoke test: execute_skills with ABC=1234 returned 1234 from the sandbox agent