### PR TITLE
feat(frontend): add analytics and code execution tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ VeSearch, and APMPlus keys for debug runs and deployed runtimes:
 The custom-agent workbench also supports the built-in `run_code` tool. Selecting
 “代码执行” adds its import and tool binding to generated Python and reveals the
 required `AGENTKIT_TOOL_ID` sandbox field directly below the built-in tool list.
+The optional `AGENTKIT_TOOL_REGION` field defaults to `cn-beijing`.
 The tool's `code`, `language`, and `timeout` arguments are supplied by the Agent
 at runtime.
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ The custom-agent workbench also supports the built-in `run_code` tool. Selecting
 “代码执行” adds its import and tool binding to generated Python and reveals the
 required `AGENTKIT_TOOL_ID` sandbox field directly below the built-in tool list.
 The optional `AGENTKIT_TOOL_REGION` field defaults to `cn-beijing`.
+Both values are applied to local debug runs and deployed runtimes.
 The tool's `code`, `language`, and `timeout` arguments are supplied by the Agent
 at runtime.
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ settings that cannot be derived automatically. Studio forwards its server-side
 Volcengine credentials and lets VeADK resolve Ark, embedding, media, speech,
 VeSearch, and APMPlus keys for debug runs and deployed runtimes:
 
+The custom-agent workbench also supports the built-in `run_code` tool. Selecting
+“代码执行” adds its import and tool binding to generated Python and reveals the
+required `AGENTKIT_TOOL_ID` sandbox field directly below the built-in tool list.
+The tool's `code`, `language`, and `timeout` arguments are supplied by the Agent
+at runtime.
+
 ```bash
 veadk frontend --agents-dir examples           # serve UI + API on http://127.0.0.1:8000
 ```

--- a/docs/content/docs/framework/frontend.en.mdx
+++ b/docs/content/docs/framework/frontend.en.mdx
@@ -48,8 +48,9 @@ VeADK ships a React frontend that renders [A2UI](/en/docs/framework/a2ui) (agent
   Agents dynamically for each request.
 - Selecting **Code execution** in the custom Agent's built-in tools adds the
   `run_code` tool and reveals the required `AGENTKIT_TOOL_ID` sandbox field
-  below the built-in tool list. The Agent supplies code, language, and timeout
-  at runtime from the tool signature, while ADK injects `tool_context`.
+  and optional `AGENTKIT_TOOL_REGION` field below the built-in tool list. The
+  region defaults to `cn-beijing`. The Agent supplies code, language, and
+  timeout at runtime from the tool signature, while ADK injects `tool_context`.
   Initialization, session, and conversation failures show credential-redacted
   error details and Runner logs that can be expanded and copied. The deployment
   page shows the Agent topology on the left, with hover details, configuration

--- a/docs/content/docs/framework/frontend.en.mdx
+++ b/docs/content/docs/framework/frontend.en.mdx
@@ -49,8 +49,9 @@ VeADK ships a React frontend that renders [A2UI](/en/docs/framework/a2ui) (agent
 - Selecting **Code execution** in the custom Agent's built-in tools adds the
   `run_code` tool and reveals the required `AGENTKIT_TOOL_ID` sandbox field
   and optional `AGENTKIT_TOOL_REGION` field below the built-in tool list. The
-  region defaults to `cn-beijing`. The Agent supplies code, language, and
-  timeout at runtime from the tool signature, while ADK injects `tool_context`.
+  region defaults to `cn-beijing`. Studio applies both fields to local debug runs
+  and deployed runtimes. The Agent supplies code, language, and timeout at runtime
+  from the tool signature, while ADK injects `tool_context`.
   Initialization, session, and conversation failures show credential-redacted
   error details and Runner logs that can be expanded and copied. The deployment
   page shows the Agent topology on the left, with hover details, configuration

--- a/docs/content/docs/framework/frontend.en.mdx
+++ b/docs/content/docs/framework/frontend.en.mdx
@@ -46,6 +46,10 @@ VeADK ships a React frontend that renders [A2UI](/en/docs/framework/a2ui) (agent
   names, descriptions, and capabilities come from Agent Cards returned by the
   center. The generated internal proxy discovers and mounts matching remote
   Agents dynamically for each request.
+- Selecting **Code execution** in the custom Agent's built-in tools adds the
+  `run_code` tool and reveals the required `AGENTKIT_TOOL_ID` sandbox field
+  below the built-in tool list. The Agent supplies code, language, and timeout
+  at runtime from the tool signature, while ADK injects `tool_context`.
   Initialization, session, and conversation failures show credential-redacted
   error details and Runner logs that can be expanded and copied. The deployment
   page shows the Agent topology on the left, with hover details, configuration

--- a/docs/content/docs/framework/frontend.en.mdx
+++ b/docs/content/docs/framework/frontend.en.mdx
@@ -486,6 +486,21 @@ must start with an ASCII letter or underscore, may then contain ASCII letters,
 digits, and underscores, cannot be the reserved name `user`, and must be unique
 within the Agent tree.
 
+### Optional frontend usage analytics
+
+Studio can collect anonymous frontend usage analytics through APMPlus WebPro.
+Set `APM_APP_ID` and `APM_APP_TOKEN` in the repository-level `.env` before the
+frontend build. Set `APM_ENABLED=false` to disable collection; browsers with Do
+Not Track enabled are excluded as well.
+
+Sidebar clicks use one `sidebar_feature_used` event with a fixed `feature`
+category for Agent selection, new chat, search, Skill Center, Agent creation and
+management, and conversation history. In WebPro Data Analysis, select the
+numeric `count` metric and group by `feature` to compare usage. Events never
+contain prompts, responses, filenames, Agent names, Session/Runtime IDs,
+credentials, or raw errors. With SSO, only a stable OIDC `sub`/`user_id` is
+used; local usernames are not sent.
+
 ### How it works
 
 <Steps>

--- a/docs/content/docs/framework/frontend.mdx
+++ b/docs/content/docs/framework/frontend.mdx
@@ -42,8 +42,9 @@ VeADK 自带一个 React 前端，用于渲染智能体经由 Google ADK API Ser
   召回数量、地域和 OpenAPI 地址配置。名称、描述和能力由中心返回的 Agent Card
   提供；生成的内部代理会在每轮请求中动态发现和挂载匹配的远程 Agent。
 - 在自定义 Agent 的内置工具中选择「代码执行」会生成 `run_code` 工具，并在工具列表
-  下方要求填写 `AGENTKIT_TOOL_ID`（代码执行沙箱 Tool ID）。代码、语言和超时
-  由 Agent 按工具函数签名在运行时传入，`tool_context` 由 ADK 自动注入。
+  下方要求填写 `AGENTKIT_TOOL_ID`（代码执行沙箱 Tool ID），同时可填写
+  `AGENTKIT_TOOL_REGION`（默认 `cn-beijing`）。代码、语言和超时由 Agent 按工具
+  函数签名在运行时传入，`tool_context` 由 ADK 自动注入。
 - **Tracing 观测**：查看本次会话的调用火焰图。
 - **登录**：支持 SSO（VeIdentity / GitHub / Google / 任意 OIDC）或本地用户名。
 

--- a/docs/content/docs/framework/frontend.mdx
+++ b/docs/content/docs/framework/frontend.mdx
@@ -41,6 +41,9 @@ VeADK 自带一个 React 前端，用于渲染智能体经由 Google ADK API Ser
   自定义创建中的“远程 Agent”仅可作为子 Agent，通过 AgentKit 智能体中心 ID、
   召回数量、地域和 OpenAPI 地址配置。名称、描述和能力由中心返回的 Agent Card
   提供；生成的内部代理会在每轮请求中动态发现和挂载匹配的远程 Agent。
+- 在自定义 Agent 的内置工具中选择「代码执行」会生成 `run_code` 工具，并在工具列表
+  下方要求填写 `AGENTKIT_TOOL_ID`（代码执行沙箱 Tool ID）。代码、语言和超时
+  由 Agent 按工具函数签名在运行时传入，`tool_context` 由 ADK 自动注入。
 - **Tracing 观测**：查看本次会话的调用火焰图。
 - **登录**：支持 SSO（VeIdentity / GitHub / Google / 任意 OIDC）或本地用户名。
 

--- a/docs/content/docs/framework/frontend.mdx
+++ b/docs/content/docs/framework/frontend.mdx
@@ -43,8 +43,8 @@ VeADK 自带一个 React 前端，用于渲染智能体经由 Google ADK API Ser
   提供；生成的内部代理会在每轮请求中动态发现和挂载匹配的远程 Agent。
 - 在自定义 Agent 的内置工具中选择「代码执行」会生成 `run_code` 工具，并在工具列表
   下方要求填写 `AGENTKIT_TOOL_ID`（代码执行沙箱 Tool ID），同时可填写
-  `AGENTKIT_TOOL_REGION`（默认 `cn-beijing`）。代码、语言和超时由 Agent 按工具
-  函数签名在运行时传入，`tool_context` 由 ADK 自动注入。
+  `AGENTKIT_TOOL_REGION`（默认 `cn-beijing`）。两个值都会用于本地调试和部署运行时；
+  代码、语言和超时由 Agent 按工具函数签名在运行时传入，`tool_context` 由 ADK 自动注入。
 - **Tracing 观测**：查看本次会话的调用火焰图。
 - **登录**：支持 SSO（VeIdentity / GitHub / Google / 任意 OIDC）或本地用户名。
 

--- a/docs/content/docs/framework/frontend.mdx
+++ b/docs/content/docs/framework/frontend.mdx
@@ -403,6 +403,19 @@ Studio 会按照 Google ADK 的规则校验根 Agent 与所有嵌套 Agent 的�
 英文字母或下划线开头，后续只能包含英文字母、数字和下划线；不能使用保留名
 `user`，并且在整个 Agent 结构中必须唯一。
 
+### 可选的前端使用统计
+
+Studio 可通过 APMPlus WebPro 采集匿名前端使用统计。构建前在仓库根目录的
+`.env` 中配置 `APM_APP_ID` 与 `APM_APP_TOKEN`；设置
+`APM_ENABLED=false` 可关闭采集，浏览器启用 Do Not Track 时也不会上报。
+
+Sidebar 点击统一记录为 `sidebar_feature_used`，通过固定的 `feature` 维度区分
+Agent 选择、新会话、搜索、Skill 中心、Agent 创建与管理、历史会话等入口。
+在 WebPro 数据分析中选择数值指标 `count`，再按 `feature` 分组，即可查看各入口
+的使用次数。
+埋点不会包含 Prompt、回复、文件名、Agent 名称、Session/Runtime ID、凭据或原始
+错误信息。SSO 场景仅使用稳定的 OIDC `sub`/`user_id`；本地用户名不会上报。
+
 ### 工作原理
 
 <Steps>

--- a/docs/content/docs/framework/tools/builtin.en.mdx
+++ b/docs/content/docs/framework/tools/builtin.en.mdx
@@ -528,6 +528,7 @@ Environment variables:
 - `AGENTKIT_TOOL_ID_OPENCODE`: sandbox ID dedicated to `coding`; falls back to `AGENTKIT_TOOL_ID`
 - `AGENTKIT_TOOL_HOST`: endpoint for calling AgentKit Tools
 - `AGENTKIT_TOOL_SERVICE_CODE`: ServiceCode for calling AgentKit Tools
+- `AGENTKIT_TOOL_REGION`: region for calling AgentKit Tools; defaults to `cn-beijing`
 
 Additional `config.yaml` keys:
 

--- a/docs/content/docs/framework/tools/builtin.en.mdx
+++ b/docs/content/docs/framework/tools/builtin.en.mdx
@@ -522,8 +522,8 @@ Environment variables:
 
 - `MODEL_AGENT_API_KEY`: API key for the agent's reasoning model
 - `VOLCENGINE_ACCESS_KEY` / `VOLCENGINE_SECRET_KEY`: Volcengine AK / SK
-- `AGENTKIT_TOOL_ID`: default AgentKit sandbox ID, the fallback for all sandbox tools
-- `AGENTKIT_TOOL_ID_SCRIPT`: sandbox ID dedicated to `run_code`; falls back to `AGENTKIT_TOOL_ID`
+- `AGENTKIT_TOOL_ID`: code-execution sandbox ID used by `run_code` and the
+  fallback for other sandbox tools
 - `AGENTKIT_TOOL_ID_SKILLS`: sandbox ID dedicated to `execute_skills`; falls back to `AGENTKIT_TOOL_ID`
 - `AGENTKIT_TOOL_ID_OPENCODE`: sandbox ID dedicated to `coding`; falls back to `AGENTKIT_TOOL_ID`
 - `AGENTKIT_TOOL_HOST`: endpoint for calling AgentKit Tools

--- a/docs/content/docs/framework/tools/builtin.mdx
+++ b/docs/content/docs/framework/tools/builtin.mdx
@@ -518,8 +518,8 @@ if __name__ == "__main__":
 
 - `MODEL_AGENT_API_KEY`：Agent 推理模型的 API Key
 - `VOLCENGINE_ACCESS_KEY` / `VOLCENGINE_SECRET_KEY`：火山引擎 AK / SK
-- `AGENTKIT_TOOL_ID`：默认 AgentKit 沙箱 ID，作为所有沙箱工具的兜底配置
-- `AGENTKIT_TOOL_ID_SCRIPT`：`run_code` 专用沙箱 ID，未配置时回退到 `AGENTKIT_TOOL_ID`
+- `AGENTKIT_TOOL_ID`：`run_code` 使用的代码执行沙箱 ID，也是其他沙箱工具的
+  兜底配置
 - `AGENTKIT_TOOL_ID_SKILLS`：`execute_skills` 专用沙箱 ID，未配置时回退到 `AGENTKIT_TOOL_ID`
 - `AGENTKIT_TOOL_ID_OPENCODE`：`coding` 专用沙箱 ID，未配置时回退到 `AGENTKIT_TOOL_ID`
 - `AGENTKIT_TOOL_HOST`：调用 AgentKit Tools 的 Endpoint

--- a/docs/content/docs/framework/tools/builtin.mdx
+++ b/docs/content/docs/framework/tools/builtin.mdx
@@ -524,6 +524,7 @@ if __name__ == "__main__":
 - `AGENTKIT_TOOL_ID_OPENCODE`：`coding` 专用沙箱 ID，未配置时回退到 `AGENTKIT_TOOL_ID`
 - `AGENTKIT_TOOL_HOST`：调用 AgentKit Tools 的 Endpoint
 - `AGENTKIT_TOOL_SERVICE_CODE`：调用 AgentKit Tools 的 ServiceCode
+- `AGENTKIT_TOOL_REGION`：调用 AgentKit Tools 的地域，默认 `cn-beijing`
 
 新增的 `config.yaml` 配置项：
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -88,6 +88,27 @@ Temporary Sandbox state is process-local. Run Studio with one server worker, or
 configure session affinity so create, message, and delete requests from the same
 browser reach the same instance.
 
+### Anonymous frontend analytics
+
+The optional APMPlus WebPro integration records Studio opens and coarse-grained
+feature events such as sidebar actions, chat submission, media type, trace
+viewing, and deployment outcomes. Sidebar actions use the
+`sidebar_feature_used` event with a fixed `feature` category; no selected Agent
+or Session identifier is included. In WebPro Data Analysis, select the `count`
+metric and group by `feature` to compare usage. Analytics never includes prompts,
+responses, filenames, agent names, runtime IDs, credentials, or raw error messages.
+Configure the repository-level `.env` before building the frontend:
+
+```dotenv
+APM_APP_ID=123456
+APM_APP_TOKEN=replace-with-webpro-app-token
+APM_ENV=production
+```
+
+Set `APM_ENABLED=false` to omit analytics. Browsers with Do Not Track enabled are
+also excluded. Authenticated analytics uses only a stable OIDC `sub`/`user_id`;
+local usernames are not sent.
+
 ## Development specification
 
 All frontend changes must follow [`SPEC.md`](SPEC.md). It defines the required

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -71,6 +71,10 @@ server that `veadk frontend` launches — no separate backend.
   its generated internal proxy mounts AgentKit A2A center agents dynamically
   from the center ID, recall count, region, and OpenAPI endpoint. Remote names,
   descriptions, and capabilities come from the returned Agent Cards.
+- **Built-in code execution**: selecting `代码执行` adds VeADK's `run_code`
+  tool to generated Python and reveals the required `AGENTKIT_TOOL_ID` sandbox
+  field below the built-in tool list. The generated `.env.example` contains the
+  same setting.
 - **Auth**: optional VeIdentity SSO, or a local username for dev.
 - **Agent-driven UI (A2UI)**: when an agent emits A2UI, it renders as native
   components (one feature among the above — not required).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -74,7 +74,8 @@ server that `veadk frontend` launches — no separate backend.
 - **Built-in code execution**: selecting `代码执行` adds VeADK's `run_code`
   tool to generated Python and reveals the required `AGENTKIT_TOOL_ID` sandbox
   field and optional `AGENTKIT_TOOL_REGION` field below the built-in tool list.
-  The region defaults to `cn-beijing`; generated `.env.example` contains both.
+  The region defaults to `cn-beijing`. Studio applies both fields to local debug
+  runs and deployments, and generated `.env.example` contains both.
 - **Auth**: optional VeIdentity SSO, or a local username for dev.
 - **Agent-driven UI (A2UI)**: when an agent emits A2UI, it renders as native
   components (one feature among the above — not required).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -73,8 +73,8 @@ server that `veadk frontend` launches — no separate backend.
   descriptions, and capabilities come from the returned Agent Cards.
 - **Built-in code execution**: selecting `代码执行` adds VeADK's `run_code`
   tool to generated Python and reveals the required `AGENTKIT_TOOL_ID` sandbox
-  field below the built-in tool list. The generated `.env.example` contains the
-  same setting.
+  field and optional `AGENTKIT_TOOL_REGION` field below the built-in tool list.
+  The region defaults to `cn-beijing`; generated `.env.example` contains both.
 - **Auth**: optional VeIdentity SSO, or a local username for dev.
 - **Agent-driven UI (A2UI)**: when an agent emits A2UI, it renders as native
   components (one feature among the above — not required).

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "veadk-a2ui-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@apmplus/web": "^2.10.1",
         "@codemirror/lang-javascript": "^6.2.5",
         "@codemirror/lang-json": "^6.0.2",
         "@codemirror/lang-markdown": "^6.5.1",
@@ -35,6 +36,12 @@
         "typescript": "^5.6.3",
         "vite": "^5.4.11"
       }
+    },
+    "node_modules/@apmplus/web": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmmirror.com/@apmplus/web/-/web-2.10.1.tgz",
+      "integrity": "sha512-6a7opvDBRgn/bLg7lYdyhipsE6paqootdF2wuDGuBK7vgmE4DrjxqSV3mD/YvFzyVWXnR2HR4Y/Bdw99LgcumQ==",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@apmplus/web": "^2.10.1",
     "@codemirror/lang-javascript": "^6.2.5",
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-markdown": "^6.5.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -95,6 +95,10 @@ import {
   SandboxSessionWarning,
 } from "./ui/SandboxSession";
 import defaultSiteLogo from "./assets/volcengine.svg";
+import {
+  identifyAnalyticsUser,
+  trackEvent,
+} from "./analytics/webpro";
 
 // Breadcrumb root label for the create flow and the per-mode leaf labels.
 const CREATE_ROOT = "创建 Agent";
@@ -890,6 +894,12 @@ export default function App() {
   }, [localMode, userId]);
 
   useEffect(() => {
+    if (authStatus !== "authenticated" || localMode || !userInfo) return;
+    const stableUserId = String(userInfo.sub ?? userInfo.user_id ?? "");
+    identifyAnalyticsUser(stableUserId);
+  }, [authStatus, localMode, userInfo]);
+
+  useEffect(() => {
     if (authStatus !== "authenticated" || !userId) {
       setNewChatCapabilities({});
       return;
@@ -1425,8 +1435,21 @@ export default function App() {
     setAttachments((current) => [...current, ...drafts.map((draft) => draft.attachment)]);
     await Promise.all(
       drafts.map(async ({ file, attachment }) => {
+        const uploadStartedAt = performance.now();
+        const mediaType = file.type.startsWith("image/")
+          ? "image"
+          : file.type.startsWith("video/")
+            ? "video"
+            : file.type === "application/pdf"
+              ? "pdf"
+              : "document";
         try {
           const uploaded = await uploadMedia(appName, userId, sid, file);
+          trackEvent(
+            "media_upload_result",
+            { media_type: mediaType, result: "success" },
+            { duration_ms: performance.now() - uploadStartedAt },
+          );
           if (removedAttachmentIdsRef.current.delete(attachment.id)) {
             if (uploaded.uri) await deleteMedia(appName, uploaded.uri);
             return;
@@ -1437,6 +1460,11 @@ export default function App() {
               : item,
           ));
         } catch (e) {
+          trackEvent(
+            "media_upload_result",
+            { media_type: mediaType, result: "error" },
+            { duration_ms: performance.now() - uploadStartedAt },
+          );
           if (removedAttachmentIdsRef.current.delete(attachment.id)) return;
           const message = e instanceof Error ? e.message : String(e);
           setAttachments((current) => current.map((item) =>
@@ -1462,6 +1490,15 @@ export default function App() {
       !userId
     ) return;
     setError("");
+    trackEvent(
+      "agent_message_submit",
+      {
+        has_media: atts.length > 0,
+        has_skill: selectedInvocation.skills.length > 0,
+        has_subagent: Boolean(selectedInvocation.targetAgent),
+      },
+      { attachment_count: atts.length },
+    );
 
     const userBlocks: Turn["blocks"] = [];
     if (selectedInvocation.skills.length > 0 || selectedInvocation.targetAgent) {
@@ -2235,7 +2272,10 @@ export default function App() {
                             <button
                               className="icon-btn"
                               title="Tracing 火焰图"
-                              onClick={() => setTraceOpen(true)}
+                              onClick={() => {
+                                trackEvent("trace_open");
+                                setTraceOpen(true);
+                              }}
                             >
                               <TraceIcon />
                             </button>

--- a/frontend/src/analytics/webpro.ts
+++ b/frontend/src/analytics/webpro.ts
@@ -1,0 +1,85 @@
+import type { BrowserCommandClient } from "@apmplus/web";
+
+type EventCategories = Record<string, string | boolean | number | undefined>;
+type EventMetrics = Record<string, number | undefined>;
+
+const appId = Number(__APMPLUS_AID__);
+const configured =
+  __APMPLUS_ENABLED__.toLowerCase() !== "false" &&
+  Number.isInteger(appId) &&
+  appId > 0 &&
+  __APMPLUS_TOKEN__.length > 0;
+
+let client: BrowserCommandClient | undefined;
+let initialization: Promise<void> | undefined;
+
+function trackingAllowed(): boolean {
+  return configured && navigator.doNotTrack !== "1";
+}
+
+export function initAnalytics(): Promise<void> {
+  if (!trackingAllowed()) return Promise.resolve();
+  if (initialization) return initialization;
+
+  initialization = import("@apmplus/web")
+    .then(({ default: browserClient }) => {
+      browserClient("context.merge", {
+        product: "veadk_studio",
+        distribution: "open_source",
+      });
+      browserClient("init", {
+        aid: appId,
+        token: __APMPLUS_TOKEN__,
+        env: __APMPLUS_ENV__,
+        pid: "/studio",
+      });
+      browserClient("start");
+      client = browserClient;
+      browserClient("sendEvent", {
+        name: "studio_open",
+        metrics: { count: 1 },
+        categories: { environment: __APMPLUS_ENV__ },
+      });
+    })
+    .catch((error: unknown) => {
+      console.warn("[analytics] WebPro initialization failed:", error);
+    });
+
+  return initialization;
+}
+
+export function identifyAnalyticsUser(userId: string): void {
+  if (!userId || !trackingAllowed()) return;
+  void initAnalytics().then(() => {
+    client?.("config", { userId });
+  });
+}
+
+export function trackEvent(
+  name: string,
+  categories: EventCategories = {},
+  metrics: EventMetrics = {},
+): void {
+  if (!trackingAllowed()) return;
+  const normalizedCategories = Object.fromEntries(
+    Object.entries(categories)
+      .filter((entry): entry is [string, string | boolean | number] => entry[1] !== undefined)
+      .map(([key, value]) => [key, String(value)]),
+  );
+  const normalizedMetrics = Object.fromEntries(
+    Object.entries(metrics).filter(
+      (entry): entry is [string, number] =>
+        entry[1] !== undefined && Number.isFinite(entry[1]),
+    ),
+  );
+  const eventMetrics =
+    Object.keys(normalizedMetrics).length > 0 ? normalizedMetrics : { count: 1 };
+
+  void initAnalytics().then(() => {
+    client?.("sendEvent", {
+      name,
+      categories: normalizedCategories,
+      metrics: eventMetrics,
+    });
+  });
+}

--- a/frontend/src/create/CustomCreate.css
+++ b/frontend/src/create/CustomCreate.css
@@ -1055,8 +1055,7 @@
   top: calc(100% + 6px);
   left: 0;
   width: 100%;
-  max-height: 238px;
-  overflow-y: auto;
+  overflow: hidden;
   padding: 4px;
   border: 1px solid hsl(var(--border));
   border-radius: 6px;
@@ -1064,6 +1063,37 @@
   color: hsl(var(--foreground));
   box-shadow: 0 8px 24px hsl(var(--foreground) / 0.08);
   font-size: 12px;
+}
+.cw-picker-search {
+  padding: 4px 4px 6px;
+  border-bottom: 1px solid hsl(var(--border) / 0.72);
+}
+.cw-picker-search-input {
+  width: 100%;
+  height: 30px;
+  padding: 0 9px;
+  border: 1px solid hsl(var(--border));
+  border-radius: 5px;
+  outline: none;
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  font: inherit;
+  font-size: 12px;
+}
+.cw-picker-search-input:focus {
+  border-color: hsl(var(--ring) / 0.5);
+  box-shadow: 0 0 0 2px hsl(var(--ring) / 0.1);
+}
+.cw-picker-options {
+  max-height: 188px;
+  overflow-y: auto;
+  padding-top: 4px;
+  overscroll-behavior: contain;
+}
+.cw-picker-empty {
+  padding: 14px 10px;
+  color: hsl(var(--muted-foreground));
+  text-align: center;
 }
 .cw-a2a-space-option {
   display: flex;
@@ -1128,10 +1158,11 @@
   gap: 6px;
 }
 .cw-viking-kb-menu {
-  max-height: min(148px, calc(100vh - 260px));
   padding: 3px;
-  overscroll-behavior: contain;
   box-shadow: 0 6px 18px hsl(var(--foreground) / 0.06);
+}
+.cw-viking-kb-menu .cw-picker-options {
+  max-height: min(112px, calc(100vh - 310px));
 }
 .cw-viking-kb-menu .cw-a2a-space-option {
   min-height: 28px;

--- a/frontend/src/create/CustomCreate.css
+++ b/frontend/src/create/CustomCreate.css
@@ -1540,6 +1540,19 @@
   container-type: inline-size;
 }
 
+.cw-tool-config {
+  padding: 14px;
+  border: 1px solid hsl(var(--border));
+  border-radius: 12px;
+  background: hsl(var(--muted) / 0.28);
+}
+
+.cw-tool-config-head {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
 .cw-checklist-tools {
   --cw-checklist-row-height: 65px;
   display: grid;

--- a/frontend/src/create/CustomCreate.tsx
+++ b/frontend/src/create/CustomCreate.tsx
@@ -66,6 +66,7 @@ import {
   isOrchestratorType,
 } from "./agentTypeMeta";
 import { displayDescription } from "./displayText";
+import { localPickerMatches } from "./localPickerSearch";
 import { draftToYaml } from "./configYaml";
 import type { AgentProject } from "./project";
 import type { SkillSource } from "./skills/types";
@@ -482,6 +483,7 @@ function A2aSpaceSelect({
   const [error, setError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
   const [open, setOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const pickerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -515,6 +517,22 @@ function A2aSpaceSelect({
       ? "已选择的智能体中心"
       : "请选择智能体中心";
   const disabled = loading && spaces.length === 0;
+  const filteredSpaces = useMemo(
+    () =>
+      spaces.filter((space) =>
+        localPickerMatches(searchQuery, [
+          a2aSpaceDisplayName(space),
+          space.id,
+          space.projectName,
+        ]),
+      ),
+    [searchQuery, spaces],
+  );
+  const showUnknownSpace = Boolean(
+    value &&
+      !selectedKnown &&
+      localPickerMatches(searchQuery, ["已选择的智能体中心", value]),
+  );
 
   useEffect(() => {
     if (!open) return;
@@ -555,7 +573,10 @@ function A2aSpaceSelect({
             aria-haspopup="listbox"
             aria-expanded={open}
             aria-label="选择 AgentKit 智能体中心"
-            onClick={() => setOpen((current) => !current)}
+            onClick={() => {
+              setSearchQuery("");
+              setOpen((current) => !current);
+            }}
           >
             <span className={!value ? "is-placeholder" : undefined}>
               {selectedLabel}
@@ -565,39 +586,58 @@ function A2aSpaceSelect({
           {open && (
             <div
               className="cw-a2a-space-menu"
-              role="listbox"
-              aria-label="AgentKit 智能体中心"
             >
-              {value && !selectedKnown && (
-                <button
-                  type="button"
-                  role="option"
-                  aria-selected
-                  className="cw-a2a-space-option is-selected"
-                  onClick={() => selectSpace(value)}
-                >
-                  已选择的智能体中心
-                </button>
-              )}
-              {spaces.map((space) => {
-                const optionLabel = a2aSpaceDisplayName(space);
-                const selected = space.id === value;
-                return (
+              <div className="cw-picker-search">
+                <input
+                  className="cw-picker-search-input"
+                  type="search"
+                  value={searchQuery}
+                  autoFocus
+                  autoComplete="off"
+                  aria-label="搜索 AgentKit 智能体中心"
+                  placeholder="搜索名称或 ID"
+                  onChange={(event) => setSearchQuery(event.currentTarget.value)}
+                />
+              </div>
+              <div
+                className="cw-picker-options"
+                role="listbox"
+                aria-label="AgentKit 智能体中心"
+              >
+                {showUnknownSpace && (
                   <button
-                    key={space.id}
                     type="button"
                     role="option"
-                    aria-selected={selected}
-                    className={`cw-a2a-space-option ${
-                      selected ? "is-selected" : ""
-                    }`}
-                    title={optionLabel}
-                    onClick={() => selectSpace(space.id)}
+                    aria-selected
+                    className="cw-a2a-space-option is-selected"
+                    onClick={() => selectSpace(value)}
                   >
-                    {optionLabel}
+                    已选择的智能体中心
                   </button>
-                );
-              })}
+                )}
+                {filteredSpaces.map((space) => {
+                  const optionLabel = a2aSpaceDisplayName(space);
+                  const selected = space.id === value;
+                  return (
+                    <button
+                      key={space.id}
+                      type="button"
+                      role="option"
+                      aria-selected={selected}
+                      className={`cw-a2a-space-option ${
+                        selected ? "is-selected" : ""
+                      }`}
+                      title={`${optionLabel} (${space.id})`}
+                      onClick={() => selectSpace(space.id)}
+                    >
+                      {optionLabel}
+                    </button>
+                  );
+                })}
+                {!showUnknownSpace && filteredSpaces.length === 0 && (
+                  <div className="cw-picker-empty">未找到匹配的智能体中心</div>
+                )}
+              </div>
             </div>
           )}
         </div>
@@ -649,6 +689,7 @@ function VikingKnowledgebaseSelect({
   const [error, setError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
   const [open, setOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const pickerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -682,6 +723,21 @@ function VikingKnowledgebaseSelect({
       ? value
       : "请选择 VikingDB 知识库";
   const disabled = loading && items.length === 0;
+  const filteredItems = useMemo(
+    () =>
+      items.filter((item) =>
+        localPickerMatches(searchQuery, [
+          vikingKnowledgebaseDisplayName(item),
+          item.id,
+          item.description,
+          item.projectName,
+        ]),
+      ),
+    [items, searchQuery],
+  );
+  const showUnknownItem = Boolean(
+    value && !selectedKnown && localPickerMatches(searchQuery, [value]),
+  );
 
   useEffect(() => {
     if (!open) return;
@@ -722,7 +778,10 @@ function VikingKnowledgebaseSelect({
             aria-haspopup="listbox"
             aria-expanded={open}
             aria-label="选择 VikingDB 知识库"
-            onClick={() => setOpen((current) => !current)}
+            onClick={() => {
+              setSearchQuery("");
+              setOpen((current) => !current);
+            }}
           >
             <span className={!value ? "is-placeholder" : undefined}>
               {selectedLabel}
@@ -732,39 +791,58 @@ function VikingKnowledgebaseSelect({
           {open && (
             <div
               className="cw-a2a-space-menu cw-viking-kb-menu"
-              role="listbox"
-              aria-label="VikingDB 知识库"
             >
-              {value && !selectedKnown && (
-                <button
-                  type="button"
-                  role="option"
-                  aria-selected
-                  className="cw-a2a-space-option is-selected"
-                  onClick={() => selectItem(value)}
-                >
-                  {value}
-                </button>
-              )}
-              {items.map((item) => {
-                const optionLabel = vikingKnowledgebaseDisplayName(item);
-                const selected = item.id === value;
-                return (
+              <div className="cw-picker-search">
+                <input
+                  className="cw-picker-search-input"
+                  type="search"
+                  value={searchQuery}
+                  autoFocus
+                  autoComplete="off"
+                  aria-label="搜索 VikingDB 知识库"
+                  placeholder="搜索名称或 ID"
+                  onChange={(event) => setSearchQuery(event.currentTarget.value)}
+                />
+              </div>
+              <div
+                className="cw-picker-options"
+                role="listbox"
+                aria-label="VikingDB 知识库"
+              >
+                {showUnknownItem && (
                   <button
-                    key={item.id}
                     type="button"
                     role="option"
-                    aria-selected={selected}
-                    className={`cw-a2a-space-option ${
-                      selected ? "is-selected" : ""
-                    }`}
-                    title={optionLabel}
-                    onClick={() => selectItem(item.id)}
+                    aria-selected
+                    className="cw-a2a-space-option is-selected"
+                    onClick={() => selectItem(value)}
                   >
-                    {optionLabel}
+                    {value}
                   </button>
-                );
-              })}
+                )}
+                {filteredItems.map((item) => {
+                  const optionLabel = vikingKnowledgebaseDisplayName(item);
+                  const selected = item.id === value;
+                  return (
+                    <button
+                      key={item.id}
+                      type="button"
+                      role="option"
+                      aria-selected={selected}
+                      className={`cw-a2a-space-option ${
+                        selected ? "is-selected" : ""
+                      }`}
+                      title={`${optionLabel} (${item.id})`}
+                      onClick={() => selectItem(item.id)}
+                    >
+                      {optionLabel}
+                    </button>
+                  );
+                })}
+                {!showUnknownItem && filteredItems.length === 0 && (
+                  <div className="cw-picker-empty">未找到匹配的知识库</div>
+                )}
+              </div>
             </div>
           )}
         </div>

--- a/frontend/src/create/CustomCreate.tsx
+++ b/frontend/src/create/CustomCreate.tsx
@@ -54,6 +54,7 @@ import {
 } from "./veadkCatalog";
 import {
   runtimeEnvConfiguration,
+  runtimeEnvVars,
   type RuntimeEnvConfiguration,
   type RuntimeEnvSelection,
 } from "./deploymentEnv";
@@ -85,6 +86,7 @@ import {
 } from "../ui/ProjectPreview";
 import { Blocks, ThinkingPlaceholder } from "../ui/Blocks";
 import { DeploymentErrorMessage } from "../ui/DeploymentErrorMessage";
+import { isImeCompositionEvent } from "../ui/composerKeyboard";
 import {
   createGeneratedAgentTestRun,
   createGeneratedAgentTestSession,
@@ -1620,8 +1622,28 @@ function codegenDraft(draft: AgentDraft): AgentDraft {
   };
 }
 
+function debugRuntimeDraft(draft: AgentDraft): AgentDraft {
+  const runtimeEnv = collectDeploymentEnv(draft);
+  const values = {
+    ...(draft.deployment?.envValues ?? {}),
+    ...runtimeEnv.fixedValues,
+  };
+  return {
+    ...codegenDraft(draft),
+    deployment: {
+      feishuEnabled: !!draft.deployment?.feishuEnabled,
+      envValues: Object.fromEntries(
+        runtimeEnvVars(runtimeEnv.specs, values).map(({ key, value }) => [
+          key,
+          value,
+        ]),
+      ),
+    },
+  };
+}
+
 function debugSnapshotKey(draft: AgentDraft): string {
-  return JSON.stringify(codegenDraft(draft));
+  return JSON.stringify(debugRuntimeDraft(draft));
 }
 
 function DebugPanel({
@@ -1808,6 +1830,7 @@ function DebugPanel({
             disabled={!ready || busy || stale}
             onChange={(e) => onInput(e.target.value)}
             onKeyDown={(e) => {
+              if (isImeCompositionEvent(e.nativeEvent)) return;
               if (e.key === "Enter" && !e.shiftKey) {
                 e.preventDefault();
                 onSend();
@@ -2349,7 +2372,7 @@ export function CustomCreate({
       pushLog("提交 Agent 配置");
       setDebugPhase("starting");
       pushLog("初始化调试环境");
-      const run = await createGeneratedAgentTestRun(codegenDraft(draft));
+      const run = await createGeneratedAgentTestRun(debugRuntimeDraft(draft));
       debugRunRef.current = run;
       setDebugRun(run);
       setDebugProjectName(run.appName);

--- a/frontend/src/create/CustomCreate.tsx
+++ b/frontend/src/create/CustomCreate.tsx
@@ -2893,6 +2893,33 @@ export function CustomCreate({
                           scrollRows={6}
                         />
                       </div>
+                      <AnimatePresence initial={false}>
+                        {builtinTools.includes("run_code") && (
+                          <motion.div
+                            className="cw-tool-config"
+                            initial={{ opacity: 0, y: -4 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            exit={{ opacity: 0, y: -4 }}
+                            transition={{ duration: 0.16, ease: "easeOut" }}
+                          >
+                            <div className="cw-tool-config-head">
+                              <span className="cw-label">代码执行配置</span>
+                              <span className="cw-help">
+                                指定 AgentKit 代码执行沙箱。
+                              </span>
+                            </div>
+                            <RuntimeEnvFields
+                              env={
+                                BUILTIN_TOOLS.find(
+                                  (item) => item.id === "run_code",
+                                )?.env ?? []
+                              }
+                              values={draft.deployment?.envValues ?? {}}
+                              onChange={patchDeploymentEnv}
+                            />
+                          </motion.div>
+                        )}
+                      </AnimatePresence>
                     </div>
                     <button
                       type="button"

--- a/frontend/src/create/localPickerSearch.ts
+++ b/frontend/src/create/localPickerSearch.ts
@@ -1,0 +1,9 @@
+/** Match a local picker row against a case-insensitive keyword. */
+export function localPickerMatches(
+  query: string,
+  values: Array<string | undefined>,
+): boolean {
+  const keyword = query.trim().toLocaleLowerCase();
+  if (!keyword) return true;
+  return values.some((value) => value?.toLocaleLowerCase().includes(keyword));
+}

--- a/frontend/src/create/normalizeDraft.ts
+++ b/frontend/src/create/normalizeDraft.ts
@@ -20,6 +20,7 @@ const TOOL_IDS = new Set([
   "image_edit",
   "video_generate",
   "text_to_speech",
+  "run_code",
   "vesearch",
 ]);
 const AGENT_TYPES = new Set(["llm", "sequential", "parallel", "loop", "a2a"]);

--- a/frontend/src/create/veadkCatalog.ts
+++ b/frontend/src/create/veadkCatalog.ts
@@ -203,6 +203,12 @@ export const BUILTIN_TOOLS: ToolOption[] = [
         placeholder: "填写代码执行沙箱 Tool ID",
         comment: "代码执行沙箱 ID",
       },
+      {
+        key: "AGENTKIT_TOOL_REGION",
+        required: false,
+        placeholder: "cn-beijing",
+        comment: "AgentKit Tools 地域",
+      },
     ],
   },
   {

--- a/frontend/src/create/veadkCatalog.ts
+++ b/frontend/src/create/veadkCatalog.ts
@@ -191,6 +191,21 @@ export const BUILTIN_TOOLS: ToolOption[] = [
     ],
   },
   {
+    id: "run_code",
+    label: "代码执行",
+    desc: "在沙箱中执行代码",
+    importLine: "from veadk.tools.builtin_tools.run_code import run_code",
+    toolNames: ["run_code"],
+    env: [
+      {
+        key: "AGENTKIT_TOOL_ID",
+        required: true,
+        placeholder: "填写代码执行沙箱 Tool ID",
+        comment: "代码执行沙箱 ID",
+      },
+    ],
+  },
+  {
     id: "vesearch",
     label: "VeSearch 智能搜索",
     desc: "火山 VeSearch（需要 bot 端点）。",

--- a/frontend/src/create/veadkCatalog.ts
+++ b/frontend/src/create/veadkCatalog.ts
@@ -200,7 +200,7 @@ export const BUILTIN_TOOLS: ToolOption[] = [
       {
         key: "AGENTKIT_TOOL_ID",
         required: true,
-        placeholder: "填写代码执行沙箱 Tool ID",
+        placeholder: "t-xxxx",
         comment: "代码执行沙箱 ID",
       },
       {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { MotionConfig } from "motion/react";
 import { PhotoProvider } from "react-photo-view";
 import App from "./App";
+import { initAnalytics } from "./analytics/webpro";
 import "react-photo-view/dist/react-photo-view.css";
 import "./styles.css";
 
@@ -11,7 +12,7 @@ import "./styles.css";
 // the popup. Detect that case *before* the app boots, hand the full callback
 // URL (with ?code=&state=) back to the opener, and close — so the user never
 // has to paste anything and the app never mounts in a throwaway window.
-(() => {
+const handledOAuthCallback = (() => {
   const isCallback =
     window.opener &&
     window.opener !== window &&
@@ -27,15 +28,20 @@ import "./styles.css";
   }
   window.close();
   return true;
-})() ||
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    {/* reducedMotion="user" makes all motion components honor the OS
-        prefers-reduced-motion setting (transforms/opacity are stilled). */}
-    <MotionConfig reducedMotion="user">
-      <PhotoProvider maskOpacity={0.9}>
-        <App />
-      </PhotoProvider>
-    </MotionConfig>
-  </React.StrictMode>,
-);
+})();
+
+if (!handledOAuthCallback) {
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+      {/* reducedMotion="user" makes all motion components honor the OS
+          prefers-reduced-motion setting (transforms/opacity are stilled). */}
+      <MotionConfig reducedMotion="user">
+        <PhotoProvider maskOpacity={0.9}>
+          <App />
+        </PhotoProvider>
+      </MotionConfig>
+    </React.StrictMode>,
+  );
+
+  void initAnalytics();
+}

--- a/frontend/src/ui/ProjectPreview.tsx
+++ b/frontend/src/ui/ProjectPreview.tsx
@@ -71,6 +71,7 @@ import {
   runtimeEnvVars,
 } from "../create/deploymentEnv";
 import type { DeployStage } from "../adk/client";
+import { trackEvent } from "../analytics/webpro";
 import { buildZip } from "./zip";
 import { ProjectCodeBrowser } from "./CodeBrowserDialog";
 import { DeployIcon } from "./DeployIcon";
@@ -830,6 +831,17 @@ export function ProjectPreview({
     const taskId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     let taskRuntimeName = "生成中…";
     const taskStartedAt = Date.now();
+    let lastPhase = "prepare";
+    const networkMode = network?.mode ?? "public";
+    trackEvent(
+      "deploy_start",
+      {
+        region: deployRegion,
+        network_mode: networkMode,
+        feishu_enabled: feishuEnabled,
+      },
+      { agent_count: agentCount },
+    );
     onDeploymentTaskChange?.({
       id: taskId,
       runtimeName: taskRuntimeName,
@@ -842,6 +854,7 @@ export function ProjectPreview({
       const result = await onDeploy(
         project,
         (s) => {
+          lastPhase = s.phase;
           if (s.runtimeName) taskRuntimeName = s.runtimeName;
           if (mountedRef.current) {
             setStageMap((prev) => ({ ...prev, [s.phase]: s }));
@@ -885,6 +898,15 @@ export function ProjectPreview({
         status: "success",
         label: "部署完成",
       });
+      trackEvent(
+        "deploy_result",
+        {
+          region: result.region || deployRegion,
+          network_mode: networkMode,
+          result: "success",
+        },
+        { duration_ms: Date.now() - taskStartedAt, agent_count: agentCount },
+      );
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       if (err instanceof DOMException && err.name === "AbortError") {
@@ -901,6 +923,16 @@ export function ProjectPreview({
           label: "已取消",
           message: "部署已取消，相关 Runtime 资源已请求销毁。",
         });
+        trackEvent(
+          "deploy_result",
+          {
+            region: deployRegion,
+            network_mode: networkMode,
+            result: "cancelled",
+            failed_phase: lastPhase,
+          },
+          { duration_ms: Date.now() - taskStartedAt, agent_count: agentCount },
+        );
         return;
       }
       if (mountedRef.current) setDeployError(message);
@@ -914,6 +946,16 @@ export function ProjectPreview({
         message,
         retry: requestDeploymentConfirmation,
       });
+      trackEvent(
+        "deploy_result",
+        {
+          region: deployRegion,
+          network_mode: networkMode,
+          result: "error",
+          failed_phase: lastPhase,
+        },
+        { duration_ms: Date.now() - taskStartedAt, agent_count: agentCount },
+      );
     } finally {
       if (mountedRef.current) setDeploying(false);
     }

--- a/frontend/src/ui/Sidebar.tsx
+++ b/frontend/src/ui/Sidebar.tsx
@@ -16,6 +16,7 @@ import type {
 } from "../adk/client";
 import { sessionTitle } from "../blocks";
 import { displayName, profilePictureUrl } from "../adk/identity";
+import { trackEvent } from "../analytics/webpro";
 import { SkillCenterButton } from "./SkillCenter";
 import { SearchButton } from "./Search";
 import { AgentSelector, type SelectedRuntime } from "./AgentSelector";
@@ -148,7 +149,10 @@ function SidebarUser({
     <div className="sidebar-user">
       <button
         className="sidebar-user-btn"
-        onClick={() => setOpen((o) => !o)}
+        onClick={() => {
+          trackEvent("sidebar_feature_used", { feature: "account_menu" });
+          setOpen((o) => !o);
+        }}
         title={email ? `${name}\n${email}` : name}
       >
         <span
@@ -211,6 +215,7 @@ function SidebarUser({
             <button
               className="account-logout"
               onClick={() => {
+                trackEvent("sidebar_feature_used", { feature: "logout" });
                 setOpen(false);
                 onLogout();
               }}
@@ -261,12 +266,16 @@ export function Sidebar({
   );
   const [collapsed, setCollapsed] = useState(autoCollapsedRef.current);
   const toggleSelector = () => {
+    trackEvent("sidebar_feature_used", { feature: "agent_selector" });
     setSelectorOpen((o) => !o);
   };
   const sorted = [...sessions].sort(
     (a, b) => (b.lastUpdateTime ?? 0) - (a.lastUpdateTime ?? 0),
   );
   const toggleCollapsed = () => {
+    trackEvent("sidebar_feature_used", {
+      feature: collapsed ? "expand" : "collapse",
+    });
     autoCollapsedRef.current = false;
     setCollapsed((value) => !value);
     setSelectorOpen(false);
@@ -362,13 +371,22 @@ export function Sidebar({
             currentId={currentAgentId}
             currentRuntime={currentRuntime}
             runtimeScope={access.capabilities.runtimeScope}
-            onSelect={onSelectAgent}
+            onSelect={(id) => {
+              trackEvent("sidebar_feature_used", { feature: "agent_select" });
+              onSelectAgent(id);
+            }}
           />
         )}
         {show("newChat") && (
           <button
             className="new-chat"
-            onClick={onNewChat}
+            onClick={() => {
+              trackEvent("sidebar_feature_used", {
+                feature: "new_chat",
+                entry: "navigation",
+              });
+              onNewChat();
+            }}
             aria-label="新会话"
             title="新会话"
           >
@@ -376,12 +394,21 @@ export function Sidebar({
             <span className="sidebar-nav-label">新会话</span>
           </button>
         )}
-        {show("search") && <SearchButton onClick={onSearch} />}
-        {show("skillCenter") && <SkillCenterButton onClick={onSkillCenter} />}
+        {show("search") && <SearchButton onClick={() => {
+          trackEvent("sidebar_feature_used", { feature: "search" });
+          onSearch();
+        }} />}
+        {show("skillCenter") && <SkillCenterButton onClick={() => {
+          trackEvent("sidebar_feature_used", { feature: "skill_center" });
+          onSkillCenter();
+        }} />}
         {access.capabilities.createAgents && show("addAgent") && (
           <button
             className="new-chat"
-            onClick={onQuickCreate}
+            onClick={() => {
+              trackEvent("sidebar_feature_used", { feature: "add_agent" });
+              onQuickCreate();
+            }}
             aria-label="添加 Agent"
             title="添加 Agent"
           >
@@ -392,7 +419,10 @@ export function Sidebar({
         {access.capabilities.manageAgents && show("manageAgents") && (
           <button
             className="new-chat"
-            onClick={onManageAgents}
+            onClick={() => {
+              trackEvent("sidebar_feature_used", { feature: "manage_agents" });
+              onManageAgents();
+            }}
             aria-label="管理 Agent"
             title="管理 Agent"
           >
@@ -410,7 +440,13 @@ export function Sidebar({
             <button
               type="button"
               className="history-new-chat"
-              onClick={onNewChat}
+              onClick={() => {
+                trackEvent("sidebar_feature_used", {
+                  feature: "new_chat",
+                  entry: "history",
+                });
+                onNewChat();
+              }}
               aria-label="新建会话"
               title="新建会话"
             >
@@ -431,7 +467,10 @@ export function Sidebar({
               >
                 <button
                   className="history-item-btn"
-                  onClick={() => onPickSession(s.id)}
+                  onClick={() => {
+                    trackEvent("sidebar_feature_used", { feature: "history_open" });
+                    onPickSession(s.id);
+                  }}
                   title={title}
                 >
                   {streamingSids?.has(s.id) && (
@@ -453,6 +492,9 @@ export function Sidebar({
                     <button
                       className="menu-item menu-item--danger"
                       onClick={() => {
+                        trackEvent("sidebar_feature_used", {
+                          feature: "history_delete",
+                        });
                         setMenuFor(null);
                         onDeleteSession(s.id);
                       }}

--- a/frontend/src/ui/builtin-tools/builtin-tools.css
+++ b/frontend/src/ui/builtin-tools/builtin-tools.css
@@ -34,6 +34,10 @@
   --builtin-tool-accent: 225 48% 45%;
 }
 
+.builtin-tool-head[data-tool-tone="sandbox"] {
+  --builtin-tool-accent: 32 67% 42%;
+}
+
 .builtin-tool-head:hover {
   color: hsl(var(--foreground));
 }

--- a/frontend/src/ui/builtin-tools/icons.tsx
+++ b/frontend/src/ui/builtin-tools/icons.tsx
@@ -98,6 +98,27 @@ export function LoadKnowledgebaseIcon(props: ToolIconProps) {
   );
 }
 
+/** A hand-drawn sandbox with a small code prompt inside. */
+export function RunCodeIcon(props: ToolIconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="m4.2 8.4 1.15 10.2h13.3L19.8 8.4" />
+      <path d="M4.2 8.4h15.6L17.9 5H6.1L4.2 8.4Z" />
+      <path d="M7.2 12.2c1.1-1 2.25 1.25 3.4.25 1.05-.9 2.15 1.3 3.3.25" />
+      <path d="m8.2 15.1 1.45 1.35 1.45-1.35M13.55 16.45h2.35" />
+    </svg>
+  );
+}
+
 export function ToolDisclosureIcon(props: ToolIconProps) {
   return (
     <svg

--- a/frontend/src/ui/builtin-tools/registry.ts
+++ b/frontend/src/ui/builtin-tools/registry.ts
@@ -3,11 +3,18 @@ import {
   ImageGenerateIcon,
   LoadKnowledgebaseIcon,
   LoadMemoryIcon,
+  RunCodeIcon,
   VideoGenerateIcon,
   WebSearchIcon,
 } from "./icons";
 
-export type BuiltinToolTone = "search" | "image" | "video" | "memory" | "knowledge";
+export type BuiltinToolTone =
+  | "search"
+  | "image"
+  | "video"
+  | "memory"
+  | "knowledge"
+  | "sandbox";
 
 export interface BuiltinToolDefinition {
   name: string;
@@ -24,6 +31,13 @@ const BUILTIN_TOOLS: Readonly<Record<string, BuiltinToolDefinition>> = {
     doneLabel: "已完成网络搜索",
     tone: "search",
     icon: WebSearchIcon,
+  },
+  run_code: {
+    name: "run_code",
+    runningLabel: "正在 AgentKit 沙箱中执行代码",
+    doneLabel: "已在 AgentKit 沙箱中完成代码执行",
+    tone: "sandbox",
+    icon: RunCodeIcon,
   },
   image_generate: {
     name: "image_generate",

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+declare const __APMPLUS_AID__: string;
+declare const __APMPLUS_TOKEN__: string;
+declare const __APMPLUS_ENABLED__: string;
+declare const __APMPLUS_ENV__: string;

--- a/frontend/tests/analytics.test.mjs
+++ b/frontend/tests/analytics.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const analyticsSource = readFileSync(
+  new URL("../src/analytics/webpro.ts", import.meta.url),
+  "utf8",
+);
+const mainSource = readFileSync(
+  new URL("../src/main.tsx", import.meta.url),
+  "utf8",
+);
+const viteSource = readFileSync(
+  new URL("../vite.config.ts", import.meta.url),
+  "utf8",
+);
+
+test("analytics is optional and respects browser Do Not Track", () => {
+  assert.match(analyticsSource, /__APMPLUS_ENABLED__\.toLowerCase\(\) !== "false"/);
+  assert.match(analyticsSource, /navigator\.doNotTrack !== "1"/);
+  assert.match(viteSource, /env\.APM_APP_ID/);
+  assert.match(viteSource, /env\.APM_APP_TOKEN/);
+});
+
+test("OAuth callback pages never initialize analytics", () => {
+  assert.match(mainSource, /const handledOAuthCallback =/);
+  assert.match(
+    mainSource,
+    /if \(!handledOAuthCallback\) \{[\s\S]*?void initAnalytics\(\);[\s\S]*?\}/,
+  );
+});
+
+test("custom events always include a numeric metric for WebPro charts", () => {
+  assert.match(
+    analyticsSource,
+    /Object\.keys\(normalizedMetrics\)\.length > 0 \? normalizedMetrics : \{ count: 1 \}/,
+  );
+  assert.match(analyticsSource, /metrics: eventMetrics/);
+});

--- a/frontend/tests/builtinToolStatus.test.mjs
+++ b/frontend/tests/builtinToolStatus.test.mjs
@@ -40,6 +40,7 @@ test("maps supported built-in tools to dedicated Chinese running and done labels
     ["web_search", "正在进行网络搜索", "已完成网络搜索"],
     ["image_generate", "正在生成图片", "已完成图片生成"],
     ["video_generate", "正在生成视频", "已完成视频生成"],
+    ["run_code", "正在 AgentKit 沙箱中执行代码", "已在 AgentKit 沙箱中完成代码执行"],
     ["load_memory", "正在检索长期记忆", "已完成记忆检索"],
     ["load_knowledgebase", "正在检索知识库", "已完成知识库检索"],
   ];
@@ -123,6 +124,7 @@ test("uses repository-owned current-color SVG icons for every special tool", () 
     "VideoGenerateIcon",
     "LoadMemoryIcon",
     "LoadKnowledgebaseIcon",
+    "RunCodeIcon",
   ]) {
     assert.match(iconsSource, new RegExp(`export function ${icon}`));
   }

--- a/frontend/tests/deploymentConfigUi.test.mjs
+++ b/frontend/tests/deploymentConfigUi.test.mjs
@@ -18,6 +18,27 @@ const agentTypeMetaSource = readFileSync(
   new URL("../src/create/agentTypeMeta.tsx", import.meta.url),
   "utf8",
 );
+const catalogSource = readFileSync(
+  new URL("../src/create/veadkCatalog.ts", import.meta.url),
+  "utf8",
+);
+
+test("offers code execution with its sandbox configuration", () => {
+  assert.match(
+    catalogSource,
+    /id: "run_code"[\s\S]*?label: "代码执行"[\s\S]*?desc: "在沙箱中执行代码"/,
+  );
+  assert.match(
+    catalogSource,
+    /importLine: "from veadk\.tools\.builtin_tools\.run_code import run_code"/,
+  );
+  assert.match(catalogSource, /key: "AGENTKIT_TOOL_ID",\s*required: true/);
+  assert.doesNotMatch(catalogSource, /AGENTKIT_TOOL_ID_SCRIPT/);
+  assert.match(
+    customCreateSource,
+    /builtinTools\.includes\("run_code"\)[\s\S]*?<RuntimeEnvFields/,
+  );
+});
 
 test("shares the create-page agent type icons with the deployment topology", () => {
   assert.match(customCreateSource, /from "\.\/agentTypeMeta"/);

--- a/frontend/tests/deploymentConfigUi.test.mjs
+++ b/frontend/tests/deploymentConfigUi.test.mjs
@@ -32,7 +32,10 @@ test("offers code execution with its sandbox configuration", () => {
     catalogSource,
     /importLine: "from veadk\.tools\.builtin_tools\.run_code import run_code"/,
   );
-  assert.match(catalogSource, /key: "AGENTKIT_TOOL_ID",\s*required: true/);
+  assert.match(
+    catalogSource,
+    /key: "AGENTKIT_TOOL_ID",\s*required: true,\s*placeholder: "t-xxxx"/,
+  );
   assert.match(
     catalogSource,
     /key: "AGENTKIT_TOOL_REGION",\s*required: false,\s*placeholder: "cn-beijing"/,

--- a/frontend/tests/deploymentConfigUi.test.mjs
+++ b/frontend/tests/deploymentConfigUi.test.mjs
@@ -45,6 +45,14 @@ test("offers code execution with its sandbox configuration", () => {
     customCreateSource,
     /builtinTools\.includes\("run_code"\)[\s\S]*?<RuntimeEnvFields/,
   );
+  assert.match(
+    customCreateSource,
+    /createGeneratedAgentTestRun\(debugRuntimeDraft\(draft\)\)/,
+  );
+  assert.match(
+    customCreateSource,
+    /if \(isImeCompositionEvent\(e\.nativeEvent\)\) return;[\s\S]*?e\.key === "Enter"/,
+  );
 });
 
 test("shares the create-page agent type icons with the deployment topology", () => {

--- a/frontend/tests/deploymentConfigUi.test.mjs
+++ b/frontend/tests/deploymentConfigUi.test.mjs
@@ -33,6 +33,10 @@ test("offers code execution with its sandbox configuration", () => {
     /importLine: "from veadk\.tools\.builtin_tools\.run_code import run_code"/,
   );
   assert.match(catalogSource, /key: "AGENTKIT_TOOL_ID",\s*required: true/);
+  assert.match(
+    catalogSource,
+    /key: "AGENTKIT_TOOL_REGION",\s*required: false,\s*placeholder: "cn-beijing"/,
+  );
   assert.doesNotMatch(catalogSource, /AGENTKIT_TOOL_ID_SCRIPT/);
   assert.match(
     customCreateSource,

--- a/frontend/tests/deploymentEnv.test.mjs
+++ b/frontend/tests/deploymentEnv.test.mjs
@@ -29,6 +29,9 @@ const {
   STM_BACKENDS,
   TRACING_EXPORTERS,
 } = await loadTypeScriptModule("../src/create/veadkCatalog.ts");
+const { localPickerMatches } = await loadTypeScriptModule(
+  "../src/create/localPickerSearch.ts",
+);
 const customCreateSource = readFileSync(
   new URL("../src/create/CustomCreate.tsx", import.meta.url),
   "utf8",
@@ -60,6 +63,16 @@ test("defaults knowledgebase creation to VikingDB collections", () => {
   assert.notEqual(KB_BACKENDS.findIndex((item) => item.id === "viking"), -1);
   assert.match(customCreateSource, /<VikingKnowledgebaseSelect/);
   assert.match(vikingKnowledgebasesSource, /\/web\/viking-knowledgebases/);
+});
+
+test("filters A2A spaces and Viking knowledgebases locally by name or id", () => {
+  assert.equal(localPickerMatches("客服", ["客服中心", "space-123"]), true);
+  assert.equal(localPickerMatches("SPACE-123", ["客服中心", "space-123"]), true);
+  assert.equal(localPickerMatches("missing", ["客服中心", "space-123"]), false);
+  assert.match(customCreateSource, /filteredSpaces = useMemo/);
+  assert.match(customCreateSource, /filteredItems = useMemo/);
+  assert.match(customCreateSource, /搜索 AgentKit 智能体中心/);
+  assert.match(customCreateSource, /搜索 VikingDB 知识库/);
 });
 
 test("maps active feature settings to VeADK runtime env rows", () => {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 
 // In dev, proxy the ADK API server routes to the backend started with
@@ -9,31 +9,42 @@ const API_TARGET = process.env.VEADK_API_TARGET ?? "http://127.0.0.1:8000";
 // CORS headers, so the browser cannot call it cross-origin directly.
 const SKILLHUB_TARGET = "https://skills.volces.com";
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 5173,
-    proxy: {
-      "/list-apps": API_TARGET,
-      "/apps": API_TARGET,
-      "/run_sse": API_TARGET,
-      "/run": API_TARGET,
-      "/debug": API_TARGET,
-      "/dev": API_TARGET,
-      "/oauth2": API_TARGET,
-      "/web": API_TARGET,
-      "/skillhub": {
-        target: SKILLHUB_TARGET,
-        changeOrigin: true,
-        secure: true,
-        rewrite: (p) => p.replace(/^\/skillhub/, ""),
+export default defineConfig(({ mode }) => {
+  // Only expose the WebPro browser credentials from the repository-level .env.
+  // Vite's usual VITE_* passthrough is intentionally not enabled for other keys.
+  const env = loadEnv(mode, "..", "");
+  return {
+    plugins: [react()],
+    define: {
+      __APMPLUS_AID__: JSON.stringify(env.APM_APP_ID ?? ""),
+      __APMPLUS_TOKEN__: JSON.stringify(env.APM_APP_TOKEN ?? ""),
+      __APMPLUS_ENABLED__: JSON.stringify(env.APM_ENABLED ?? "true"),
+      __APMPLUS_ENV__: JSON.stringify(env.APM_ENV ?? mode),
+    },
+    server: {
+      port: 5173,
+      proxy: {
+        "/list-apps": API_TARGET,
+        "/apps": API_TARGET,
+        "/run_sse": API_TARGET,
+        "/run": API_TARGET,
+        "/debug": API_TARGET,
+        "/dev": API_TARGET,
+        "/oauth2": API_TARGET,
+        "/web": API_TARGET,
+        "/skillhub": {
+          target: SKILLHUB_TARGET,
+          changeOrigin: true,
+          secure: true,
+          rewrite: (p) => p.replace(/^\/skillhub/, ""),
+        },
       },
     },
-  },
-  build: {
-    // Build straight into the Python package so `veadk frontend` ships the UI
-    // with the wheel and works for pip-installed users.
-    outDir: "../veadk/webui",
-    emptyOutDir: true,
-  },
+    build: {
+      // Build straight into the Python package so `veadk frontend` ships the UI
+      // with the wheel and works for pip-installed users.
+      outDir: "../veadk/webui",
+      emptyOutDir: true,
+    },
+  };
 });

--- a/tests/cli/test_generated_agent_backend_codegen_extended.py
+++ b/tests/cli/test_generated_agent_backend_codegen_extended.py
@@ -630,6 +630,14 @@ def test_generated_project_and_debug_run_api_lifecycle(
         "name": "demo-agent",
         "description": "Demo agent",
         "instruction": "Always answer with hello.",
+        "builtinTools": ["run_code"],
+        "deployment": {
+            "envValues": {
+                "AGENTKIT_TOOL_ID": "t-debug",
+                "AGENTKIT_TOOL_REGION": "cn-shanghai",
+                "DATABASE_MYSQL_PASSWORD": "not-selected",
+            }
+        },
     }
     with TestClient(captured["app"]) as client:
         project_response = client.post(
@@ -657,6 +665,9 @@ def test_generated_project_and_debug_run_api_lifecycle(
         process = _FakeProcess.created[-1]
         assert process.env["VOLCENGINE_ACCESS_KEY"] == "test-ak"
         assert process.env["VOLCENGINE_SECRET_KEY"] == "test-sk"
+        assert process.env["AGENTKIT_TOOL_ID"] == "t-debug"
+        assert process.env["AGENTKIT_TOOL_REGION"] == "cn-shanghai"
+        assert "DATABASE_MYSQL_PASSWORD" not in process.env
         generated_files = {
             str(path.relative_to(process.cwd)): path.read_text(encoding="utf-8")
             for path in Path(process.cwd).rglob("*")

--- a/tests/cli/test_generated_agent_component_matrix.py
+++ b/tests/cli/test_generated_agent_component_matrix.py
@@ -128,6 +128,25 @@ def test_managed_components_keep_only_component_specific_env() -> None:
     assert "OBSERVABILITY_OPENTELEMETRY_APMPLUS_API_KEY" not in env_keys
 
 
+def test_run_code_generates_tool_import_and_sandbox_env() -> None:
+    project = generate_project_from_draft(
+        AgentDraft(
+            name="code-agent",
+            instruction="Execute code when it helps answer the request.",
+            builtinTools=["run_code"],
+        )
+    )
+    files = _files(project)
+    agent_py = files["agents/code_agent/agent.py"]
+    env_example = files[".env.example"]
+
+    assert "from veadk.tools.builtin_tools.run_code import run_code" in agent_py
+    assert "tools=[run_code]" in agent_py
+    assert "AGENTKIT_TOOL_ID=" in env_example
+    assert "AGENTKIT_TOOL_ID_SCRIPT=" not in env_example
+    _assert_python_files_compile(project)
+
+
 @pytest.mark.parametrize("backend", STM_BACKENDS, ids=lambda item: item.id)
 def test_every_short_term_memory_backend_generates_code_and_env(
     backend: BackendOption,

--- a/tests/cli/test_generated_agent_component_matrix.py
+++ b/tests/cli/test_generated_agent_component_matrix.py
@@ -33,8 +33,10 @@ from veadk.cli.generated_agent_catalog import (
 from veadk.cli.generated_agent_codegen import (
     A2ARegistryConfig,
     AgentDraft,
+    DeploymentConfig,
     GeneratedProject,
     MemoryConfig,
+    debug_runtime_env_from_draft,
     generate_project_from_draft,
 )
 
@@ -85,6 +87,101 @@ def test_component_catalog_does_not_request_auto_resolved_credentials() -> None:
 
     assert component_env_keys.isdisjoint(auto_resolved_credentials)
     assert "MODEL_AGENT_API_KEY" not in _catalog_env_keys(MODEL_ENV)
+
+
+@pytest.mark.parametrize(
+    ("draft_updates", "env"),
+    [({"builtinTools": [option.id]}, option.env) for option in BUILTIN_TOOLS]
+    + [
+        (
+            {
+                "memory": MemoryConfig(shortTerm=True),
+                "shortTermBackend": option.id,
+            },
+            option.env,
+        )
+        for option in STM_BACKENDS
+    ]
+    + [
+        (
+            {
+                "memory": MemoryConfig(longTerm=True),
+                "longTermBackend": option.id,
+            },
+            option.env,
+        )
+        for option in LTM_BACKENDS
+    ]
+    + [
+        (
+            {"knowledgebase": True, "knowledgebaseBackend": option.id},
+            option.env,
+        )
+        for option in KB_BACKENDS
+    ],
+)
+def test_debug_runtime_forwards_active_component_env(
+    draft_updates: dict[str, object],
+    env: tuple[EnvVar, ...],
+) -> None:
+    env_values = {item.key: f"configured-{item.key.lower()}" for item in env}
+    env_values["UNSELECTED_COMPONENT_ENV"] = "blocked"
+    draft = AgentDraft.model_validate(
+        {
+            "name": "debug-env",
+            "deployment": DeploymentConfig(envValues=env_values),
+            **draft_updates,
+        }
+    )
+
+    result = debug_runtime_env_from_draft(draft)
+
+    assert result == {
+        key: value
+        for key, value in env_values.items()
+        if key != "UNSELECTED_COMPONENT_ENV"
+    }
+
+
+@pytest.mark.parametrize("exporter", TRACING_EXPORTERS, ids=lambda item: item.id)
+def test_debug_runtime_forwards_active_tracing_env_and_enable_flag(
+    exporter: ExporterOption,
+) -> None:
+    env_values = {item.key: f"configured-{item.key.lower()}" for item in exporter.env}
+    draft = AgentDraft(
+        name="debug-tracing-env",
+        tracing=True,
+        tracingExporters=[exporter.id],
+        deployment=DeploymentConfig(envValues=env_values),
+    )
+
+    assert debug_runtime_env_from_draft(draft) == {
+        **env_values,
+        exporter.enable_flag: "true",
+    }
+
+
+def test_debug_runtime_materializes_nested_a2a_registry_defaults() -> None:
+    draft = AgentDraft(
+        name="debug-a2a-env",
+        subAgents=[
+            AgentDraft(
+                name="remote-agent",
+                agentType="a2a",
+                a2aRegistry=A2ARegistryConfig(
+                    enabled=True,
+                    registrySpaceId="space-debug",
+                ),
+            )
+        ],
+    )
+
+    assert debug_runtime_env_from_draft(draft) == {
+        "REGISTRY_SPACE_ID": "space-debug",
+        "REGISTRY_TOP_K": "3",
+        "REGISTRY_REGION": "cn-beijing",
+        "REGISTRY_ENDPOINT": "https://open.volcengineapi.com/",
+    }
 
 
 def test_managed_components_keep_only_component_specific_env() -> None:

--- a/tests/cli/test_generated_agent_component_matrix.py
+++ b/tests/cli/test_generated_agent_component_matrix.py
@@ -143,6 +143,7 @@ def test_run_code_generates_tool_import_and_sandbox_env() -> None:
     assert "from veadk.tools.builtin_tools.run_code import run_code" in agent_py
     assert "tools=[run_code]" in agent_py
     assert "AGENTKIT_TOOL_ID=" in env_example
+    assert "AGENTKIT_TOOL_REGION=cn-beijing" in env_example
     assert "AGENTKIT_TOOL_ID_SCRIPT=" not in env_example
     _assert_python_files_compile(project)
 

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -1322,6 +1322,7 @@ def _run_frontend_server(
         GeneratedAgentProjectRequest,
         GeneratedAgentTestRunRequest,
         GeneratedProject,
+        debug_runtime_env_from_draft,
         generate_project_from_draft,
         normalize_and_validate_draft,
     )
@@ -1478,28 +1479,6 @@ def _run_frontend_server(
         env["PYTHONPATH"] = (
             f"{repo_root}{os.pathsep}{pythonpath}" if pythonpath else repo_root
         )
-        return env
-
-    def _a2a_registry_env_from_draft(draft: AgentDraft) -> dict[str, str]:
-        env: dict[str, str] = {}
-
-        def visit(node: AgentDraft) -> None:
-            registry = node.a2aRegistry
-            if registry.enabled:
-                env.update(
-                    {
-                        "REGISTRY_SPACE_ID": registry.registrySpaceId.strip(),
-                        "REGISTRY_TOP_K": registry.registryTopK.strip() or "3",
-                        "REGISTRY_REGION": registry.registryRegion.strip()
-                        or "cn-beijing",
-                        "REGISTRY_ENDPOINT": registry.registryEndpoint.strip()
-                        or "https://open.volcengineapi.com/",
-                    }
-                )
-            for sub_agent in node.subAgents:
-                visit(sub_agent)
-
-        visit(draft)
         return env
 
     def _read_runner_log_tail(path: PathlibPath, max_chars: int = 6000) -> str:
@@ -1817,7 +1796,7 @@ def _run_frontend_server(
                 str(port),
             ]
             runner_env = _safe_runner_env()
-            runner_env.update(_a2a_registry_env_from_draft(draft))
+            runner_env.update(debug_runtime_env_from_draft(draft))
             with stdout_path.open("w", encoding="utf-8") as stdout_file:
                 with stderr_path.open("w", encoding="utf-8") as stderr_file:
                     proc = subprocess.Popen(

--- a/veadk/cli/generated_agent_catalog.py
+++ b/veadk/cli/generated_agent_catalog.py
@@ -159,6 +159,12 @@ BUILTIN_TOOLS = (
         ),
     ),
     ToolOption(
+        id="run_code",
+        import_line="from veadk.tools.builtin_tools.run_code import run_code",
+        tool_names=("run_code",),
+        env=(EnvVar("AGENTKIT_TOOL_ID", True, "", "代码执行沙箱 ID"),),
+    ),
+    ToolOption(
         id="vesearch",
         import_line="from veadk.tools.builtin_tools.vesearch import vesearch",
         tool_names=("vesearch",),

--- a/veadk/cli/generated_agent_catalog.py
+++ b/veadk/cli/generated_agent_catalog.py
@@ -162,7 +162,10 @@ BUILTIN_TOOLS = (
         id="run_code",
         import_line="from veadk.tools.builtin_tools.run_code import run_code",
         tool_names=("run_code",),
-        env=(EnvVar("AGENTKIT_TOOL_ID", True, "", "代码执行沙箱 ID"),),
+        env=(
+            EnvVar("AGENTKIT_TOOL_ID", True, "", "代码执行沙箱 ID"),
+            EnvVar("AGENTKIT_TOOL_REGION", False, "cn-beijing", "AgentKit Tools 地域"),
+        ),
     ),
     ToolOption(
         id="vesearch",

--- a/veadk/cli/generated_agent_codegen.py
+++ b/veadk/cli/generated_agent_codegen.py
@@ -1120,6 +1120,61 @@ def _a2a_registry_env_values(draft: AgentDraft) -> dict[str, str]:
     return {}
 
 
+def debug_runtime_env_from_draft(draft: AgentDraft) -> dict[str, str]:
+    """Return runtime env values allowed by active components in a debug draft."""
+    allowed_keys: set[str] = set()
+    fixed_values: dict[str, str] = {}
+
+    def allow_env(items: tuple[EnvVar, ...]) -> None:
+        allowed_keys.update(item.key for item in items)
+
+    def visit(node: AgentDraft) -> None:
+        for tool_id in node.builtinTools:
+            tool = TOOL_BY_ID.get(tool_id)
+            if tool:
+                allow_env(tool.env)
+        if node.a2aRegistry.enabled:
+            registry = node.a2aRegistry
+            fixed_values.update(
+                {
+                    "REGISTRY_SPACE_ID": registry.registrySpaceId.strip(),
+                    "REGISTRY_TOP_K": registry.registryTopK.strip() or "3",
+                    "REGISTRY_REGION": registry.registryRegion.strip() or "cn-beijing",
+                    "REGISTRY_ENDPOINT": registry.registryEndpoint.strip()
+                    or "https://open.volcengineapi.com/",
+                }
+            )
+        if node.memory.shortTerm:
+            backend = STM_BY_ID.get(node.shortTermBackend)
+            if backend:
+                allow_env(backend.env)
+        if node.memory.longTerm:
+            backend = LTM_BY_ID.get(node.longTermBackend)
+            if backend:
+                allow_env(backend.env)
+        if node.knowledgebase:
+            backend = KB_BY_ID.get(node.knowledgebaseBackend)
+            if backend:
+                allow_env(backend.env)
+        if node.tracing:
+            for exporter_id in node.tracingExporters:
+                exporter = EXPORTER_BY_ID.get(exporter_id)
+                if exporter:
+                    allow_env(exporter.env)
+                    fixed_values[exporter.enable_flag] = "true"
+        for sub_agent in node.subAgents:
+            visit(sub_agent)
+
+    visit(draft)
+    env = {
+        key: value
+        for key, value in draft.deployment.envValues.items()
+        if key in allowed_keys and value.strip()
+    }
+    env.update(fixed_values)
+    return env
+
+
 def _materialize_a2a_registry_env(env: list[EnvVar], draft: AgentDraft) -> list[EnvVar]:
     values = _a2a_registry_env_values(draft)
     if not values:


### PR DESCRIPTION
## Summary
- add optional APMPlus WebPro analytics with Do Not Track and opt-out support
- track coarse-grained Studio, sidebar, chat, media upload, tracing, and deployment events without resource identifiers or raw content
- add the built-in `run_code` option to custom Agent creation and generated projects
- expose the required `AGENTKIT_TOOL_ID` and optional `AGENTKIT_TOOL_REGION` directly below the selected code execution tool; region defaults to `cn-beijing`
- forward active component runtime settings into local debug runs through a server-side allowlist, while rejecting stale or unselected component values
- prevent Enter from sending debug messages while an IME composition is active
- render code execution calls with dedicated sandbox status text and iconography
- add local filtering by name or ID to A2A Space and VikingDB knowledgebase pickers
- document configuration and add frontend and generator coverage

## Validation
- `npm test`
- `npm run build`
- generated-agent component and debug lifecycle `pytest`
- Ruff and Pyright checks
- `npm run types:check` in `docs/`

No environment files are included.