### PR TITLE
fix(studio): recover hidden feedback dataset names

### DIFF
--- a/docs/content/docs/framework/frontend.en.mdx
+++ b/docs/content/docs/framework/frontend.en.mdx
@@ -39,8 +39,10 @@ VeADK ships a React frontend that renders [A2UI](/en/docs/framework/a2ui) (agent
   like/dislike controls below each answer write the question, answer, and
   feedback state to AgentKit evaluation sets. Each Agent gets stable
   `{agent_name}_good_case` and `{agent_name}_bad_case` sets; changing or
-  cancelling a rating updates the item idempotently. If a Runtime does not
-  expose Session state updates, the browser keeps a compatibility cache.
+  cancelling a rating updates the item idempotently. If the standard name is
+  reserved but hidden by the service, Studio uses and reuses a deterministic
+  suffixed name. If a Runtime does not expose Session state updates, the browser
+  keeps a compatibility cache.
 - **Add an AgentKit agent**: paste a URL + API key to connect a remote agent over the ADK protocol; it then appears in the picker.
 - **Custom-agent workbench**: author system prompts in a rich Markdown editor
   with heading and list shortcuts. Local skills accept a dropped folder or ZIP

--- a/docs/content/docs/framework/frontend.mdx
+++ b/docs/content/docs/framework/frontend.mdx
@@ -30,7 +30,8 @@ VeADK 自带一个 React 前端，用于渲染智能体经由 Google ADK API Ser
 - **消息反馈回流**：连接云端 AgentKit Runtime 时，回答下方的赞/踩按钮会将
   当前问题、回答和反馈状态写入 AgentKit 评测集。每个 Agent 自动维护
   `{agent_name}_good_case` 与 `{agent_name}_bad_case` 两个评测集，切换或取消反馈会
-  幂等更新对应样本；Runtime 不支持 Session 状态更新时，浏览器会保留兼容性缓存。
+  幂等更新对应样本。如果标准名称已被云端占用但不可见，Studio 会改用带稳定短后缀的
+  备用名称并在后续反馈中复用；Runtime 不支持 Session 状态更新时，浏览器会保留兼容性缓存。
 - **添加 AgentKit 智能体**：填入访问地址 + API Key，按 ADK 协议接入远程 agent，接入后出现在选择器中。
 - **自定义 Agent 工作台**：系统提示词支持所见即所得的 Markdown
   编辑与标题、列表等快捷输入；本地技能可直接拖入文件夹或 ZIP，格式会自动识别，

--- a/tests/integrations/agentkit/evaluation/test_client.py
+++ b/tests/integrations/agentkit/evaluation/test_client.py
@@ -21,7 +21,70 @@ import pytest
 from veadk.integrations.agentkit.evaluation.client import (
     AgentKitEvaluationDatasetsClient,
     AgentKitOpenApiError,
+    feedback_set_name,
 )
+
+
+def test_feedback_set_name_preserves_suffix_within_agentkit_limit() -> None:
+    name = feedback_set_name("a" * 100, "good")
+
+    assert len(name) == 50
+    assert name.endswith("_good_case")
+
+
+class _HiddenDuplicateBackend:
+    def __init__(self, *, race_fallback: bool = False) -> None:
+        self.race_fallback = race_fallback
+        self.created_names: list[str] = []
+        self.visible_sets = [
+            {
+                "Id": "other-set",
+                "Name": "其他评测集",
+                "WorkspaceId": "workspace-1",
+            }
+        ]
+
+    async def __call__(
+        self,
+        *,
+        action: str,
+        payload: dict[str, Any],
+        query: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        del query
+        if action == "ListEvaluationSets":
+            requested_name = str(payload.get("Name") or "")
+            items = self.visible_sets
+            if requested_name:
+                items = [item for item in items if item["Name"] == requested_name]
+            return {"Result": {"EvaluationSets": items}}
+        if action != "CreateEvaluationSet":
+            raise AssertionError(action)
+
+        name = str(payload["Name"])
+        self.created_names.append(name)
+        if name == "dt_good_case":
+            raise AgentKitOpenApiError(
+                "601104504",
+                "dataset name is duplicated in this space",
+            )
+        self.visible_sets.append(
+            {
+                "Id": "fallback-set",
+                "Name": name,
+                "WorkspaceId": "workspace-1",
+            }
+        )
+        if self.race_fallback:
+            raise AgentKitOpenApiError(
+                "601104504",
+                "dataset name is duplicated in this space",
+            )
+        return {"Result": {"EvaluationSetId": "fallback-set"}}
+
+
+async def _no_sleep(delay: float) -> None:
+    del delay
 
 
 @pytest.mark.asyncio
@@ -51,7 +114,7 @@ async def test_ensure_set_creates_and_resolves_workspace() -> None:
                         ]
                     }
                 }
-            if list_count == 3:
+            if list_count == 4:
                 return {
                     "Result": {
                         "EvaluationSets": [
@@ -76,6 +139,7 @@ async def test_ensure_set_creates_and_resolves_workspace() -> None:
     assert [call["action"] for call in calls] == [
         "ListEvaluationSets",
         "ListEvaluationSets",
+        "ListEvaluationSets",
         "CreateEvaluationSet",
         "ListEvaluationSets",
     ]
@@ -84,11 +148,11 @@ async def test_ensure_set_creates_and_resolves_workspace() -> None:
         "ProjectName": "support",
         "WorkspaceId": "workspace-1",
     }
-    assert calls[2]["query"] == {
+    assert calls[3]["query"] == {
         "ProjectName": "support",
         "WorkspaceId": "workspace-1",
     }
-    create_payload = calls[2]["payload"]
+    create_payload = calls[3]["payload"]
     assert create_payload["Name"] == "客服助手_good_case"
     assert "BizCategory" not in create_payload
     field_keys = {
@@ -172,7 +236,7 @@ async def test_ensure_set_recovers_when_duplicate_becomes_visible(
                         ]
                     }
                 }
-            if find_count < 4:
+            if find_count < 5:
                 return {"Result": {"EvaluationSets": []}}
             return {
                 "Result": {
@@ -209,10 +273,92 @@ async def test_ensure_set_recovers_when_duplicate_becomes_visible(
     assert calls == [
         "ListEvaluationSets",
         "ListEvaluationSets",
+        "ListEvaluationSets",
         "CreateEvaluationSet",
         "ListEvaluationSets",
         "ListEvaluationSets",
     ]
+
+
+@pytest.mark.asyncio
+async def test_ensure_set_uses_and_reuses_fallback_for_hidden_duplicate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = _HiddenDuplicateBackend()
+    monkeypatch.setattr(
+        "veadk.integrations.agentkit.evaluation.client.asyncio.sleep",
+        _no_sleep,
+    )
+
+    first_client = AgentKitEvaluationDatasetsClient(backend, project_name="default")
+    first = await first_client.ensure_feedback_set("dt", "good")
+    second_client = AgentKitEvaluationDatasetsClient(backend, project_name="default")
+    second = await second_client.ensure_feedback_set("dt", "good")
+
+    assert backend.created_names[0] == "dt_good_case"
+    assert len(backend.created_names) == 2
+    fallback_name = backend.created_names[1]
+    assert fallback_name.startswith("dt_good_case_")
+    assert len(fallback_name) <= 50
+    assert first.id == "fallback-set"
+    assert first.name == fallback_name
+    assert second == first
+
+
+@pytest.mark.asyncio
+async def test_ensure_set_recovers_when_fallback_creation_races(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = _HiddenDuplicateBackend(race_fallback=True)
+    monkeypatch.setattr(
+        "veadk.integrations.agentkit.evaluation.client.asyncio.sleep",
+        _no_sleep,
+    )
+
+    client = AgentKitEvaluationDatasetsClient(backend, project_name="default")
+    evaluation_set = await client.ensure_feedback_set("dt", "good")
+
+    fallback_name = backend.created_names[1]
+    assert fallback_name.startswith("dt_good_case_")
+    assert evaluation_set.id == "fallback-set"
+    assert evaluation_set.name == fallback_name
+
+
+@pytest.mark.asyncio
+async def test_ensure_set_propagates_non_duplicate_create_error() -> None:
+    create_calls = 0
+
+    async def post(
+        *,
+        action: str,
+        payload: dict[str, Any],
+        query: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        del payload, query
+        nonlocal create_calls
+        if action == "ListEvaluationSets":
+            return {
+                "Result": {
+                    "EvaluationSets": [
+                        {
+                            "Id": "other-set",
+                            "Name": "其他评测集",
+                            "WorkspaceId": "workspace-1",
+                        }
+                    ]
+                }
+            }
+        if action == "CreateEvaluationSet":
+            create_calls += 1
+            raise AgentKitOpenApiError("500", "upstream unavailable")
+        raise AssertionError(action)
+
+    client = AgentKitEvaluationDatasetsClient(post, project_name="default")
+
+    with pytest.raises(AgentKitOpenApiError, match="500: upstream unavailable"):
+        await client.ensure_feedback_set("dt", "good")
+
+    assert create_calls == 1
 
 
 @pytest.mark.asyncio

--- a/veadk/integrations/agentkit/evaluation/client.py
+++ b/veadk/integrations/agentkit/evaluation/client.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import re
 from dataclasses import dataclass
 from typing import Any, Protocol
@@ -78,6 +79,8 @@ _FEEDBACK_FIELD_KEYS = (
 
 _DUPLICATE_DATASET_ERROR_CODE = "601104504"
 _DUPLICATE_LOOKUP_DELAYS = (0.25, 0.5, 1.0, 2.0, 4.0)
+_MAX_DATASET_NAME_LENGTH = 50
+_FALLBACK_NAME_HASH_LENGTH = 8
 
 
 def _feedback_field_schemas() -> list[dict[str, Any]]:
@@ -100,8 +103,16 @@ def feedback_set_name(agent_name: str, rating: str) -> str:
     """Return the stable good/bad dataset name for an Agent."""
     if rating not in {"good", "bad"}:
         raise ValueError(f"unsupported feedback rating: {rating}")
-    normalized = re.sub(r"\s+", "_", agent_name.strip())[:80] or "agent"
-    return f"{normalized}_{rating}_case"
+    suffix = f"_{rating}_case"
+    normalized = re.sub(r"\s+", "_", agent_name.strip()) or "agent"
+    return f"{normalized[: _MAX_DATASET_NAME_LENGTH - len(suffix)]}{suffix}"
+
+
+def _fallback_set_name(name: str, workspace_id: str) -> str:
+    """Return a stable alternative when AgentKit invisibly reserves a name."""
+    digest = hashlib.sha256(f"{workspace_id}\0{name}".encode()).hexdigest()
+    suffix = f"_{digest[:_FALLBACK_NAME_HASH_LENGTH]}"
+    return f"{name[: _MAX_DATASET_NAME_LENGTH - len(suffix)]}{suffix}"
 
 
 class AgentKitEvaluationDatasetsClient:
@@ -129,29 +140,57 @@ class AgentKitEvaluationDatasetsClient:
         """Return the feedback set, creating it when absent."""
         name = feedback_set_name(agent_name, rating)
         workspace_id = await self._resolve_workspace_id()
+        fallback_name = _fallback_set_name(name, workspace_id)
         existing = await self._find_set(name, workspace_id=workspace_id)
+        if existing is not None:
+            return existing
+        existing = await self._find_set(fallback_name, workspace_id=workspace_id)
         if existing is not None:
             return existing
 
         try:
-            created = await self._post(
-                action="CreateEvaluationSet",
-                query={**self._project_query, "WorkspaceId": workspace_id},
-                payload={
-                    "Name": name,
-                    "Description": "VeADK Studio 对话反馈自动回流评测集",
-                    "EvaluationSetSchema": {
-                        "FieldSchemas": _feedback_field_schemas(),
-                    },
-                },
-            )
+            return await self._create_set(name, workspace_id=workspace_id)
         except AgentKitOpenApiError as error:
             if error.code != _DUPLICATE_DATASET_ERROR_CODE:
                 raise
             existing = await self._wait_for_set(name, workspace_id=workspace_id)
             if existing is not None:
                 return existing
+
+        existing = await self._find_set(fallback_name, workspace_id=workspace_id)
+        if existing is not None:
+            return existing
+        try:
+            return await self._create_set(fallback_name, workspace_id=workspace_id)
+        except AgentKitOpenApiError as error:
+            if error.code != _DUPLICATE_DATASET_ERROR_CODE:
+                raise
+            existing = await self._wait_for_set(
+                fallback_name,
+                workspace_id=workspace_id,
+            )
+            if existing is not None:
+                return existing
             raise
+
+    async def _create_set(
+        self,
+        name: str,
+        *,
+        workspace_id: str,
+    ) -> EvaluationSetRef:
+        """Create one evaluation set and verify its stable identifiers."""
+        created = await self._post(
+            action="CreateEvaluationSet",
+            query={**self._project_query, "WorkspaceId": workspace_id},
+            payload={
+                "Name": name,
+                "Description": "VeADK Studio 对话反馈自动回流评测集",
+                "EvaluationSetSchema": {
+                    "FieldSchemas": _feedback_field_schemas(),
+                },
+            },
+        )
         created_id = str((created.get("Result") or {}).get("EvaluationSetId") or "")
         if not created_id:
             raise RuntimeError("AgentKit did not return the created evaluation set ID")


### PR DESCRIPTION
## Summary

- recover Studio feedback sync when AgentKit reserves a dataset name that ListEvaluationSets cannot see
- derive and reuse a deterministic workspace-scoped fallback name while preserving concurrent-create recovery
- cap generated evaluation-set names at the AgentKit 50-character limit and document the fallback behavior

## Testing

- 863 passed, 2 skipped
- Ruff check and format passed
- Pyright passed
- Markdown lint passed
- pre-commit hooks passed