### PR TITLE
fix(studio): harden release publishing pipeline

### DIFF
--- a/.github/workflows/publish-studio-release.yaml
+++ b/.github/workflows/publish-studio-release.yaml
@@ -35,6 +35,7 @@ jobs:
       github.repository == 'volcengine/veadk-python' &&
       github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     environment: studio-release
     env:
       RELEASE_SERVER_URL: ${{ secrets.STUDIO_RELEASE_SERVER_URL }}
@@ -60,10 +61,16 @@ jobs:
             echo "STUDIO_RELEASE_SERVER_URL is not configured." >&2
             exit 1
           }
-          test -n "$RELEASE_SERVER_API_KEY" || {
-            echo "STUDIO_RELEASE_SERVER_API_KEY is not configured." >&2
+          release_server_url="${RELEASE_SERVER_URL%/}"
+          if [[ ! "$release_server_url" =~ ^https://[^[:space:]/]+(/[^[:space:]]*)?$ ]]; then
+            echo "STUDIO_RELEASE_SERVER_URL must be an absolute HTTPS URL." >&2
             exit 1
-          }
+          fi
+          if (( ${#RELEASE_SERVER_API_KEY} < 32 )); then
+            echo "STUDIO_RELEASE_SERVER_API_KEY must contain at least 32 characters." >&2
+            exit 1
+          fi
+          echo "RELEASE_SERVER_URL=$release_server_url" >> "$GITHUB_ENV"
 
       - name: Resolve release changelog
         id: changelog
@@ -103,19 +110,25 @@ jobs:
           tar -C "$source_parent" -czf "$archive" \
             "veadk-python-${GITHUB_SHA}"
           upload_response="$(curl --fail-with-body --silent --show-error \
+            --proto '=https' \
+            --connect-timeout 30 \
+            --max-time 60 \
             --request POST \
             --header "Content-Type: application/json" \
             --header "X-API-Key: $RELEASE_SERVER_API_KEY" \
             --data "$(jq -n --arg requestId "$job_id" \
               '{requestId:$requestId}')" \
-            "$RELEASE_SERVER_URL/source-upload")"
+            --url "$RELEASE_SERVER_URL/source-upload")"
           source_key="$(jq -er '.sourceKey' <<<"$upload_response")"
           upload_url="$(jq -er '.uploadUrl' <<<"$upload_response")"
           curl --fail-with-body --silent --show-error \
+            --proto '=https' \
+            --connect-timeout 30 \
+            --max-time 600 \
             --request PUT \
             --header "Content-Type: application/gzip" \
             --upload-file "$archive" \
-            "$upload_url"
+            --url "$upload_url"
           echo "job_id=$job_id" >> "$GITHUB_OUTPUT"
           echo "source_key=$source_key" >> "$GITHUB_OUTPUT"
 
@@ -135,11 +148,14 @@ jobs:
             --arg sourceKey "$SOURCE_KEY" \
             '{repository:$repository,gitSha:$gitSha,requestId:$requestId,changelog:[$changelog],sourceKey:$sourceKey}')"
           curl --fail-with-body --silent --show-error \
+            --proto '=https' \
+            --connect-timeout 30 \
+            --max-time 1800 \
             --request POST \
             --header "Content-Type: application/json" \
             --header "X-API-Key: $RELEASE_SERVER_API_KEY" \
             --data "$payload" \
-            "$RELEASE_SERVER_URL/release" >/dev/null
+            --url "$RELEASE_SERVER_URL/release" >/dev/null
           echo "job_id=$JOB_ID" >> "$GITHUB_OUTPUT"
 
       - name: Wait for Studio release
@@ -149,8 +165,11 @@ jobs:
           set -euo pipefail
           for _ in $(seq 1 180); do
             response="$(curl --fail-with-body --silent --show-error \
+              --proto '=https' \
+              --connect-timeout 30 \
+              --max-time 60 \
               --header "X-API-Key: $RELEASE_SERVER_API_KEY" \
-              "$RELEASE_SERVER_URL/status/$JOB_ID")"
+              --url "$RELEASE_SERVER_URL/status/$JOB_ID")"
             state="$(jq -r '.state' <<<"$response")"
             stage="$(jq -r '.stage' <<<"$response")"
             echo "Studio release state=$state stage=$stage"

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -206,10 +206,12 @@ the service, deploy it from the repository root:
 frontend/service/studio_release_server/deploy.sh
 ```
 
-The script updates the existing VeFaaS Function, verifies `/healthz`, rotates
+The script updates the existing VeFaaS Function, verifies `/readyz`, rotates
 the API key, and updates the two GitHub Secrets. It requires
 `VOLCENGINE_ACCESS_KEY`, `VOLCENGINE_SECRET_KEY`, and an authenticated GitHub
-CLI session.
+CLI session with permission to update Actions Secrets in the upstream repository.
+It validates that permission before changing any cloud resources and verifies the
+new revision with the rotated API key before updating the Secrets.
 
 ## Authentication
 

--- a/frontend/service/studio_release_server/app.py
+++ b/frontend/service/studio_release_server/app.py
@@ -93,6 +93,11 @@ def create_app(
     def healthz() -> dict[str, str]:
         return {"status": "ok"}
 
+    @app.get("/readyz", dependencies=[Depends(require_api_key)])
+    def readyz() -> dict[str, str]:
+        """Confirm that the active revision loaded the expected API key."""
+        return {"status": "ready"}
+
     @app.post(
         "/source-upload",
         response_model=SourceUpload,

--- a/frontend/service/studio_release_server/builder.py
+++ b/frontend/service/studio_release_server/builder.py
@@ -45,6 +45,8 @@ from frontend.service.studio_release_server.tos_store import (
 )
 
 _MAX_SOURCE_ARCHIVE_BYTES = 200 * 1024 * 1024
+_MAX_SOURCE_EXTRACTED_BYTES = 1024 * 1024 * 1024
+_MAX_SOURCE_ARCHIVE_MEMBERS = 50_000
 _SOURCE_DOWNLOAD_REPORT_BYTES = 8 * 1024 * 1024
 _SOURCE_DOWNLOAD_TIMEOUT_SECONDS = 10 * 60
 _NODE_VERSION = "22.17.0"
@@ -196,26 +198,26 @@ class StudioReleaseBuilder:
         size = 0
         reported_size = 0
         download_started = time.monotonic()
-        with urllib.request.urlopen(http_request, timeout=120) as response:
-            with archive.open("wb") as output:
-                while chunk := response.read(1024 * 1024):
-                    if (
-                        time.monotonic() - download_started
-                        > _SOURCE_DOWNLOAD_TIMEOUT_SECONDS
-                    ):
-                        raise TimeoutError(
-                            "GitHub source download exceeded 10 minutes."
-                        )
-                    size += len(chunk)
-                    if size > _MAX_SOURCE_ARCHIVE_BYTES:
-                        raise ValueError("GitHub source archive exceeds 200 MiB.")
-                    output.write(chunk)
-                    if size - reported_size >= _SOURCE_DOWNLOAD_REPORT_BYTES:
-                        on_progress(
-                            "fetching",
-                            f"已下载 GitHub 源码 {size // (1024 * 1024)} MiB",
-                        )
-                        reported_size = size
+        with (
+            urllib.request.urlopen(http_request, timeout=120) as response,
+            archive.open("wb") as output,
+        ):
+            while chunk := response.read(1024 * 1024):
+                if (
+                    time.monotonic() - download_started
+                    > _SOURCE_DOWNLOAD_TIMEOUT_SECONDS
+                ):
+                    raise TimeoutError("GitHub source download exceeded 10 minutes.")
+                size += len(chunk)
+                if size > _MAX_SOURCE_ARCHIVE_BYTES:
+                    raise ValueError("GitHub source archive exceeds 200 MiB.")
+                output.write(chunk)
+                if size - reported_size >= _SOURCE_DOWNLOAD_REPORT_BYTES:
+                    on_progress(
+                        "fetching",
+                        f"已下载 GitHub 源码 {size // (1024 * 1024)} MiB",
+                    )
+                    reported_size = size
         on_progress("extracting", "GitHub 源码下载完成，正在解压")
         return self._extract_source(archive, workspace)
 
@@ -223,7 +225,17 @@ class StudioReleaseBuilder:
         extract_root = workspace / "source"
         extract_root.mkdir()
         with tarfile.open(archive, "r:gz") as source_archive:
-            source_archive.extractall(extract_root, filter="data")
+            members = source_archive.getmembers()
+            if not members or len(members) > _MAX_SOURCE_ARCHIVE_MEMBERS:
+                raise ValueError("Source archive member count is invalid.")
+            extracted_size = 0
+            for member in members:
+                if not (member.isfile() or member.isdir()):
+                    raise ValueError("Source archive contains an unsupported entry.")
+                extracted_size += member.size
+                if extracted_size > _MAX_SOURCE_EXTRACTED_BYTES:
+                    raise ValueError("Source archive expands beyond 1 GiB.")
+            source_archive.extractall(extract_root, members=members, filter="data")
         roots = [path for path in extract_root.iterdir() if path.is_dir()]
         if len(roots) != 1 or not (roots[0] / "frontend" / "package.json").is_file():
             raise ValueError("GitHub archive is not a VeADK source checkout.")
@@ -347,7 +359,12 @@ class StudioReleaseBuilder:
             bucket=self._settings.bucket,
             key=f"{self._settings.release_prefix.strip().strip('/')}/latest.json",
         )
-        actual = json.loads(b"".join(response))
+        content = bytearray()
+        for chunk in response:
+            if len(content) + len(chunk) > 64 * 1024:
+                raise RuntimeError("Published latest.json is too large.")
+            content.extend(chunk)
+        actual = json.loads(content)
         for field in ("version", "gitSha", "sha256", "size"):
             if actual.get(field) != expected.get(field):
                 raise RuntimeError(f"Published latest.json has mismatched {field}.")

--- a/frontend/service/studio_release_server/deploy.py
+++ b/frontend/service/studio_release_server/deploy.py
@@ -105,7 +105,7 @@ def _ensure_runtime_role(access_key: str, secret_key: str) -> str:
                 }
             )
         )
-    except Exception as update_error:
+    except Exception as update_error:  # noqa: BLE001 - SDK has no common error type
         try:
             _result(
                 iam.create_policy(
@@ -116,14 +116,14 @@ def _ensure_runtime_role(access_key: str, secret_key: str) -> str:
                     }
                 )
             )
-        except Exception as create_error:
+        except Exception as create_error:  # noqa: BLE001 - preserve both SDK errors
             raise RuntimeError(
                 f"Could not create or update IAM policy: {create_error}"
             ) from update_error
 
     try:
         role_result = _result(iam.get_role({"RoleName": _ROLE_NAME}))
-    except Exception:
+    except Exception:  # noqa: BLE001 - absent roles are reported as SDK exceptions
         role_result = _result(
             iam.create_role(
                 {
@@ -289,8 +289,8 @@ def _https_endpoint(gateway_service: Any) -> str:
 def _ensure_gateway_binding(service: Any, function_id: str) -> str:
     """Expose one Function through a service on the fixed serverless gateway."""
     from volcenginesdkapig import (
-        ListGatewaysRequest,
         ListGatewayServicesRequest,
+        ListGatewaysRequest,
         ListUpstreamsRequest,
     )
     from volcenginesdkapig20221112 import (
@@ -480,21 +480,44 @@ def _deploy(source_root: Path, api_key: str, role_trn: str) -> tuple[str, str, s
         return endpoint, app_id or "", function_id
 
 
-def _wait_for_health(endpoint: str) -> None:
-    health_url = f"{endpoint}/healthz"
+def _wait_for_health(endpoint: str, api_key: str) -> None:
+    ready_request = urllib.request.Request(
+        f"{endpoint}/readyz",
+        headers={"X-API-Key": api_key},
+    )
     for _ in range(60):
         try:
-            with urllib.request.urlopen(health_url, timeout=10) as response:
+            with urllib.request.urlopen(ready_request, timeout=10) as response:
                 if response.status == 200:
                     return
         except (OSError, urllib.error.URLError):
             time.sleep(5)
-    raise RuntimeError("Release server health check did not become ready in 5 minutes.")
+    raise RuntimeError("Release server readiness check failed for 5 minutes.")
+
+
+def _validate_github_secret_access() -> None:
+    """Fail before cloud changes if GitHub Secrets cannot be updated."""
+    completed = subprocess.run(
+        [
+            "gh",
+            "api",
+            f"repos/{_REPOSITORY}/actions/secrets/public-key",
+            "--silent",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "GitHub Secrets preflight failed; no cloud resources were changed: "
+            f"{completed.stderr}"
+        )
 
 
 def _set_github_secret(name: str, value: str) -> None:
     completed = subprocess.run(
-        ["gh", "secret", "set", name, "--repo", _REPOSITORY, "--body", "-"],
+        ["gh", "secret", "set", name, "--repo", _REPOSITORY],
         input=value,
         text=True,
         capture_output=True,
@@ -524,10 +547,12 @@ def main() -> None:
         raise ValueError(
             "VOLCENGINE_ACCESS_KEY and VOLCENGINE_SECRET_KEY are required."
         )
+    if not args.skip_github_secrets:
+        _validate_github_secret_access()
     role_trn = _ensure_runtime_role(access_key, secret_key)
     api_key = secrets.token_urlsafe(48)
     endpoint, app_id, function_id = _deploy(source_root, api_key, role_trn)
-    _wait_for_health(endpoint)
+    _wait_for_health(endpoint, api_key)
     if not args.skip_github_secrets:
         _set_github_secret("STUDIO_RELEASE_SERVER_URL", endpoint)
         _set_github_secret("STUDIO_RELEASE_SERVER_API_KEY", api_key)

--- a/tests/cli/test_studio_release.py
+++ b/tests/cli/test_studio_release.py
@@ -20,6 +20,10 @@ from pathlib import Path
 
 import pytest
 
+from veadk.cli.studio_dependencies import (
+    StudioDependencyWheel,
+    stage_studio_dependency_wheels,
+)
 from veadk.cli.studio_release import (
     StudioReleaseError,
     StudioReleaseManifest,
@@ -29,10 +33,6 @@ from veadk.cli.studio_release import (
     latest_manifest_object_key,
     manifest_object_key,
     release_catalog_object_key,
-)
-from veadk.cli.studio_dependencies import (
-    StudioDependencyWheel,
-    stage_studio_dependency_wheels,
 )
 
 
@@ -164,6 +164,36 @@ def test_publish_does_not_replace_an_immutable_release(tmp_path: Path) -> None:
 
     with pytest.raises(FileExistsError):
         store.publish(bundle, manifest)
+
+
+def test_publish_does_not_move_latest_pointer_to_an_older_release(
+    tmp_path: Path,
+) -> None:
+    client = _FakeTosClient()
+    store = _store(client)
+    newer_content = b"newer"
+    newer_bundle = tmp_path / "newer.zip"
+    newer_bundle.write_bytes(newer_content)
+    newer = StudioReleaseManifest(
+        version="20260724163045",
+        git_sha="b" * 40,
+        sha256=hashlib.sha256(newer_content).hexdigest(),
+        size=len(newer_content),
+        created_at="2026-07-24T16:30:45+08:00",
+    )
+    store.publish(newer_bundle, newer)
+    put_order = list(client.put_order)
+
+    older_content = b"older"
+    older_bundle = tmp_path / "older.zip"
+    older_bundle.write_bytes(older_content)
+    older = _manifest(older_content)
+
+    with pytest.raises(StudioReleaseError, match="must be newer"):
+        store.publish(older_bundle, older)
+
+    assert client.put_order == put_order
+    assert store.latest_manifest() == newer
 
 
 def test_download_rejects_content_with_wrong_digest(tmp_path: Path) -> None:

--- a/tests/test_studio_release_server.py
+++ b/tests/test_studio_release_server.py
@@ -17,15 +17,19 @@
 from __future__ import annotations
 
 import importlib.machinery
+import io
 import shutil
+import subprocess
 import tarfile
 from collections.abc import Callable
 from concurrent.futures import Executor, Future
+from contextlib import nullcontext
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
-from fastapi.testclient import TestClient
 import pytest
+from fastapi.testclient import TestClient
 
 from frontend.service.studio_release_server import (
     BuildResult,
@@ -45,7 +49,7 @@ class _InlineExecutor(Executor):
         future: Future[None] = Future()
         try:
             function(*args, **kwargs)
-        except Exception as error:  # pragma: no cover - executor contract
+        except Exception as error:  # noqa: BLE001  # pragma: no cover
             future.set_exception(error)
         else:
             future.set_result(None)
@@ -188,6 +192,21 @@ def test_api_requires_key_and_returns_durable_status() -> None:
     assert current.json()["result"]["gitSha"] == "a" * 40
 
 
+def test_readiness_requires_the_active_revision_api_key() -> None:
+    settings = _settings()
+    app = create_app(settings=settings, service=_service())
+
+    with TestClient(app) as client:
+        unauthorized = client.get("/readyz")
+        ready = client.get(
+            "/readyz",
+            headers={"X-API-Key": settings.api_key},
+        )
+
+    assert unauthorized.status_code == 401
+    assert ready.json() == {"status": "ready"}
+
+
 def test_api_rejects_another_repository() -> None:
     settings = _settings()
     app = create_app(settings=settings, service=_service())
@@ -276,6 +295,26 @@ def test_builder_consumes_staged_source_archive(tmp_path: Path) -> None:
     assert source_store.consumed_key == request.source_key
 
 
+def test_builder_rejects_unsafe_source_archive_entry(tmp_path: Path) -> None:
+    archive = tmp_path / "source.tar.gz"
+    with tarfile.open(archive, "w:gz") as output:
+        root = tarfile.TarInfo("veadk-python")
+        root.type = tarfile.DIRTYPE
+        output.addfile(root)
+        package = tarfile.TarInfo("veadk-python/frontend/package.json")
+        package.size = 2
+        output.addfile(package, io.BytesIO(b"{}"))
+        link = tarfile.TarInfo("veadk-python/frontend/escape")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "../../outside"
+        output.addfile(link)
+
+    builder = StudioReleaseBuilder(_settings())
+
+    with pytest.raises(ValueError, match="unsupported entry"):
+        builder._extract_source(archive, tmp_path)
+
+
 def test_stage_deployment_uses_frontend_service_package(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -316,3 +355,68 @@ def test_stage_deployment_uses_frontend_service_package(
     assert "frontend.service.studio_release_server.app:app" in (
         destination / "run.sh"
     ).read_text(encoding="utf-8")
+
+
+def test_set_github_secret_reads_value_from_stdin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    invocation: dict[str, Any] = {}
+
+    def _run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        invocation["command"] = command
+        invocation.update(kwargs)
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(release_deploy.subprocess, "run", _run)
+
+    release_deploy._set_github_secret("STUDIO_RELEASE_SERVER_URL", "https://x")
+
+    assert invocation["command"] == [
+        "gh",
+        "secret",
+        "set",
+        "STUDIO_RELEASE_SERVER_URL",
+        "--repo",
+        "volcengine/veadk-python",
+    ]
+    assert invocation["input"] == "https://x"
+
+
+def test_github_secret_preflight_checks_access_without_writing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    invocation: dict[str, Any] = {}
+
+    def _run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        invocation["command"] = command
+        invocation.update(kwargs)
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(release_deploy.subprocess, "run", _run)
+
+    release_deploy._validate_github_secret_access()
+
+    assert invocation["command"] == [
+        "gh",
+        "api",
+        "repos/volcengine/veadk-python/actions/secrets/public-key",
+        "--silent",
+    ]
+
+
+def test_release_server_readiness_uses_rotated_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[Any] = []
+
+    def _urlopen(request: Any, *, timeout: int) -> Any:
+        requests.append(request)
+        assert timeout == 10
+        return nullcontext(SimpleNamespace(status=200))
+
+    monkeypatch.setattr(release_deploy.urllib.request, "urlopen", _urlopen)
+
+    release_deploy._wait_for_health("https://release.example.com", "rotated-key")
+
+    assert requests[0].full_url == "https://release.example.com/readyz"
+    assert dict(requests[0].header_items())["X-api-key"] == "rotated-key"

--- a/veadk/cli/studio_release.py
+++ b/veadk/cli/studio_release.py
@@ -54,7 +54,9 @@ class StudioReleaseManifest:
 
     def __post_init__(self) -> None:
         try:
-            parsed_version = datetime.strptime(self.version, "%Y%m%d%H%M%S")
+            parsed_version = datetime.strptime(self.version, "%Y%m%d%H%M%S").replace(
+                tzinfo=ZoneInfo("Asia/Shanghai")
+            )
         except ValueError as error:
             raise StudioReleaseError(
                 "Studio release version must use Beijing time YYYYMMDDHHMMSS."
@@ -268,6 +270,11 @@ class StudioReleaseStore:
                 "Studio release bundle checksum does not match manifest."
             )
         manifest_bytes = manifest.to_json()
+        releases = self._existing_releases()
+        if any(item.version > manifest.version for item in releases):
+            raise StudioReleaseError(
+                "Studio release version must be newer than the published releases."
+            )
         self._client.put_object(
             bucket=self.bucket,
             key=bundle_object_key(self.prefix, manifest.version),
@@ -282,7 +289,6 @@ class StudioReleaseStore:
             content_type="application/json",
             forbid_overwrite=True,
         )
-        releases = self._existing_releases()
         releases = [item for item in releases if item.version != manifest.version]
         releases.append(manifest)
         releases.sort(key=lambda item: item.version, reverse=True)


### PR DESCRIPTION
## Summary

- fix GitHub Secret updates so values are read from stdin instead of writing the literal `-`
- fail before cloud mutations when the authenticated account cannot update upstream Actions Secrets
- verify the active Release Server revision with the rotated API key before updating GitHub Secrets
- validate release URL and API key early, enforce HTTPS, and bound curl operations
- bound staged source extraction and prevent older releases from replacing `latest.json`

## Validation

- `uv run --extra extensions pytest -q` — 858 passed, 2 skipped, 6 subtests passed
- targeted Studio release tests — 35 passed
- Pyright — 0 errors
- Ruff check and format — passed
- Actionlint and Markdown lint — passed
- frontend production build — passed