### PR TITLE
feat: manage Harness Sidecar lifecycle in veADK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ eval = [
 harness = [
     "headroom",
 ]
+harness-sidecar = [
+    "agentkit-sdk-python[harness-sidecar]>=0.8.0",
+]
 cli = []
 dev = [
     "pre-commit>=4.2.0",            # Format checking

--- a/tests/cloud/test_harness_sidecar_bootstrap.py
+++ b/tests/cloud/test_harness_sidecar_bootstrap.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+from veadk.cloud.harness_app import utils
+from veadk.extensions.harness import HarnessExtension
+
+
+def test_harness_app_starts_extension_before_building_agent(monkeypatch) -> None:
+    events: list[str] = []
+    extension = object()
+
+    def from_env(_cls):
+        events.append("extension")
+        return extension
+
+    def init_harness_agent():
+        events.append("agent")
+        return object(), object()
+
+    monkeypatch.setattr(HarnessExtension, "from_env", classmethod(from_env))
+    monkeypatch.setattr(utils, "init_harness_agent", init_harness_agent)
+    agent_module = (
+        Path(__file__).resolve().parents[2]
+        / "veadk"
+        / "cloud"
+        / "harness_app"
+        / "agent.py"
+    )
+
+    namespace = runpy.run_path(str(agent_module))
+
+    assert events == ["extension", "agent"]
+    assert namespace["harness_extension"] is extension

--- a/tests/cloud/test_harness_sidecar_env.py
+++ b/tests/cloud/test_harness_sidecar_env.py
@@ -1,0 +1,61 @@
+import json
+
+from veadk.cloud.harness_app.env_mapping import to_runtime_env
+
+
+def test_nested_harness_sidecar_uses_public_product_env_names() -> None:
+    env = to_runtime_env(
+        {
+            "harness": {
+                "profile": "ops",
+                "sidecar": {
+                    "enabled": True,
+                    "model_proxy": {"enabled": False},
+                    "mcp_gateway": {
+                        "enabled": True,
+                    },
+                },
+            }
+        }
+    )
+
+    assert env["HARNESS_SIDECAR_ENABLED"] == "true"
+    assert env["HARNESS_PROFILE"] == "ops"
+    assert env["HARNESS_MODEL_PROXY_ENABLED"] == "false"
+    assert env["HARNESS_MCP_PRESETS"] == "sql_readonly"
+    assert env["HARNESS_MCP_READONLY_SEGMENTS"] == "*"
+    assert not any(key.startswith("HARNESS_SIDECAR_MCP_") for key in env)
+
+
+def test_boolean_sidecar_shorthand_uses_profile_defaults() -> None:
+    env = to_runtime_env({"harness": {"profile": "ops", "sidecar": True}})
+
+    assert env["HARNESS_SIDECAR_ENABLED"] == "true"
+    assert env["HARNESS_PROFILE"] == "ops"
+    assert env["HARNESS_MCP_GATEWAY_ENABLED"] == "true"
+    assert env["HARNESS_MCP_PRESETS"] == "sql_readonly"
+    assert env["HARNESS_MCP_READONLY_SEGMENTS"] == "*"
+
+
+def test_product_component_overrides_are_carried_by_versioned_plan() -> None:
+    env = to_runtime_env(
+        {
+            "harness": {
+                "profile": "ops",
+                "sidecar": {
+                    "enabled": True,
+                    "component_overrides": {
+                        "verifier": False,
+                        "sql_readonly": False,
+                    },
+                },
+            }
+        }
+    )
+
+    plan = json.loads(env["HARNESS_SIDECAR_PLAN"])
+    assert plan["schema_version"] == "agentkit.harness-sidecar.plan/v1"
+    assert "verifier" not in plan["effective_components"]
+    assert "sql_readonly" not in plan["effective_components"]
+    assert env["HARNESS_MCP_PRESETS"] == ""
+    assert env["HARNESS_MCP_READONLY_SEGMENTS"] == ""

--- a/tests/extensions/harness/test_env.py
+++ b/tests/extensions/harness/test_env.py
@@ -52,3 +52,14 @@ def test_build_harness_plugins_from_env_defaults_to_builtin_compression():
 
     assert plugins[0].name == "harness_compress_plugin"
     assert plugins[0].compressor.config.provider == "builtin"
+
+
+def test_ops_profile_enables_long_run_control_by_default():
+    plugins = build_harness_plugins_from_env(
+        {
+            "HARNESS_ENHANCE_ENABLED": "true",
+            "HARNESS_PROFILE": "ops",
+        }
+    )
+
+    assert [plugin.name for plugin in plugins][-1] == "harness_long_run_control_plugin"

--- a/tests/extensions/harness/test_extension.py
+++ b/tests/extensions/harness/test_extension.py
@@ -12,7 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+import tomllib
+
 from veadk.extensions.harness import HarnessExtension
+
+
+def test_harness_sidecar_dependency_is_optional_extra_only() -> None:
+    pyproject = tomllib.loads(
+        (Path(__file__).resolve().parents[3] / "pyproject.toml").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    base_dependencies = pyproject["project"].get("dependencies", [])
+    sidecar_extra = pyproject["project"]["optional-dependencies"]["harness-sidecar"]
+
+    assert not any(
+        "agentkit-sdk-python[harness-sidecar]" in item for item in base_dependencies
+    )
+    assert any("agentkit-sdk-python[harness-sidecar]" in item for item in sidecar_extra)
 
 
 def test_harness_extension_builds_runner_plugins() -> None:
@@ -32,6 +55,33 @@ def test_harness_extension_from_env_respects_disabled_default() -> None:
     assert HarnessExtension.from_env({}).plugins() == []
 
 
+def test_default_sidecar_does_not_resolve_or_start_public_runtime(
+    monkeypatch,
+) -> None:
+    def unexpected_start_function():
+        raise AssertionError("default HarnessExtension must not start Sidecar")
+
+    monkeypatch.setattr(
+        "veadk.extensions.harness.sidecar._public_start_function",
+        unexpected_start_function,
+    )
+
+    extension = HarnessExtension()
+
+    assert extension.sidecar_status == "disabled"
+    assert extension.plugins() == []
+
+
+def test_explicit_enabled_keeps_plugin_only_compatibility() -> None:
+    extension = HarnessExtension(enabled=True)
+
+    assert [plugin.name for plugin in extension.plugins()] == [
+        "harness_invocation_context_plugin",
+        "harness_compress_plugin",
+        "harness_response_verification_plugin",
+    ]
+
+
 def test_harness_extension_from_env_builds_configured_plugins() -> None:
     plugins = HarnessExtension.from_env(
         {
@@ -41,3 +91,123 @@ def test_harness_extension_from_env_builds_configured_plugins() -> None:
     ).plugins()
 
     assert [plugin.name for plugin in plugins] == ["harness_invocation_context_plugin"]
+
+
+def test_ops_profile_manages_sidecar_and_adds_long_run_plugin(monkeypatch) -> None:
+    calls = []
+
+    class FakeBinding:
+        spec = SimpleNamespace(status="ok")
+        env: ClassVar[dict[str, str]] = {
+            "MODEL_AGENT_API_BASE": "http://127.0.0.1:18787/api/v3"
+        }
+
+        def stop(self) -> None:
+            calls.append("stop")
+
+    def fake_start(config, **kwargs):
+        calls.append((config, kwargs))
+        return FakeBinding()
+
+    monkeypatch.setattr(
+        "veadk.extensions.harness.sidecar._public_start_function",
+        lambda: fake_start,
+    )
+
+    extension = HarnessExtension(
+        profile="ops",
+        sidecar={"mcp_gateway": {"presets": ["sql_readonly"]}},
+    )
+    try:
+        assert extension.sidecar_status == "ok"
+        assert extension.sidecar_env["MODEL_AGENT_API_BASE"].startswith("http://")
+        assert calls[0][1]["profile"] == "ops"
+        assert calls[0][1]["apply_env"] is True
+        assert [plugin.name for plugin in extension.plugins()][-1] == (
+            "harness_long_run_control_plugin"
+        )
+    finally:
+        extension.close()
+
+    assert calls[-1] == "stop"
+
+
+def test_sidecar_startup_can_fail_open(monkeypatch) -> None:
+    def fail_start(*_args, **_kwargs):
+        raise RuntimeError("runtime unavailable")
+
+    monkeypatch.setattr(
+        "veadk.extensions.harness.sidecar._public_start_function",
+        lambda: fail_start,
+    )
+
+    extension = HarnessExtension(sidecar={"enabled": True, "fail_open": True})
+
+    assert extension.sidecar_status == "degraded"
+    assert extension.plugins()
+
+
+def test_product_component_overrides_drive_veadk_plugins(monkeypatch) -> None:
+    class FakeBinding:
+        spec = SimpleNamespace(status="ok")
+        env: ClassVar[dict[str, str]] = {}
+
+        def stop(self) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "veadk.extensions.harness.sidecar._public_start_function",
+        lambda: lambda *_args, **_kwargs: FakeBinding(),
+    )
+
+    extension = HarnessExtension(
+        profile="ops",
+        sidecar={
+            "enabled": True,
+            "component_overrides": {
+                "verifier": False,
+                "long_run_control": False,
+            },
+        },
+    )
+    try:
+        assert [plugin.name for plugin in extension.plugins()] == [
+            "harness_invocation_context_plugin",
+            "harness_compress_plugin",
+        ]
+    finally:
+        extension.close()
+
+
+def test_sidecar_env_switch_activates_plan_without_legacy_enhance_switch(
+    monkeypatch,
+) -> None:
+    class FakeBinding:
+        spec = SimpleNamespace(status="ok")
+        env: ClassVar[dict[str, str]] = {}
+
+        def stop(self) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "veadk.extensions.harness.sidecar._public_start_function",
+        lambda: lambda *_args, **_kwargs: FakeBinding(),
+    )
+
+    extension = HarnessExtension.from_env(
+        {"HARNESS_SIDECAR_ENABLED": "true", "HARNESS_PROFILE": "ops"}
+    )
+    try:
+        assert [plugin.name for plugin in extension.plugins()] == [
+            "harness_invocation_context_plugin",
+            "harness_compress_plugin",
+            "harness_response_verification_plugin",
+            "harness_long_run_control_plugin",
+        ]
+    finally:
+        extension.close()
+
+
+def test_sidecar_rejects_legacy_component_namespace() -> None:
+    with pytest.raises(ValueError, match="component_overrides"):
+        HarnessExtension(sidecar=True, components=["compactor"])

--- a/veadk/cloud/harness_app/agent.py
+++ b/veadk/cloud/harness_app/agent.py
@@ -37,5 +37,9 @@ Environment variables:
 """
 
 from veadk.cloud.harness_app.utils import init_harness_agent
+from veadk.extensions.harness import HarnessExtension
 
+harness_extension = HarnessExtension.from_env()
 agent, short_term_memory = init_harness_agent()
+
+__all__ = ["agent", "harness_extension", "short_term_memory"]

--- a/veadk/cloud/harness_app/app.py
+++ b/veadk/cloud/harness_app/app.py
@@ -67,7 +67,7 @@ from veadk.a2a.registry_client import (
     registry_tip_token_from_headers,
 )
 from veadk.a2a.utils.agent_to_a2a import to_a2a
-from veadk.cloud.harness_app.agent import agent, short_term_memory
+from veadk.cloud.harness_app.agent import agent, harness_extension, short_term_memory
 from veadk.cloud.harness_app.harness_plugins import (
     build_harness_plugins_from_enhance,
     build_harness_plugins_from_headers,
@@ -88,6 +88,7 @@ from veadk.cloud.harness_app.utils import (
     has_a2a_registry_config,
     spawn_harness_run_agent,
 )
+from veadk.extensions.harness import HarnessExtension
 from veadk.memory.short_term_memory import ShortTermMemory
 from veadk.runner import Runner
 from veadk.utils.logger import get_logger
@@ -169,13 +170,19 @@ class HarnessApp:
         short_term_memory: ShortTermMemory,
         harness_name: str = "default",
         max_llm_calls: int | None = None,
+        extension: HarnessExtension | None = None,
     ):
         self.agent = agent
         self.short_term_memory = short_term_memory
         self.harness_name = harness_name
         self.max_llm_calls = max_llm_calls
         self.return_llm_usage = RETURN_LLM_USAGE
-        self.plugins = build_harness_plugins_from_runtime_env()
+        self.harness_extension = extension
+        self.plugins = (
+            extension.plugins()
+            if extension is not None
+            else build_harness_plugins_from_runtime_env()
+        )
         self.runner = Runner(
             agent=agent,
             short_term_memory=short_term_memory,
@@ -205,8 +212,12 @@ class HarnessApp:
             # A mounted sub-app's lifespan is not run automatically. The A2A app
             # registers its routes (agent card + RPC) inside its lifespan, so
             # enter it here or those routes never appear.
-            async with self._a2a_app.router.lifespan_context(self._a2a_app):
-                yield
+            try:
+                async with self._a2a_app.router.lifespan_context(self._a2a_app):
+                    yield
+            finally:
+                if self.harness_extension is not None:
+                    self.harness_extension.close()
 
         # Base app = ADK api routes; then add /harness/invoke; mount A2A last so
         # it catches the well-known / RPC paths the ADK routes don't claim.
@@ -535,7 +546,11 @@ class HarnessApp:
 
 
 harness_app = HarnessApp(
-    agent, short_term_memory, HARNESS_NAME, max_llm_calls=DEFAULT_MAX_LLM_CALLS
+    agent,
+    short_term_memory,
+    HARNESS_NAME,
+    max_llm_calls=DEFAULT_MAX_LLM_CALLS,
+    extension=harness_extension,
 )
 app = harness_app.app
 

--- a/veadk/cloud/harness_app/env_mapping.py
+++ b/veadk/cloud/harness_app/env_mapping.py
@@ -44,6 +44,7 @@ components using the same backend share those vars (e.g. a Viking knowledge base
 and a Viking long-term memory).
 """
 
+from copy import deepcopy
 from typing import Any
 
 from veadk.utils.misc import flatten_dict
@@ -164,12 +165,30 @@ def to_runtime_env(spec: dict[str, Any]) -> dict[str, str]:
     rest = {
         k: v for k, v in spec.items() if k not in COMPONENT_TYPE_ENV and k != "auth"
     }
+    sidecar_section, sidecar_profile = _sidecar_section(spec)
+    if sidecar_section is not None:
+        rest.pop("sidecar", None)
+        rest.pop("harness_sidecar", None)
+        harness = rest.get("harness")
+        if isinstance(harness, dict):
+            harness = deepcopy(harness)
+            harness.pop("sidecar", None)
+            if harness:
+                rest["harness"] = harness
+            else:
+                rest.pop("harness", None)
     for key, value in flatten_dict(rest).items():
         if _is_empty(value):
             continue
         env[key.upper()] = _stringify(value)
 
     _add_harness_enhance_aliases(env, spec)
+    if sidecar_section is not None:
+        _add_harness_sidecar_aliases(
+            env,
+            sidecar_section,
+            profile=sidecar_profile,
+        )
 
     # Component sections: `type` selector + backend-specific connection params.
     for component, type_env in COMPONENT_TYPE_ENV.items():
@@ -237,3 +256,44 @@ def _add_harness_enhance_aliases(env: dict[str, str], spec: dict[str, Any]) -> N
     verifier_mode = verifier.get("mode")
     if not _is_empty(verifier_mode):
         env["HARNESS_VERIFIER_MODE"] = _stringify(verifier_mode)
+
+
+def _sidecar_section(
+    spec: dict[str, Any],
+) -> tuple[dict[str, Any] | bool | None, str]:
+    harness = spec.get("harness")
+    if not isinstance(harness, dict):
+        harness = {}
+    section = harness.get("sidecar")
+    if not isinstance(section, (dict, bool)):
+        section = spec.get("harness_sidecar")
+    if not isinstance(section, (dict, bool)):
+        section = spec.get("sidecar")
+    if not isinstance(section, (dict, bool)):
+        return None, "default"
+    enhance = spec.get("harness_enhance")
+    if not isinstance(enhance, dict):
+        enhance = {}
+    profile = str(
+        harness.get("profile")
+        or enhance.get("profile")
+        or spec.get("profile")
+        or "default"
+    )
+    return section, profile
+
+
+def _add_harness_sidecar_aliases(
+    env: dict[str, str],
+    section: dict[str, Any] | bool,
+    *,
+    profile: str,
+) -> None:
+    try:
+        from agentkit.toolkit.harness import sidecar_config_to_env
+    except (ImportError, AttributeError) as error:
+        raise RuntimeError(
+            "Harness Sidecar config requires "
+            'pip install "veadk-python[harness-sidecar]"'
+        ) from error
+    env.update(sidecar_config_to_env(section, profile=profile))

--- a/veadk/extensions/harness/__init__.py
+++ b/veadk/extensions/harness/__init__.py
@@ -14,71 +14,73 @@
 
 """Composable Agent Harness SDK."""
 
-from veadk.extensions.harness.plugins import HarnessLongRunControlPlugin
 from veadk.extensions.harness.extension import HarnessExtension, HarnessExtensionConfig
+from veadk.extensions.harness.modules.final_response_verifier import (
+    FinalResponseVerifier,
+    ResultVerifier,
+)
 from veadk.extensions.harness.modules.invocation_context import (
     ContextEngine,
     HarnessInvocationContextBuilder,
     HarnessInvocationContextConfig,
-)
-from veadk.extensions.harness.modules.final_response_verifier import (
-    FinalResponseVerifier,
-    ResultVerifier,
 )
 from veadk.extensions.harness.modules.tool_result_compactor import (
     HeadroomCompressionProvider,
     ToolResultCompactor,
     ToolResultCompressor,
 )
+from veadk.extensions.harness.plugins import HarnessLongRunControlPlugin
 from veadk.extensions.harness.schemas import (
     CapabilityReceipt,
-    ToolReceipt,
     CompactionReport,
+    CompactionResult,
     CompressionReport,
     CompressionRequest,
-    CompactionResult,
     CompressionResult,
     ContextBundle,
-    InvocationContextBlock,
     ConversationMessage,
     EvidenceRef,
     HarnessEvent,
     HarnessIntervention,
-    VerificationDecision,
-    HarnessRunContext,
     HarnessInvocationRef,
+    HarnessRunContext,
+    InvocationContextBlock,
     TaskContract,
+    ToolReceipt,
+    VerificationDecision,
     VerificationReport,
 )
+from veadk.extensions.harness.sidecar import HarnessSidecarDependencyError
 
 __all__ = [
     "CapabilityReceipt",
-    "ToolReceipt",
     "CompactionReport",
+    "CompactionResult",
     "CompressionReport",
     "CompressionRequest",
-    "CompactionResult",
     "CompressionResult",
     "ContextBundle",
-    "InvocationContextBlock",
     "ContextEngine",
     "ConversationMessage",
     "EvidenceRef",
-    "HeadroomCompressionProvider",
-    "HarnessIntervention",
-    "VerificationDecision",
+    "FinalResponseVerifier",
     "HarnessEvent",
     "HarnessExtension",
     "HarnessExtensionConfig",
+    "HarnessIntervention",
     "HarnessInvocationContextBuilder",
     "HarnessInvocationContextConfig",
-    "HarnessRunContext",
     "HarnessInvocationRef",
     "HarnessLongRunControlPlugin",
-    "FinalResponseVerifier",
+    "HarnessRunContext",
+    "HarnessSidecarDependencyError",
+    "HeadroomCompressionProvider",
+    "InvocationContextBlock",
     "ResultVerifier",
     "TaskContract",
+    "ToolReceipt",
     "ToolResultCompactor",
     "ToolResultCompressor",
+    "VerificationDecision",
     "VerificationReport",
 ]

--- a/veadk/extensions/harness/env.py
+++ b/veadk/extensions/harness/env.py
@@ -22,7 +22,6 @@ from typing import Literal
 
 from google.adk.plugins import BasePlugin
 
-from veadk.extensions.harness.plugins import build_harness_plugins
 from veadk.extensions.harness.modules.final_response_verifier import (
     FinalResponseVerifierConfig,
 )
@@ -32,13 +31,14 @@ from veadk.extensions.harness.modules.invocation_context import (
 from veadk.extensions.harness.modules.tool_result_compactor import (
     ToolResultCompactorConfig,
 )
+from veadk.extensions.harness.plugins import build_harness_plugins
 from veadk.extensions.harness.stores import JsonlHarnessStore
 
 
 def harness_enabled_from_env(env: Mapping[str, str] | None = None) -> bool:
     """Return whether Harness plugins should be attached."""
 
-    values = env or os.environ
+    values = env if env is not None else os.environ
     return _truthy(values.get("HARNESS_ENHANCE_ENABLED"))
 
 
@@ -47,18 +47,21 @@ def build_harness_plugins_from_env(
 ) -> list[BasePlugin]:
     """Build Harness plugins from generic runtime environment variables."""
 
-    values = env or os.environ
+    values = env if env is not None else os.environ
     if not harness_enabled_from_env(values):
         return []
-    components = (
-        values.get("HARNESS_ENHANCE_COMPONENTS")
-        or values.get("HARNESS_COMPONENTS")
-        or "invocation_context,compactor,response_verification"
-    )
     profile = (
         values.get("HARNESS_ENHANCE_PROFILE")
         or values.get("HARNESS_PROFILE")
         or "default"
+    )
+    default_components = "invocation_context,compactor,response_verification"
+    if profile == "ops":
+        default_components += ",long_run_control"
+    components = (
+        values.get("HARNESS_ENHANCE_COMPONENTS")
+        or values.get("HARNESS_COMPONENTS")
+        or default_components
     )
     max_context_chars = _int_value(
         values.get("HARNESS_MAX_CONTEXT_CHARS")

--- a/veadk/extensions/harness/extension.py
+++ b/veadk/extensions/harness/extension.py
@@ -18,11 +18,12 @@ from __future__ import annotations
 
 import os
 from collections.abc import Iterable, Mapping
+from typing import Any
 
 from google.adk.plugins import BasePlugin
 from pydantic import Field
+from typing_extensions import Self
 
-from veadk.extensions.harness.plugins import build_harness_plugins
 from veadk.extensions.harness.env import (
     build_harness_plugins_from_env,
     harness_enabled_from_env,
@@ -36,7 +37,13 @@ from veadk.extensions.harness.modules.invocation_context import (
 from veadk.extensions.harness.modules.tool_result_compactor import (
     ToolResultCompactorConfig,
 )
+from veadk.extensions.harness.plugins import build_harness_plugins
 from veadk.extensions.harness.schemas import HarnessBaseModel
+from veadk.extensions.harness.sidecar import (
+    ManagedHarnessSidecar,
+    normalize_sidecar_config,
+    sidecar_config_from_env,
+)
 from veadk.extensions.harness.stores import HarnessStoreProtocol
 
 
@@ -52,6 +59,7 @@ class HarnessExtensionConfig(HarnessBaseModel):
         ]
     )
     profile: str = "default"
+    sidecar: bool | dict[str, Any] = False
 
 
 class HarnessExtension:
@@ -65,46 +73,85 @@ class HarnessExtension:
     def __init__(
         self,
         *,
-        enabled: bool = True,
+        enabled: bool | None = None,
         components: Iterable[str] | str | None = None,
         profile: str = "default",
         store: HarnessStoreProtocol | None = None,
         context_config: HarnessInvocationContextConfig | None = None,
         compaction_config: ToolResultCompactorConfig | None = None,
         verifier_config: FinalResponseVerifierConfig | None = None,
+        sidecar: bool | Mapping[str, Any] | Any | None = None,
         env: Mapping[str, str] | None = None,
     ) -> None:
-        if components is None:
-            component_list = HarnessExtensionConfig().components
+        normalized_sidecar = normalize_sidecar_config(sidecar)
+        self.sidecar = ManagedHarnessSidecar(
+            normalized_sidecar,
+            profile=profile,
+            process_env=dict(env) if env is not None else None,
+        )
+        if self.sidecar.enabled:
+            if components is not None:
+                raise ValueError(
+                    "components cannot be combined with Harness Sidecar; "
+                    "use component_overrides with Product Component IDs"
+                )
+            component_list = list(self.sidecar.plan.activation_targets.veadk_plugins)
+            plugin_enabled = True
+        elif components is None:
+            component_list = _default_components(profile)
+            plugin_enabled = bool(enabled)
         elif isinstance(components, str):
             component_list = [
                 item.strip() for item in components.split(",") if item.strip()
             ]
+            plugin_enabled = True if enabled is None else enabled
         else:
             component_list = [
                 str(item).strip() for item in components if str(item).strip()
             ]
+            plugin_enabled = True if enabled is None else enabled
         self.config = HarnessExtensionConfig(
-            enabled=enabled,
+            enabled=plugin_enabled,
             components=component_list,
             profile=profile,
+            sidecar=normalized_sidecar,
         )
         self.store = store
         self.context_config = context_config
         self.compaction_config = compaction_config
         self.verifier_config = verifier_config
         self.env = dict(env) if env is not None else None
+        self.sidecar.start()
 
     @classmethod
     def from_env(cls, env: Mapping[str, str] | None = None) -> HarnessExtension:
         """Create an extension controlled by Harness environment variables."""
 
-        values = dict(env or os.environ)
-        return cls(enabled=harness_enabled_from_env(values), env=values)
+        values = dict(env if env is not None else os.environ)
+        return cls(
+            enabled=harness_enabled_from_env(values),
+            profile=(
+                values.get("HARNESS_ENHANCE_PROFILE")
+                or values.get("HARNESS_PROFILE")
+                or "default"
+            ),
+            sidecar=sidecar_config_from_env(values),
+            env=values,
+        )
 
     def plugins(self) -> list[BasePlugin]:
         """Build plugins for ``Runner(..., plugins=...)``."""
 
+        self.sidecar.start()
+        if self.sidecar.enabled:
+            return build_harness_plugins(
+                components=self.config.components,
+                profile=self.config.profile,
+                store=self.store,
+                context_config=self.context_config,
+                compaction_config=self.compaction_config,
+                verifier_config=self.verifier_config,
+            )
         if self.env is not None:
             return build_harness_plugins_from_env(self.env)
         if not self.config.enabled:
@@ -117,6 +164,36 @@ class HarnessExtension:
             compaction_config=self.compaction_config,
             verifier_config=self.verifier_config,
         )
+
+    @property
+    def sidecar_status(self) -> str:
+        """Return ``ok``, ``degraded``, ``disabled``, or runtime status."""
+
+        return self.sidecar.status
+
+    @property
+    def sidecar_env(self) -> dict[str, str]:
+        """Return environment bindings injected by the managed Sidecar."""
+
+        return self.sidecar.env
+
+    def close(self) -> None:
+        """Stop the managed Sidecar early; normal process exit is automatic."""
+
+        self.sidecar.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
+
+def _default_components(profile: str) -> list[str]:
+    components = HarnessExtensionConfig().components
+    if profile == "ops":
+        return [*components, "long_run_control"]
+    return components
 
 
 __all__ = ["HarnessExtension", "HarnessExtensionConfig"]

--- a/veadk/extensions/harness/sidecar.py
+++ b/veadk/extensions/harness/sidecar.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VeADK-managed lifecycle for the AgentKit Harness Sidecar product API."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Mapping, MutableMapping
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_INSTALL_HINT = 'pip install "veadk-python[harness-sidecar]"'
+
+
+class HarnessSidecarDependencyError(RuntimeError):
+    """Raised when Sidecar was requested without its optional dependency."""
+
+
+class ManagedHarnessSidecar:
+    """Own one Sidecar binding without exposing process details to VeADK users."""
+
+    def __init__(
+        self,
+        config: bool | Mapping[str, Any] | Any = False,
+        *,
+        profile: str = "default",
+        process_env: Mapping[str, str] | None = None,
+        binding_env: MutableMapping[str, str] | None = None,
+    ) -> None:
+        self.config = config
+        self.profile = profile
+        self.process_env = process_env
+        self.binding_env = binding_env if binding_env is not None else os.environ
+        self.binding: Any | None = None
+        self.error: Exception | None = None
+        self._attempted = False
+        self.plan = resolve_sidecar_plan(config, profile=profile)
+
+    @property
+    def enabled(self) -> bool:
+        if isinstance(self.config, bool):
+            return self.config
+        if isinstance(self.config, Mapping):
+            return bool(self.config.get("enabled", True))
+        return bool(getattr(self.config, "enabled", True))
+
+    @property
+    def fail_open(self) -> bool:
+        if isinstance(self.config, Mapping):
+            return bool(self.config.get("fail_open", True))
+        return bool(getattr(self.config, "fail_open", True))
+
+    @property
+    def status(self) -> str:
+        if self.binding is not None:
+            return str(self.binding.spec.status)
+        if self.error is not None:
+            return "degraded"
+        return "not_started" if self.enabled else "disabled"
+
+    @property
+    def env(self) -> dict[str, str]:
+        return dict(self.binding.env) if self.binding is not None else {}
+
+    def start(self) -> Any | None:
+        if not self.enabled or self.binding is not None or self._attempted:
+            return self.binding
+        self._attempted = True
+        try:
+            start_harness_sidecar = _public_start_function()
+            self.binding = start_harness_sidecar(
+                self.config,
+                profile=self.profile,
+                apply_env=True,
+                environ=self.binding_env,
+                process_env=self.process_env,
+            )
+        except Exception as error:
+            self.error = error
+            if not self.fail_open:
+                raise
+            logger.warning("Harness Sidecar startup failed open: %s", error)
+        return self.binding
+
+    def close(self) -> None:
+        if self.binding is not None:
+            self.binding.stop()
+            self.binding = None
+
+
+def sidecar_config_from_env(env: Mapping[str, str] | None = None) -> Any | bool:
+    """Load the public AgentKit Sidecar config only when explicitly enabled."""
+
+    values = env if env is not None else os.environ
+    if not _truthy(values.get("HARNESS_SIDECAR_ENABLED")):
+        return False
+    try:
+        from agentkit.toolkit.harness import HarnessSidecarConfig
+    except (ImportError, AttributeError) as error:
+        raise HarnessSidecarDependencyError(
+            f"Harness Sidecar support is not installed. Install it with: {_INSTALL_HINT}"
+        ) from error
+    return HarnessSidecarConfig.from_env(values)
+
+
+def normalize_sidecar_config(value: Any | None) -> bool | dict[str, Any]:
+    """Convert public config objects into VeADK's serializable extension config."""
+
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, Mapping):
+        return dict(value)
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return dict(model_dump(exclude_none=True))
+    raise TypeError("sidecar must be a bool, mapping, or HarnessSidecarConfig")
+
+
+def resolve_sidecar_plan(
+    value: bool | Mapping[str, Any] | Any,
+    *,
+    profile: str,
+) -> Any | None:
+    """Resolve the public Product Component plan without starting the Runtime."""
+
+    enabled = (
+        value
+        if isinstance(value, bool)
+        else bool(
+            value.get("enabled", True)
+            if isinstance(value, Mapping)
+            else getattr(value, "enabled", True)
+        )
+    )
+    if not enabled:
+        return None
+    try:
+        from agentkit.toolkit.harness import resolve_sidecar_config
+    except (ImportError, AttributeError) as error:
+        raise HarnessSidecarDependencyError(
+            f"Harness Sidecar support is not installed. Install it with: {_INSTALL_HINT}"
+        ) from error
+    config = resolve_sidecar_config(value, profile=profile)
+    plan = config.resolved_plan
+    if not plan.valid:
+        raise ValueError("; ".join(plan.errors))
+    return plan
+
+
+def _public_start_function():
+    try:
+        from agentkit.toolkit.harness import start_harness_sidecar
+    except (ImportError, AttributeError) as error:
+        raise HarnessSidecarDependencyError(
+            f"Harness Sidecar support is not installed. Install it with: {_INSTALL_HINT}"
+        ) from error
+    return start_harness_sidecar
+
+
+def _truthy(value: str | None) -> bool:
+    return bool(value and value.strip().lower() in {"1", "true", "yes", "on"})
+
+
+__all__ = [
+    "HarnessSidecarDependencyError",
+    "ManagedHarnessSidecar",
+    "normalize_sidecar_config",
+    "resolve_sidecar_plan",
+    "sidecar_config_from_env",
+]


### PR DESCRIPTION
## Summary
- start the Harness Sidecar before cloud Agent construction and clean it up on exit
- map resolved Product Components to veADK plugins without the legacy enhance switch
- keep the Runtime dependency optional through `agentkit-sdk-python[harness-sidecar]`

## Verification
- Harness extension/cloud tests: 96 passed
- Ruff checks for changed files passed

## Note
This branch intentionally excludes the unrelated local `feishu_channel.py` change.