### PR TITLE
test(studio): clarify default admin access

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,9 +220,10 @@ veadk studio deploy \
   --developer "alice@example.com,bob@example.com"
 ```
 
-Supplying either role list enables role-based access control; users not in a
-list are regular users, and `admin` wins when an identity appears in both
-lists. Admins have all Studio capabilities and can see every Runtime.
+Omitting both role lists makes every signed-in user an `admin`. Supplying
+either list enables role-based access control; users not in a list are regular
+users, and `admin` wins when an identity appears in both lists. Admins have all
+Studio capabilities and can see every Runtime.
 Developers can add and manage agents but can see and manage only their own
 Runtimes. Regular users can see only their own Runtimes; the add/manage-agent
 sidebar items are hidden. The sidebar account footer shows the OAuth email

--- a/docs/content/docs/framework/frontend.en.mdx
+++ b/docs/content/docs/framework/frontend.en.mdx
@@ -231,9 +231,9 @@ veadk studio deploy \
   --developer "alice@example.com,bob@example.com"
 ```
 
-Supplying either list enables role-based access control. An identity that does
-not match either list is a regular user. Omitting both options preserves the
-existing unrestricted Studio behavior.
+Omitting both options treats every signed-in user as an `admin`. Supplying
+either list enables role-based access control. An identity that does not match
+either list is a regular user.
 
 | Capability | admin | developer | Regular user |
 | :-- | :-- | :-- | :-- |

--- a/docs/content/docs/framework/frontend.mdx
+++ b/docs/content/docs/framework/frontend.mdx
@@ -209,8 +209,8 @@ veadk studio deploy \
   --developer "alice@example.com,bob@example.com"
 ```
 
-只要传入任一名单就会启用角色权限；未命中名单的身份是普通用户。两项都不传时
-保留原有行为，不限制 Studio 功能。
+两项都不传时，所有登录用户都按管理员（`admin`）处理。只要传入任一名单就会启用
+角色权限；未命中名单的身份是普通用户。
 
 | 功能 | admin | developer | 普通用户 |
 | :-- | :-- | :-- | :-- |

--- a/tests/cli/test_studio_deploy_target.py
+++ b/tests/cli/test_studio_deploy_target.py
@@ -118,6 +118,8 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
     assert captured["region"] == expected_region
     assert captured["project"] == expected_project
     assert veadk_environments["VEIDENTITY_REGION"] == expected_identity_region
+    assert "VEADK_STUDIO_ADMINS" not in veadk_environments
+    assert "VEADK_STUDIO_DEVELOPERS" not in veadk_environments
     assert f"{expected_region}/{expected_project}" in result.output
     assert ("Warning:" in result.output) == (
         expected_identity_region != expected_region
@@ -126,6 +128,78 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
     assert isinstance(callback, dict)
     assert callback["dismiss_login_page_enabled"] is False
     assert callback["skip_consent_enabled"] is True
+
+
+@pytest.mark.parametrize(
+    ("role_args", "expected_environment"),
+    [
+        (
+            ["--admin", "admin@example.com"],
+            {"VEADK_STUDIO_ADMINS": "admin@example.com"},
+        ),
+        (
+            ["--developer", "dev@example.com"],
+            {"VEADK_STUDIO_DEVELOPERS": "dev@example.com"},
+        ),
+    ],
+)
+def test_studio_deploy_enables_rbac_when_either_role_is_configured(
+    monkeypatch: pytest.MonkeyPatch,
+    role_args: list[str],
+    expected_environment: dict[str, str],
+) -> None:
+    class _FakeCloudAgentEngine:
+        def __init__(self, **_: object) -> None:
+            pass
+
+        def deploy(self, **_: object) -> SimpleNamespace:
+            return SimpleNamespace(
+                vefaas_endpoint="https://studio.example.com",
+                vefaas_application_id="app-id",
+                vefaas_function_id="",
+            )
+
+    monkeypatch.setattr(
+        "veadk.cloud.cloud_agent_engine.CloudAgentEngine", _FakeCloudAgentEngine
+    )
+    monkeypatch.setattr(
+        "veadk.cli.cli_frontend._resolve_studio_identity_region",
+        lambda **_: "cn-beijing",
+    )
+    monkeypatch.setattr(
+        "veadk.integrations.ve_identity.identity_client.IdentityClient.register_callback_for_user_pool_client",
+        lambda *_args, **_kwargs: None,
+    )
+
+    result = CliRunner().invoke(
+        studio,
+        [
+            "deploy",
+            "--user-pool-id",
+            "pool-id",
+            "--allowed-client-id",
+            "client-id",
+            "--vefaas-app-name",
+            "studio-app",
+            "--iam-role",
+            "trn:iam::role/test",
+            "--gateway-name",
+            "gateway",
+            "--volcengine-access-key",
+            "ak",
+            "--volcengine-secret-key",
+            "sk",
+            *role_args,
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    configured_roles = {
+        key: value
+        for key, value in veadk_environments.items()
+        if key in {"VEADK_STUDIO_ADMINS", "VEADK_STUDIO_DEVELOPERS"}
+    }
+    assert configured_roles == expected_environment
 
 
 def test_studio_identity_region_searches_deployment_region_first(

--- a/tests/cli/test_studio_rbac.py
+++ b/tests/cli/test_studio_rbac.py
@@ -141,9 +141,40 @@ def test_role_matching_uses_all_trusted_identifiers_and_admin_wins() -> None:
 
 def test_unconfigured_policy_preserves_legacy_full_access() -> None:
     policy = StudioAccessPolicy.from_csv(None, "")
+    principal = StudioPrincipal.local("any-user")
 
     assert not policy.enabled
-    assert policy.role_for(None) == StudioRole.ADMIN
+    assert policy.role_for(principal) == StudioRole.ADMIN
+    assert policy.access_payload(principal) == {
+        "role": "admin",
+        "username": "any-user",
+        "rbacEnabled": False,
+        "capabilities": {
+            "createAgents": True,
+            "manageAgents": True,
+            "runtimeScope": "all",
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("admins", "developers", "listed_user", "listed_role"),
+    [
+        ("admin", None, "admin", StudioRole.ADMIN),
+        (None, "developer", "developer", StudioRole.DEVELOPER),
+    ],
+)
+def test_either_role_list_enables_rbac(
+    admins: str | None,
+    developers: str | None,
+    listed_user: str,
+    listed_role: StudioRole,
+) -> None:
+    policy = StudioAccessPolicy.from_csv(admins, developers)
+
+    assert policy.enabled
+    assert policy.role_for(StudioPrincipal.local(listed_user)) == listed_role
+    assert policy.role_for(StudioPrincipal.local("unlisted")) == StudioRole.USER
 
 
 def test_unlisted_identity_is_a_regular_user() -> None:
@@ -195,6 +226,9 @@ def test_studio_deploy_exposes_role_options() -> None:
     assert result.exit_code == 0
     assert "--admin" in result.output
     assert "--developer" in result.output
+    assert "Omit both role options to grant every user admin access" in " ".join(
+        result.output.split()
+    )
 
 
 def test_access_endpoint_resolves_local_roles_and_blocks_user_management(

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -485,7 +485,8 @@ def _serve_options(f):
             default=None,
             envvar="VEADK_STUDIO_ADMINS",
             help="Comma-separated Studio admin usernames or OAuth emails "
-            "(env: VEADK_STUDIO_ADMINS).",
+            "(env: VEADK_STUDIO_ADMINS). Omit both role options to grant "
+            "every user admin access.",
         ),
         click.option(
             "--developer",
@@ -3378,7 +3379,8 @@ def _resolve_studio_identity_region(
     "studio_admins",
     default=None,
     envvar="VEADK_STUDIO_ADMINS",
-    help="Comma-separated Studio admin usernames or OAuth emails.",
+    help="Comma-separated Studio admin usernames or OAuth emails. Omit both "
+    "role options to grant every user admin access.",
 )
 @click.option(
     "--developer",


### PR DESCRIPTION
## Summary

- document that omitting both Studio role options grants every signed-in user admin access
- clarify that configuring either role list enables RBAC for unlisted users
- add deployment and access-policy regression coverage for default and single-flag configurations
- update CLI help for the default-admin behavior

## Verification

- 24 targeted Studio RBAC and deployment tests passed
- Ruff and formatting checks passed
- targeted Pyright passed
- Markdown lint passed
- git diff checks passed