### PR TITLE
fix(studio): default to published update bucket

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -165,18 +165,20 @@ local image or a downloaded network image into the VeFaaS deployment package.
 
 ## In-app Studio updates
 
-Configure an immutable TOS release channel when deploying Studio to let
-administrators update its frontend and Python backend together from the navbar:
+Studio deployments use the `veadk-studio` TOS bucket in the deployment region
+as their immutable release channel by default, so administrators can update the
+frontend and Python backend together from the navbar without extra options:
 
 ```bash
 veadk studio deploy \
   --user-pool-id <pool-id> \
   --allowed-client-id <client-id> \
-  --vefaas-app-name <app-name> \
-  --studio-update-bucket <tos-bucket> \
-  --studio-update-region cn-beijing \
-  --studio-update-prefix veadk/studio/main
+  --vefaas-app-name <app-name>
 ```
+
+Use `--studio-update-bucket`, `--studio-update-region`, and
+`--studio-update-prefix` (or their `VEADK_STUDIO_UPDATE_*` environment
+variables) to override the default release channel.
 
 Studio checks `latest.json` every three minutes and lists newer releases with
 their changelog and Git SHA. An accepted update verifies the selected complete

--- a/tests/cli/test_studio_deploy_target.py
+++ b/tests/cli/test_studio_deploy_target.py
@@ -183,19 +183,38 @@ def test_studio_deploy_surfaces_redacted_provisioning_error_chain(
 
 
 @pytest.mark.parametrize(
-    ("target_args", "expected_region", "expected_identity_region", "expected_project"),
+    (
+        "target_args",
+        "expected_region",
+        "expected_identity_region",
+        "expected_project",
+        "expected_update_bucket",
+        "update_bucket_env",
+    ),
     [
-        ([], "cn-beijing", "cn-beijing", "default"),
+        ([], "cn-beijing", "cn-beijing", "default", "veadk-studio", None),
         (
             [
                 "--region",
                 "cn-shanghai",
                 "--project",
                 "studio-project",
+                "--studio-update-bucket",
+                "custom-studio-releases",
             ],
             "cn-shanghai",
             "cn-beijing",
             "studio-project",
+            "custom-studio-releases",
+            "environment-studio-releases",
+        ),
+        (
+            [],
+            "cn-beijing",
+            "cn-beijing",
+            "default",
+            "environment-studio-releases",
+            "environment-studio-releases",
         ),
     ],
 )
@@ -205,9 +224,16 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
     expected_region: str,
     expected_identity_region: str,
     expected_project: str,
+    expected_update_bucket: str,
+    update_bucket_env: str | None,
 ) -> None:
     captured: dict[str, object] = {}
     credential_tool_ids: list[str] = []
+
+    if update_bucket_env is None:
+        monkeypatch.delenv("VEADK_STUDIO_UPDATE_BUCKET", raising=False)
+    else:
+        monkeypatch.setenv("VEADK_STUDIO_UPDATE_BUCKET", update_bucket_env)
 
     class _FakeCloudAgentEngine:
         def __init__(self, **kwargs: object) -> None:
@@ -278,6 +304,10 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
     assert veadk_environments["SANDBOX_CHAT_CODEX"] == "chat-code-env-id"
     assert veadk_environments["SANDBOX_SKILL_CREATOR"] == "skill-code-env-id"
     assert veadk_environments["AGENTKIT_SANDBOX_REGION"] == expected_region
+    assert veadk_environments["VEADK_STUDIO_UPDATE_BUCKET"] == expected_update_bucket
+    assert veadk_environments["VEADK_STUDIO_UPDATE_REGION"] == expected_region
+    assert veadk_environments["VEADK_STUDIO_UPDATE_PREFIX"] == "veadk/studio/main"
+    assert veadk_environments["VEADK_STUDIO_PROJECT"] == expected_project
     assert credential_tool_ids == [
         "chat-code-env-id",
         "skill-code-env-id",

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -4196,10 +4196,10 @@ def _resolve_studio_cloud_credentials(
 )
 @click.option(
     "--studio-update-bucket",
-    default=None,
+    default="veadk-studio",
+    show_default=True,
     envvar="VEADK_STUDIO_UPDATE_BUCKET",
-    help="TOS bucket containing immutable Studio release bundles. When omitted, "
-    "in-app Studio updates are disabled.",
+    help="TOS bucket containing immutable Studio release bundles.",
 )
 @click.option(
     "--studio-update-region",
@@ -4235,7 +4235,7 @@ def frontend_deploy(
     studio_developers: str | None,
     sandbox_chat_codex_tool_id: str | None,
     sandbox_skill_creator_tool_id: str | None,
-    studio_update_bucket: str | None,
+    studio_update_bucket: str,
     studio_update_region: str | None,
     studio_update_prefix: str,
 ) -> None:
@@ -4406,13 +4406,10 @@ def frontend_deploy(
     veadk_environments["SANDBOX_CHAT_CODEX"] = chat_codex_tool_id
     veadk_environments["SANDBOX_SKILL_CREATOR"] = skill_creator_tool_id
     veadk_environments["AGENTKIT_SANDBOX_REGION"] = region
-    if studio_update_bucket:
-        veadk_environments["VEADK_STUDIO_UPDATE_BUCKET"] = studio_update_bucket
-        veadk_environments["VEADK_STUDIO_UPDATE_REGION"] = (
-            studio_update_region or region
-        )
-        veadk_environments["VEADK_STUDIO_UPDATE_PREFIX"] = studio_update_prefix
-        veadk_environments["VEADK_STUDIO_PROJECT"] = project
+    veadk_environments["VEADK_STUDIO_UPDATE_BUCKET"] = studio_update_bucket
+    veadk_environments["VEADK_STUDIO_UPDATE_REGION"] = studio_update_region or region
+    veadk_environments["VEADK_STUDIO_UPDATE_PREFIX"] = studio_update_prefix
+    veadk_environments["VEADK_STUDIO_PROJECT"] = project
     if client_secret:
         veadk_environments["OAUTH2_CLIENT_SECRET"] = client_secret
 


### PR DESCRIPTION
## Summary

- default Studio deployments to the published veadk-studio release bucket
- preserve environment and CLI overrides, with CLI taking precedence
- document the default update channel and cover configuration precedence

## Verification

- uv run pytest -n 16 (859 passed, 2 skipped)
- uv run pre-commit run --files veadk/cli/cli_frontend.py tests/cli/test_studio_deploy_target.py frontend/README.md
- npx --yes markdownlint-cli2 frontend/README.md