### PR TITLE
feat(agentkit): add session-scoped capability overlays

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type WheelEvent,
+} from "react";
 import {
   Check,
   ChevronDown,
@@ -12,6 +19,7 @@ import {
 import { motion } from "motion/react";
 import {
   cancelAgentkitDeployment,
+  addSessionCapability,
   createSession,
   DEFAULT_STUDIO_ACCESS,
   DEFAULT_SITE_BRANDING,
@@ -19,10 +27,13 @@ import {
   deleteSessionMedia,
   deleteSession,
   getAgentInfo,
+  getSessionCapabilities,
   getSession,
   getStudioAccess,
   listApps,
+  listSessionBuiltinTools,
   listSessions,
+  removeSessionCapability,
   runSSE,
   submitMessageFeedback,
   uploadMedia,
@@ -32,11 +43,13 @@ import {
   type AgentNode,
   type AgentTarget,
   type AdkSession,
+  type AddSessionCapability,
   type Attachment,
   type FrontendInvocation,
   type ManagedRuntime,
   type MessageFeedbackRating,
   type SiteBranding,
+  type SessionCapabilities,
   type StudioAccess,
   type UiFeatures,
 } from "./adk/client";
@@ -168,7 +181,6 @@ function loadView(): CreateView {
 import { TraceDrawer } from "./ui/TraceDrawer";
 import { LoginPage } from "./ui/LoginPage";
 import { Markdown } from "./ui/Markdown";
-import { useStickToBottom } from "./ui/useStickToBottom";
 import {
   clearLocalUser,
   logout,
@@ -612,6 +624,13 @@ export default function App() {
   const [invocation, setInvocation] = useState<FrontendInvocation>(emptyInvocation);
   const [agentInfo, setAgentInfo] = useState<AgentInfo | null>(null);
   const [capabilitiesLoading, setCapabilitiesLoading] = useState(false);
+  const [sessionCapabilities, setSessionCapabilities] =
+    useState<SessionCapabilities | null>(null);
+  const [sessionCapabilitiesLoading, setSessionCapabilitiesLoading] =
+    useState(false);
+  const [sessionBuiltinTools, setSessionBuiltinTools] = useState<string[]>([]);
+  const [sessionCapabilityMutating, setSessionCapabilityMutating] =
+    useState(false);
   const removedAttachmentIdsRef = useRef<Set<string>>(new Set());
   // Streaming state is PER SESSION so multiple sessions can stream at once
   // (each /run_sse is an independent request). `streamingSids` = which sessions
@@ -621,7 +640,11 @@ export default function App() {
   const [streamingSids, setStreamingSids] = useState<Set<string>>(
     () => new Set(),
   );
+  const [streamPresentationSids, setStreamPresentationSids] = useState<Set<string>>(
+    () => new Set(),
+  );
   const streamAbortsRef = useRef<Map<string, AbortController>>(new Map());
+  const streamPresentationTimersRef = useRef<Map<string, number>>(new Map());
   const setStreaming = (sid: string, on: boolean) =>
     setStreamingSids((s) => {
       const n = new Set(s);
@@ -629,6 +652,25 @@ export default function App() {
       else n.delete(sid);
       return n;
     });
+  const startStreamPresentation = (sid: string) => {
+    const timer = streamPresentationTimersRef.current.get(sid);
+    if (timer !== undefined) window.clearTimeout(timer);
+    streamPresentationTimersRef.current.delete(sid);
+    setStreamPresentationSids((current) => new Set(current).add(sid));
+  };
+  const finishStreamPresentation = (sid: string) => {
+    const previousTimer = streamPresentationTimersRef.current.get(sid);
+    if (previousTimer !== undefined) window.clearTimeout(previousTimer);
+    const timer = window.setTimeout(() => {
+      streamPresentationTimersRef.current.delete(sid);
+      setStreamPresentationSids((current) => {
+        const next = new Set(current);
+        next.delete(sid);
+        return next;
+      });
+    }, 2400);
+    streamPresentationTimersRef.current.set(sid, timer);
+  };
   // The session currently on screen — used to gate the single global error
   // banner (per-session transcripts/topology don't need it).
   const viewSidRef = useRef("");
@@ -683,10 +725,14 @@ export default function App() {
   // Everything the view needs for the ACTIVE session, derived from the
   // per-session maps above.
   const busy = streamingSids.has(sessionId);
+  const presentingStream = streamPresentationSids.has(sessionId);
   const conversationBusy = busy || initializingSession;
+  const sessionConfigurationBusy = !!sessionId && sessionCapabilitiesLoading;
   const activeConversationBusy = sandboxSession
     ? sandboxBusy
     : conversationBusy;
+  const activeConversationPresenting =
+    activeConversationBusy || (!sandboxSession && presentingStream);
   const activeAgent = activeAgentBySession[sessionId] ?? "";
   const seenAgents = seenAgentsBySession[sessionId] ?? EMPTY_STRING_SET;
   const execPath = execPathBySession[sessionId] ?? EMPTY_STRING_ARR;
@@ -880,7 +926,82 @@ export default function App() {
     setAppName(agentId);
     // startNewChat will be called automatically by the appName change effect
   }
-  const { ref: scrollRef, onScroll } = useStickToBottom<HTMLDivElement>(turns);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const conversationAutoFollowRef = useRef(true);
+  const conversationSmoothScrollRef = useRef(false);
+  const conversationSmoothTimerRef = useRef<number | null>(null);
+  const conversationScrollStateRef = useRef({ key: "", turnCount: 0 });
+  const conversationScrollKey = sandboxSession?.id ?? sessionId;
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    const previous = conversationScrollStateRef.current;
+    const conversationChanged = previous.key !== conversationScrollKey;
+    const turnAppended = !conversationChanged && turns.length > previous.turnCount;
+    conversationScrollStateRef.current = {
+      key: conversationScrollKey,
+      turnCount: turns.length,
+    };
+    if (!el || turns.length === 0 || (!conversationChanged && !turnAppended)) return;
+
+    conversationAutoFollowRef.current = true;
+    conversationSmoothScrollRef.current = false;
+    if (conversationSmoothTimerRef.current !== null) {
+      window.clearTimeout(conversationSmoothTimerRef.current);
+      conversationSmoothTimerRef.current = null;
+    }
+
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (conversationChanged || reduceMotion) {
+      el.scrollTop = el.scrollHeight;
+      return;
+    }
+
+    conversationSmoothScrollRef.current = true;
+    el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+    conversationSmoothTimerRef.current = window.setTimeout(() => {
+      conversationSmoothScrollRef.current = false;
+      conversationSmoothTimerRef.current = null;
+    }, 450);
+  }, [conversationScrollKey, turns.length]);
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (
+      !el ||
+      !conversationAutoFollowRef.current ||
+      conversationSmoothScrollRef.current
+    ) return;
+    el.scrollTop = el.scrollHeight;
+  }, [activeConversationBusy, turns]);
+  useEffect(() => () => {
+    if (conversationSmoothTimerRef.current !== null) {
+      window.clearTimeout(conversationSmoothTimerRef.current);
+    }
+  }, []);
+  const onConversationScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el || conversationSmoothScrollRef.current) return;
+    conversationAutoFollowRef.current =
+      el.scrollHeight - el.scrollTop - el.clientHeight < 32;
+  }, []);
+  const onConversationWheel = useCallback((event: WheelEvent<HTMLDivElement>) => {
+    if (event.deltaY < 0) {
+      conversationSmoothScrollRef.current = false;
+      conversationAutoFollowRef.current = false;
+    }
+  }, []);
+  const onConversationTouchMove = useCallback(() => {
+    conversationSmoothScrollRef.current = false;
+    conversationAutoFollowRef.current = false;
+  }, []);
+  const followConversationStreamFrame = useCallback(() => {
+    const el = scrollRef.current;
+    if (
+      !el ||
+      !conversationAutoFollowRef.current ||
+      conversationSmoothScrollRef.current
+    ) return;
+    el.scrollTop = el.scrollHeight;
+  }, []);
 
   // Resolve SSO identity first; it provides the ADK user_id.
   const resolveAuth = useCallback(() => {
@@ -1078,6 +1199,37 @@ export default function App() {
   }, [appName]);
   useEffect(() => {
     let cancelled = false;
+    setSessionCapabilities(null);
+    setSessionBuiltinTools([]);
+    if (!appName || !userId || !sessionId) {
+      setSessionCapabilitiesLoading(false);
+      return;
+    }
+    setSessionCapabilitiesLoading(true);
+    getSessionCapabilities(appName, userId, sessionId)
+      .then((capabilities) => {
+        if (cancelled) return;
+        setSessionCapabilities(capabilities);
+        void listSessionBuiltinTools(appName)
+          .then((tools) => {
+            if (!cancelled) setSessionBuiltinTools(tools);
+          })
+          .catch(() => {
+            if (!cancelled) setSessionBuiltinTools([]);
+          });
+      })
+      .catch(() => {
+        if (!cancelled) setSessionCapabilities(null);
+      })
+      .finally(() => {
+        if (!cancelled) setSessionCapabilitiesLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [appName, userId, sessionId]);
+  useEffect(() => {
+    let cancelled = false;
     setAgentInfo(null);
     setInvocation(emptyInvocation());
     if (!appName) {
@@ -1115,6 +1267,12 @@ export default function App() {
   // Abort the in-flight stream when the whole view unmounts.
   useEffect(
     () => () => streamAbortsRef.current.forEach((c) => c.abort()),
+    [],
+  );
+  useEffect(
+    () => () => streamPresentationTimersRef.current.forEach((timer) => {
+      window.clearTimeout(timer);
+    }),
     [],
   );
   useEffect(
@@ -1351,6 +1509,8 @@ export default function App() {
       : "";
     viewSidRef.current = "";
     setSessionId("");
+    setSessionCapabilities(null);
+    setSessionBuiltinTools([]);
     setInitializingSession(false);
     setPendingTurns([]);
     setInvocation(emptyInvocation());
@@ -1365,6 +1525,15 @@ export default function App() {
       streamAbortsRef.current.get(id)?.abort();
       await deleteSessionMedia(appName, userId, id);
       await deleteSession(appName, userId, id);
+      const presentationTimer = streamPresentationTimersRef.current.get(id);
+      if (presentationTimer !== undefined) window.clearTimeout(presentationTimer);
+      streamPresentationTimersRef.current.delete(id);
+      setStreamPresentationSids((current) => {
+        if (!current.has(id)) return current;
+        const next = new Set(current);
+        next.delete(id);
+        return next;
+      });
       setTurnsBySession((m) => {
         const { [id]: _drop, ...rest } = m;
         return rest;
@@ -1386,6 +1555,8 @@ export default function App() {
     setNewChatMode("agent");
     discardSkillCreation();
     setInvocation(emptyInvocation());
+    setSessionCapabilities(null);
+    setSessionBuiltinTools([]);
     setSessionId(id);
     // Already have this session's turns (it's cached, or streaming in the
     // background)? Show them instantly and let any live stream keep updating —
@@ -1417,6 +1588,48 @@ export default function App() {
       return sid;
     } finally {
       if (creatingSessionRef.current === pending) creatingSessionRef.current = null;
+    }
+  }
+
+  async function addCapability(capability: AddSessionCapability): Promise<boolean> {
+    if (!appName || !userId || !sessionId || !sessionCapabilities) return false;
+    setSessionCapabilityMutating(true);
+    setError("");
+    try {
+      const updated = await addSessionCapability(
+        appName,
+        userId,
+        sessionId,
+        capability,
+        sessionCapabilities.revision,
+      );
+      setSessionCapabilities(updated);
+      return true;
+    } catch (e) {
+      setError(String(e));
+      return false;
+    } finally {
+      setSessionCapabilityMutating(false);
+    }
+  }
+
+  async function removeCapability(capabilityId: string) {
+    if (!appName || !userId || !sessionId || !sessionCapabilities) return;
+    setSessionCapabilityMutating(true);
+    setError("");
+    try {
+      const updated = await removeSessionCapability(
+        appName,
+        userId,
+        sessionId,
+        capabilityId,
+        sessionCapabilities.revision,
+      );
+      setSessionCapabilities(updated);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setSessionCapabilityMutating(false);
     }
   }
 
@@ -1475,6 +1688,7 @@ export default function App() {
     if (
       (!text.trim() && atts.length === 0) ||
       conversationBusy ||
+      sessionConfigurationBusy ||
       !appName ||
       !userId
     ) return;
@@ -1535,6 +1749,7 @@ export default function App() {
     const ctrl = new AbortController();
     streamAbortsRef.current.set(sid, ctrl);
     setStreaming(sid, true);
+    startStreamPresentation(sid);
     viewSidRef.current = sid;
 
     setActiveAgentBySession((m) => ({ ...m, [sid]: "" }));
@@ -1555,6 +1770,7 @@ export default function App() {
         attachments: atts,
         invocation: selectedInvocation,
         signal: ctrl.signal,
+        sessionCapabilities: sessionCapabilities !== null,
       })) {
         if (ctrl.signal.aborted) break;
         const errMsg = event.error ?? event.errorMessage ?? event.error_message;
@@ -1599,6 +1815,7 @@ export default function App() {
     } finally {
       if (streamAbortsRef.current.get(sid) === ctrl) streamAbortsRef.current.delete(sid);
       setStreaming(sid, false);
+      finishStreamPresentation(sid);
       setActiveAgentBySession((m) => ({ ...m, [sid]: "" }));
       setExecPathBySession((m) => ({ ...m, [sid]: [] }));
     }
@@ -1645,6 +1862,7 @@ export default function App() {
     const ctrl = new AbortController();
     streamAbortsRef.current.set(sid, ctrl);
     setStreaming(sid, true);
+    startStreamPresentation(sid);
     try {
       let acc = emptyAcc();
       let tokens = 0;
@@ -1660,6 +1878,7 @@ export default function App() {
           { id: block.callId, name: "adk_request_credential", response },
         ],
         signal: ctrl.signal,
+        sessionCapabilities: sessionCapabilities !== null,
       })) {
         if (ctrl.signal.aborted) break;
         applyStreamSignals(sid, event);
@@ -1701,6 +1920,7 @@ export default function App() {
     } finally {
       if (streamAbortsRef.current.get(sid) === ctrl) streamAbortsRef.current.delete(sid);
       setStreaming(sid, false);
+      finishStreamPresentation(sid);
       setActiveAgentBySession((m) => ({ ...m, [sid]: "" }));
       setExecPathBySession((m) => ({ ...m, [sid]: [] }));
     }
@@ -2299,7 +2519,13 @@ export default function App() {
               </div>
             ) : (
               <>
-                <div className="transcript" ref={scrollRef} onScroll={onScroll}>
+                <div
+                  className={`transcript${activeConversationPresenting ? " is-streaming" : ""}`}
+                  ref={scrollRef}
+                  onScroll={onConversationScroll}
+                  onWheel={onConversationWheel}
+                  onTouchMove={onConversationTouchMove}
+                >
                   {turns.map((turn, i) => {
             const isLast = i === turns.length - 1;
             if (turn.role === "user") {
@@ -2353,7 +2579,14 @@ export default function App() {
                   isLast && activeConversationBusy ? <ThinkingPlaceholder /> : null
                 ) : (
                   <>
-                    <Blocks appName={appName} blocks={turn.blocks} onAction={onAction} onAuth={onAuth} />
+                    <Blocks
+                      appName={appName}
+                      blocks={turn.blocks}
+                      streaming={isLast && (activeConversationBusy || presentingStream)}
+                      onStreamFrame={isLast ? followConversationStreamFrame : undefined}
+                      onAction={onAction}
+                      onAuth={onAuth}
+                    />
                     {/* Finalized turn that produced no visible answer (e.g. only
                         thinking + an empty A2UI surface) — show a fallback note. */}
                     {!(isLast && activeConversationBusy) && !turnHasVisibleContent(turn) && (
@@ -2435,11 +2668,18 @@ export default function App() {
                 </div>
                 {!sandboxSession && (
                   <AgentInfoPanel
+                    appName={appName}
                     info={agentInfo}
                     loading={capabilitiesLoading}
                     activeAgent={activeAgent}
                     seenAgents={seenAgents}
                     execPath={execPath}
+                    capabilities={sessionCapabilities}
+                    capabilityLoading={sessionCapabilitiesLoading}
+                    capabilityMutating={sessionCapabilityMutating}
+                    builtinTools={sessionBuiltinTools}
+                    onAddCapability={addCapability}
+                    onRemoveCapability={(id) => void removeCapability(id)}
                   />
                 )}
                 <div className="conversation-composer-slot">
@@ -2462,11 +2702,18 @@ export default function App() {
 
       {agentInfoOpen && turns.length > 0 && (
         <AgentInfoDrawer
+          appName={appName}
           info={agentInfo}
           loading={capabilitiesLoading}
           activeAgent={activeAgent}
           seenAgents={seenAgents}
           execPath={execPath}
+          capabilities={sessionCapabilities}
+          capabilityLoading={sessionCapabilitiesLoading}
+          capabilityMutating={sessionCapabilityMutating}
+          builtinTools={sessionBuiltinTools}
+          onAddCapability={addCapability}
+          onRemoveCapability={(id) => void removeCapability(id)}
           onClose={closeAgentInfo}
           returnFocusRef={agentInfoTriggerRef}
         />

--- a/frontend/src/adk/client.ts
+++ b/frontend/src/adk/client.ts
@@ -636,6 +636,204 @@ export interface AgentInfo {
   graph?: AgentNode;
 }
 
+export interface SessionCapabilityItem {
+  id: string;
+  kind: "tool" | "skill";
+  name: string;
+  custom: boolean;
+  description?: string;
+  skillSourceId?: string;
+  version?: string;
+}
+
+export interface SessionCapabilities {
+  schemaVersion: number;
+  revision: number;
+  tools: SessionCapabilityItem[];
+  skills: SessionCapabilityItem[];
+}
+
+export interface AddSessionCapability {
+  kind: "tool" | "skill";
+  name: string;
+  skillSourceId?: string;
+  description?: string;
+  version?: string;
+}
+
+export interface SessionSkillSpace {
+  id: string;
+  name: string;
+  description: string;
+  status: string;
+  region?: string;
+  projectName?: string;
+  skillCount?: number;
+}
+
+export interface SessionSkillCatalogItem {
+  skillId: string;
+  skillName: string;
+  skillDescription: string;
+  version: string;
+  skillStatus: string;
+}
+
+export interface SessionPublicSkill {
+  slug: string;
+  name: string;
+  description: string;
+  sourceType: string;
+  sourceRepo: string;
+  downloadCount: number;
+  evaluationScore: number;
+  version: string;
+  updatedAt: string;
+}
+
+export interface SessionPublicSkillSearchResult {
+  items: SessionPublicSkill[];
+  totalCount: number;
+}
+
+function normalizeSessionCapabilities(payload: Record<string, unknown>): SessionCapabilities {
+  const normalizeItem = (item: Record<string, unknown>): SessionCapabilityItem => ({
+    id: String(item.id ?? ""),
+    kind: item.kind === "skill" ? "skill" : "tool",
+    name: String(item.name ?? ""),
+    custom: item.custom === true,
+    description: typeof item.description === "string" ? item.description : undefined,
+    skillSourceId: typeof item.skill_source_id === "string" ? item.skill_source_id : undefined,
+    version: typeof item.version === "string" ? item.version : undefined,
+  });
+  return {
+    schemaVersion: Number(payload.schema_version ?? 1),
+    revision: Number(payload.revision ?? 0),
+    tools: Array.isArray(payload.tools)
+      ? payload.tools.map((item) => normalizeItem(item as Record<string, unknown>))
+      : [],
+    skills: Array.isArray(payload.skills)
+      ? payload.skills.map((item) => normalizeItem(item as Record<string, unknown>))
+      : [],
+  };
+}
+
+function sessionCapabilitiesPath(
+  app: string,
+  userId: string,
+  sessionId: string,
+): string {
+  return `/harness/apps/${encodeURIComponent(app)}/users/${encodeURIComponent(userId)}/sessions/${encodeURIComponent(sessionId)}/capabilities`;
+}
+
+export async function getSessionCapabilities(
+  appName: string,
+  userId: string,
+  sessionId: string,
+): Promise<SessionCapabilities> {
+  const { app, ep } = resolve(appName);
+  const res = await apiFetch(sessionCapabilitiesPath(app, userId, sessionId), {}, ep);
+  if (!res.ok) throw new Error(await httpErrorMessage(res, "读取会话能力失败"));
+  return normalizeSessionCapabilities(await res.json());
+}
+
+export async function listSessionBuiltinTools(appName: string): Promise<string[]> {
+  const { ep } = resolve(appName);
+  const res = await apiFetch("/harness/capabilities/tools", {}, ep);
+  if (!res.ok) throw new Error(await httpErrorMessage(res, "读取内置工具失败"));
+  const payload = (await res.json()) as { tools?: { name?: string }[] };
+  return (payload.tools ?? [])
+    .map((tool) => tool.name?.trim() ?? "")
+    .filter(Boolean);
+}
+
+export async function listSessionSkillSpaces(
+  appName: string,
+): Promise<SessionSkillSpace[]> {
+  const { ep } = resolve(appName);
+  const res = await apiFetch("/harness/skills/spaces?region=all", {}, ep);
+  if (!res.ok) throw new Error(await httpErrorMessage(res, "读取 Skill Space 失败"));
+  const payload = (await res.json()) as { items?: SessionSkillSpace[] };
+  return payload.items ?? [];
+}
+
+export async function listSessionSkillsInSpace(
+  appName: string,
+  spaceId: string,
+  region?: string,
+): Promise<SessionSkillCatalogItem[]> {
+  const { ep } = resolve(appName);
+  const params = new URLSearchParams({ region: region || "cn-beijing" });
+  const path = `/harness/skills/spaces/${encodeURIComponent(spaceId)}/skills?${params.toString()}`;
+  const res = await apiFetch(path, {}, ep);
+  if (!res.ok) throw new Error(await httpErrorMessage(res, "读取 Skill 列表失败"));
+  const payload = (await res.json()) as { items?: SessionSkillCatalogItem[] };
+  return payload.items ?? [];
+}
+
+export async function searchSessionPublicSkills(
+  appName: string,
+  query: string,
+  pageNumber = 1,
+  pageSize = 20,
+): Promise<SessionPublicSkillSearchResult> {
+  const { ep } = resolve(appName);
+  const params = new URLSearchParams({
+    query,
+    page_number: String(pageNumber),
+    page_size: String(pageSize),
+  });
+  const res = await apiFetch(`/harness/skills/findskill?${params.toString()}`, {}, ep);
+  if (!res.ok) throw new Error(await httpErrorMessage(res, "搜索 Skill Hub 失败"));
+  const payload = (await res.json()) as Partial<SessionPublicSkillSearchResult>;
+  return {
+    items: payload.items ?? [],
+    totalCount: Number(payload.totalCount ?? 0),
+  };
+}
+
+export async function addSessionCapability(
+  appName: string,
+  userId: string,
+  sessionId: string,
+  capability: AddSessionCapability,
+  expectedRevision: number,
+): Promise<SessionCapabilities> {
+  const { app, ep } = resolve(appName);
+  const res = await apiFetch(
+    sessionCapabilitiesPath(app, userId, sessionId),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        kind: capability.kind,
+        name: capability.name,
+        skill_source_id: capability.skillSourceId,
+        description: capability.description,
+        version: capability.version,
+        expected_revision: expectedRevision,
+      }),
+    },
+    ep,
+  );
+  if (!res.ok) throw new Error(await httpErrorMessage(res, "添加会话能力失败"));
+  return normalizeSessionCapabilities(await res.json());
+}
+
+export async function removeSessionCapability(
+  appName: string,
+  userId: string,
+  sessionId: string,
+  capabilityId: string,
+  expectedRevision: number,
+): Promise<SessionCapabilities> {
+  const { app, ep } = resolve(appName);
+  const path = `${sessionCapabilitiesPath(app, userId, sessionId)}/${encodeURIComponent(capabilityId)}?expected_revision=${expectedRevision}`;
+  const res = await apiFetch(path, { method: "DELETE" }, ep);
+  if (!res.ok) throw new Error(await httpErrorMessage(res, "移除会话能力失败"));
+  return normalizeSessionCapabilities(await res.json());
+}
+
 async function fetchAgentInfo(app: string, ep: AdkEndpoint): Promise<AgentInfo> {
   const res = await apiFetch(`/web/agent-info/${app}`, {}, ep);
   if (!res.ok) throw new Error(`agent-info failed: ${res.status}`);
@@ -744,6 +942,8 @@ export interface RunArgs {
   functionResponses?: { id: string; name: string; response: unknown }[];
   /** Abort the stream (e.g. when the user switches to another session). */
   signal?: AbortSignal;
+  /** Use the session-aware harness runner when the server exposes it. */
+  sessionCapabilities?: boolean;
 }
 
 /** Stream agent events for one user turn. */
@@ -756,6 +956,7 @@ export async function* runSSE({
   invocation,
   functionResponses = [],
   signal,
+  sessionCapabilities = false,
 }: RunArgs): AsyncGenerator<AdkEvent, void, unknown> {
   const { app, ep } = resolve(appName);
   const attachmentParts = attachments.flatMap<Record<string, unknown>>((a) => {
@@ -801,7 +1002,7 @@ export async function* runSSE({
     };
   }
   const res = await apiFetch(
-    `/run_sse`,
+    sessionCapabilities ? `/harness/run_sse` : `/run_sse`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -939,6 +939,7 @@ body {
 
 /* ---------- main ---------- */
 .main {
+  position: relative;
   flex: 1;
   min-width: 0;
   min-height: 0;
@@ -950,7 +951,6 @@ body {
   border-radius: 12px;
   overflow: hidden; /* clip inner scroll regions to the rounded corners */
 }
-
 .error {
   margin: 10px auto 0;
   max-width: 768px;
@@ -963,6 +963,7 @@ body {
 }
 
 .transcript { flex: 1; overflow-y: auto; padding: 28px 16px 8px; }
+.transcript.is-streaming { overflow-anchor: none; }
 
 /* new-chat empty state: centered greeting + composer */
 .welcome {
@@ -992,8 +993,11 @@ body {
 .turn:last-child { margin-bottom: 0; }
 .turn--user { align-items: flex-end; }
 .turn--assistant { align-items: flex-start; }
+.transcript.is-streaming > .turn--assistant:last-child {
+  min-height: max(0px, calc(100% - 180px));
+}
 
-.bubble { line-height: 1.65; font-size: 14px; }
+.bubble { line-height: 1.65; font-size: 16px; }
 .turn--user .bubble {
   max-width: 85%;
   padding: 10px 16px;
@@ -1003,7 +1007,7 @@ body {
 .turn--assistant .bubble { max-width: 100%; }
 
 /* ---------- markdown (used by both user + assistant message bodies) ---------- */
-.md { font-size: 14px; line-height: 1.65; }
+.md { font-size: 16px; line-height: 1.65; }
 /* tight vertical rhythm: no margin on first/last child so bubbles hug content */
 .md > :first-child { margin-top: 0; }
 .md > :last-child { margin-bottom: 0; }
@@ -1444,7 +1448,7 @@ body {
 .chev.open { transform: rotate(90deg); } /* right (closed) -> down (open) */
 
 .think-label {
-  font-size: 13.5px;
+  font-size: 14.5px;
   font-weight: 400;
   line-height: 1.35;
 }
@@ -1460,7 +1464,7 @@ body {
 }
 .tool-name {
   color: inherit;
-  font-size: 13.5px;
+  font-size: 14.5px;
   font-weight: 400;
   line-height: 1.35;
 }
@@ -1503,11 +1507,11 @@ body {
 .think-collapse.open { grid-template-rows: 1fr; }
 .think-collapse-inner { overflow: hidden; }
 .think-body {
-  margin: 8px 0 4px;
-  padding: 10px 14px;
-  border-left: 2px solid hsl(var(--border));
+  margin: 0;
+  padding: 0;
+  border-left: 0;
   color: hsl(var(--muted-foreground));
-  font-size: 13px;
+  font-size: 14px;
   line-height: 1.7;
   white-space: pre-wrap;
   max-height: 220px;
@@ -4423,8 +4427,8 @@ a.search-result { text-decoration: none; color: inherit; }
 .topo-module-stack {
   display: grid;
   grid-template-rows:
-    minmax(86px, 0.95fr)
-    minmax(102px, 1.15fr)
+    minmax(124px, 0.95fr)
+    minmax(142px, 1.15fr)
     minmax(106px, 0.75fr);
   flex: 1;
   min-width: 0;
@@ -4455,6 +4459,7 @@ a.search-result { text-decoration: none; color: inherit; }
   font-size: 13px;
   font-weight: 600;
   line-height: 1;
+  width: 100%;
 }
 .topo-module-label {
   display: inline-flex;
@@ -4463,12 +4468,6 @@ a.search-result { text-decoration: none; color: inherit; }
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-.topo-section-icon {
-  display: block;
-  width: 14px;
-  height: 14px;
-  flex-shrink: 0;
 }
 .topo-section-count {
   display: inline-flex;
@@ -4485,6 +4484,11 @@ a.search-result { text-decoration: none; color: inherit; }
   font-variant-numeric: tabular-nums;
   line-height: 1;
   white-space: nowrap;
+}
+.topo-remove-capability:disabled,
+.topo-capability-add-slot:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
 }
 .topo-module-scroll {
   box-sizing: border-box;
@@ -4517,13 +4521,14 @@ a.search-result { text-decoration: none; color: inherit; }
 }
 .topo-tool {
   position: relative;
-  overflow: hidden;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
   padding: 7px 2px 7px 14px;
   color: hsl(var(--foreground));
   font-size: 12.5px;
   line-height: 1.4;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 .topo-tool::before {
   content: "";
@@ -4540,6 +4545,109 @@ a.search-result { text-decoration: none; color: inherit; }
 .topo-tool:last-child { padding-bottom: 1px; }
 .topo-tool + .topo-tool {
   border-top: 1px solid hsl(var(--border) / 0.72);
+}
+.topo-capability-title,
+.topo-skill-title {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 6px;
+}
+.topo-capability-title {
+  flex: 1;
+}
+.topo-capability-name {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.topo-capability-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 1px;
+}
+.topo-capability-copy code {
+  overflow: hidden;
+  color: hsl(var(--muted-foreground));
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 9.5px;
+  font-weight: 450;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.topo-capability-add-slot {
+  display: flex;
+  width: 100%;
+  min-height: 34px;
+  margin: 0;
+  padding: 5px 10px;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 1px dashed hsl(var(--border));
+  border-radius: 9px;
+  background: hsl(var(--muted) / 0.18);
+  color: hsl(var(--muted-foreground));
+  font: inherit;
+  font-size: 11.5px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.topo-capability-add-dock {
+  flex: 0 0 auto;
+  padding-top: 6px;
+  background: hsl(var(--background));
+}
+.topo-capability-add-slot > span:first-child {
+  font-size: 15px;
+  line-height: 1;
+}
+.topo-capability-add-slot:hover:not(:disabled) {
+  border-color: hsl(var(--primary) / 0.55);
+  background: hsl(var(--primary) / 0.055);
+  color: hsl(var(--primary));
+}
+.topo-capability-add-slot:focus-visible {
+  outline: 2px solid hsl(var(--ring) / 0.38);
+  outline-offset: 2px;
+}
+.topo-custom-badge {
+  display: inline-flex;
+  align-items: center;
+  height: 17px;
+  padding: 0 5px;
+  flex-shrink: 0;
+  border-radius: 5px;
+  background: hsl(var(--primary) / 0.1);
+  color: hsl(var(--primary));
+  font-size: 9.5px;
+  font-weight: 650;
+  line-height: 1;
+}
+.topo-remove-capability {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  margin-left: auto;
+  padding: 0;
+  flex-shrink: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+}
+.topo-remove-capability:hover:not(:disabled) {
+  background: hsl(var(--destructive) / 0.1);
+  color: hsl(var(--destructive));
 }
 .topo-skill-list {
   display: flex;
@@ -4559,13 +4667,18 @@ a.search-result { text-decoration: none; color: inherit; }
   border-top: 1px solid hsl(var(--border) / 0.72);
 }
 .topo-skill-name {
+  min-width: 0;
   overflow: hidden;
   color: hsl(var(--foreground));
-  font-size: 12.5px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 13px;
   font-weight: 500;
   line-height: 1.45;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.topo-skill-title {
+  width: 100%;
 }
 .topo-skill-description {
   display: -webkit-box;
@@ -4584,21 +4697,6 @@ a.search-result { text-decoration: none; color: inherit; }
 }
 .topo-topology {
   min-height: 0;
-}
-.topo-topology-empty {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-height: 34px;
-  color: hsl(var(--muted-foreground));
-  font-size: 11.5px;
-  line-height: 1.5;
-}
-.topo-topology-line {
-  width: 18px;
-  height: 1px;
-  flex: 0 0 18px;
-  background: hsl(var(--foreground) / 0.2);
 }
 .topo-tree { display: flex; flex-direction: column; gap: 4px; }
 /* Nested children indent and grow a connector guide-line on the left. */
@@ -4633,7 +4731,7 @@ a.search-result { text-decoration: none; color: inherit; }
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 12.5px;
+  font-size: 13px;
   font-weight: 550;
 }
 .topo-badge {
@@ -4644,11 +4742,10 @@ a.search-result { text-decoration: none; color: inherit; }
   background: hsl(var(--muted));
   color: hsl(var(--muted-foreground));
 }
-/* Currently-executing agent: highlighted ring + gentle pulse. */
+/* Currently-executing agent: dark-gray background fade only. */
 .topo-node.is-active {
-  background: hsl(var(--primary) / 0.08);
-  box-shadow: inset 2px 0 0 hsl(var(--primary));
-  animation: topo-pulse 1.4s ease-in-out infinite;
+  background: hsl(var(--foreground) / 0.08);
+  animation: topo-active-fade 1.8s ease-in-out infinite;
 }
 .topo-node.is-active .topo-icon { opacity: 1; }
 /* An ancestor on the current delegation chain (handed off, not the leaf). */
@@ -4693,13 +4790,13 @@ a.search-result { text-decoration: none; color: inherit; }
 }
 .topo-path-name { color: hsl(var(--muted-foreground)); }
 .topo-path-name.is-current { color: hsl(var(--primary)); font-weight: 600; }
-@keyframes topo-pulse {
+@keyframes topo-active-fade {
   0%,
   100% {
-    box-shadow: 0 0 0 0 hsl(var(--primary) / 0.28);
+    background: hsl(var(--foreground) / 0.05);
   }
   50% {
-    box-shadow: 0 0 0 4px hsl(var(--primary) / 0);
+    background: hsl(var(--foreground) / 0.14);
   }
 }
 @media (min-width: 1280px) {
@@ -4728,6 +4825,435 @@ a.search-result { text-decoration: none; color: inherit; }
   .topo-node { transition: none; }
   .topo-node.is-active,
   .topo-remote { animation: none; }
+}
+
+/* Session-scoped capability pickers. */
+.session-capability-dialog-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 110;
+  display: grid;
+  padding: 24px;
+  place-items: center;
+}
+.session-capability-dialog-scrim {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  background: hsl(220 20% 8% / 0.48);
+  backdrop-filter: blur(3px);
+}
+.session-capability-dialog {
+  position: relative;
+  display: flex;
+  width: min(560px, calc(100vw - 32px));
+  max-height: min(720px, calc(100vh - 48px));
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid hsl(var(--border));
+  border-radius: 16px;
+  background: hsl(var(--background));
+  box-shadow: 0 24px 80px hsl(220 35% 8% / 0.25), 0 2px 8px hsl(220 35% 8% / 0.12);
+  animation: session-capability-dialog-in 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.session-capability-dialog.is-wide {
+  width: min(980px, calc(100vw - 48px));
+  height: min(720px, calc(100dvh - 48px));
+}
+@keyframes session-capability-dialog-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.985); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+.session-capability-dialog-head {
+  display: grid;
+  min-height: 76px;
+  padding: 16px 18px;
+  grid-template-columns: 38px minmax(0, 1fr) 32px;
+  align-items: center;
+  gap: 12px;
+  border-bottom: 1px solid hsl(var(--border));
+}
+.session-capability-dialog-head.is-iconless {
+  grid-template-columns: minmax(0, 1fr) 32px;
+}
+.session-capability-dialog-mark {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  border-radius: 11px;
+  background: hsl(var(--primary) / 0.09);
+  color: hsl(var(--primary));
+  place-items: center;
+}
+.session-capability-dialog-mark svg { width: 20px; height: 20px; }
+.session-capability-dialog-head h2 {
+  margin: 0;
+  color: hsl(var(--foreground));
+  font-size: 15px;
+  font-weight: 680;
+  letter-spacing: -0.01em;
+}
+.session-capability-dialog-head p {
+  margin: 4px 0 0;
+  color: hsl(var(--muted-foreground));
+  font-size: 11.5px;
+  line-height: 1.45;
+}
+.session-capability-dialog-close {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  place-items: center;
+}
+.session-capability-dialog-close:hover {
+  background: hsl(var(--muted) / 0.7);
+  color: hsl(var(--foreground));
+}
+.session-capability-dialog-close svg { width: 18px; height: 18px; }
+.session-capability-search {
+  display: flex;
+  min-width: 0;
+  flex: 0 0 40px;
+  height: 40px;
+  padding: 0 12px;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid hsl(var(--border));
+  border-radius: 6px;
+  background: hsl(var(--background));
+  color: hsl(var(--muted-foreground));
+}
+.session-capability-search:focus-within {
+  border-color: hsl(var(--ring) / 0.65);
+  box-shadow: 0 0 0 3px hsl(var(--ring) / 0.1);
+}
+.session-capability-search svg { width: 16px; height: 16px; flex: 0 0 auto; }
+.session-capability-search input {
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: hsl(var(--foreground));
+  font: inherit;
+  font-size: 12px;
+}
+.session-capability-search input::placeholder { color: hsl(var(--muted-foreground) / 0.8); }
+.session-tool-dialog-body {
+  display: flex;
+  min-height: 0;
+  padding: 16px;
+  flex-direction: column;
+  gap: 12px;
+}
+.session-tool-picker {
+  display: flex;
+  min-height: 120px;
+  overflow-y: auto;
+  flex-direction: column;
+  gap: 7px;
+  overscroll-behavior: contain;
+}
+.session-tool-option,
+.session-skill-option {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid hsl(var(--border) / 0.85);
+  border-radius: 10px;
+  background: hsl(var(--background));
+}
+.session-tool-option { min-height: 72px; padding: 10px 11px; }
+.session-tool-option:hover,
+.session-skill-option:hover { border-color: hsl(var(--foreground) / 0.2); background: hsl(var(--muted) / 0.22); }
+.session-tool-option-icon {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 32px;
+  border-radius: 9px;
+  background: hsl(var(--muted) / 0.75);
+  color: hsl(var(--foreground) / 0.78);
+  place-items: center;
+}
+.session-tool-option-icon svg { width: 17px; height: 17px; }
+.session-tool-option-copy,
+.session-skill-option-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+}
+.session-tool-option-copy { gap: 2px; }
+.session-tool-option-copy strong,
+.session-skill-option-copy strong {
+  overflow: hidden;
+  color: hsl(var(--foreground));
+  font-size: 12.5px;
+  font-weight: 620;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.session-skill-option-copy strong {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+.session-tool-option-copy code {
+  color: hsl(var(--muted-foreground));
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 10px;
+}
+.session-tool-option-copy > span,
+.session-skill-option-copy > span {
+  display: -webkit-box;
+  overflow: hidden;
+  color: hsl(var(--muted-foreground));
+  font-size: 11px;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+.session-tool-option > button,
+.session-skill-option > button {
+  display: inline-flex;
+  min-width: 58px;
+  height: 30px;
+  padding: 0 10px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  border: 0;
+  border-radius: 8px;
+  background: hsl(var(--foreground));
+  color: hsl(var(--background));
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.session-tool-option > button:disabled,
+.session-skill-option > button:disabled { opacity: 0.42; cursor: default; }
+.session-skill-option > button svg { width: 13px; height: 13px; }
+.session-skill-dialog-body {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+}
+.session-skill-source-tabs {
+  display: flex;
+  min-height: 48px;
+  padding: 0 18px;
+  align-items: stretch;
+  gap: 24px;
+  border-bottom: 1px solid hsl(var(--border));
+}
+.session-skill-source-tabs button {
+  position: relative;
+  display: inline-flex;
+  padding: 0 2px;
+  align-items: center;
+  gap: 7px;
+  border: 0;
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.session-skill-source-tabs button::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  bottom: -1px;
+  left: 0;
+  height: 2px;
+  border-radius: 2px 2px 0 0;
+  background: transparent;
+}
+.session-skill-source-tabs button:hover,
+.session-skill-source-tabs button.is-active { color: hsl(var(--foreground)); }
+.session-skill-source-tabs button.is-active::after { background: hsl(var(--foreground)); }
+.session-skill-source-tabs button > span {
+  display: inline-flex;
+  height: 18px;
+  padding: 0 6px;
+  align-items: center;
+  border-radius: 5px;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  font-size: 9.5px;
+  font-weight: 600;
+}
+.session-public-skill-browser {
+  display: flex;
+  min-height: 0;
+  height: min(548px, calc(100vh - 204px));
+  flex: 1;
+  flex-direction: column;
+}
+.session-public-skill-head {
+  display: flex;
+  min-height: 68px;
+  padding: 13px 16px;
+  align-items: center;
+  gap: 12px;
+}
+.session-public-skill-head .session-capability-search { flex: 1; }
+.session-public-skill-head > span {
+  flex: 0 0 auto;
+  color: hsl(var(--muted-foreground));
+  font-size: 10.5px;
+}
+.session-public-skill-list {
+  display: grid;
+  min-height: 0;
+  padding: 12px;
+  overflow-y: auto;
+  flex: 1;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-content: start;
+  gap: 8px;
+  overscroll-behavior: contain;
+}
+.session-public-skill-list > .session-capability-empty,
+.session-public-skill-list > .session-capability-loading,
+.session-public-skill-list > .session-capability-error { grid-column: 1 / -1; }
+.session-public-skill-option { min-height: 106px; padding: 11px; }
+.session-public-skill-option .session-skill-option-copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.session-skill-browser {
+  display: grid;
+  min-height: 0;
+  height: min(548px, calc(100vh - 204px));
+  flex: 1;
+  grid-template-columns: minmax(260px, 0.8fr) minmax(360px, 1.4fr);
+}
+.session-skill-spaces,
+.session-skill-results {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+.session-skill-spaces { border-right: 1px solid hsl(var(--border)); background: hsl(var(--muted) / 0.16); }
+.session-skill-pane-head {
+  display: flex;
+  min-height: 92px;
+  padding: 13px 14px;
+  flex-direction: column;
+  gap: 10px;
+}
+.session-skill-pane-head > div { display: flex; min-width: 0; align-items: center; gap: 7px; }
+.session-skill-pane-head strong {
+  overflow: hidden;
+  color: hsl(var(--foreground));
+  font-size: 12.5px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.session-skill-pane-head > div > span {
+  display: inline-flex;
+  min-width: 19px;
+  height: 18px;
+  padding: 0 5px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  font-size: 10px;
+}
+.session-skill-pane-list {
+  display: flex;
+  min-height: 0;
+  padding: 10px;
+  overflow-y: auto;
+  flex: 1;
+  flex-direction: column;
+  gap: 7px;
+  overscroll-behavior: contain;
+}
+.session-skill-space {
+  display: flex;
+  width: 100%;
+  min-height: 76px;
+  padding: 10px;
+  align-items: flex-start;
+  gap: 9px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  color: hsl(var(--foreground));
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.session-skill-space:hover { background: hsl(var(--background) / 0.72); }
+.session-skill-space.is-active {
+  border-color: hsl(var(--primary) / 0.28);
+  background: hsl(var(--background));
+  box-shadow: 0 1px 3px hsl(var(--foreground) / 0.06);
+}
+.session-skill-space > span:last-child { display: flex; min-width: 0; flex: 1; flex-direction: column; gap: 3px; }
+.session-skill-space strong,
+.session-skill-space small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.session-skill-space strong { font-size: 12px; font-weight: 620; }
+.session-skill-space small { color: hsl(var(--muted-foreground)); font-size: 10.5px; }
+.session-skill-space em { color: hsl(var(--muted-foreground)); font-size: 10px; font-style: normal; }
+.session-skill-option { min-height: 82px; padding: 11px; }
+.session-skill-option-copy { gap: 4px; }
+.session-skill-option-copy small { color: hsl(var(--muted-foreground) / 0.84); font-size: 9.5px; }
+.session-capability-empty,
+.session-capability-loading,
+.session-capability-error {
+  display: flex;
+  min-height: 120px;
+  align-items: center;
+  justify-content: center;
+  color: hsl(var(--muted-foreground));
+  font-size: 12px;
+  text-align: center;
+}
+.session-capability-error { color: hsl(var(--destructive)); }
+@media (max-width: 720px) {
+  .session-capability-dialog-layer { padding: 12px; }
+  .session-capability-dialog.is-wide {
+    width: calc(100vw - 24px);
+    height: calc(100dvh - 24px);
+  }
+  .session-skill-browser {
+    height: min(620px, calc(100vh - 170px));
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(180px, 0.75fr) minmax(260px, 1.25fr);
+  }
+  .session-public-skill-browser { height: min(620px, calc(100vh - 170px)); }
+  .session-public-skill-list { grid-template-columns: 1fr; }
+  .session-skill-spaces { border-right: 0; border-bottom: 1px solid hsl(var(--border)); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .session-capability-dialog { animation: none; }
 }
 
 .drawer--agent-info {

--- a/frontend/src/ui/AgentTopology.tsx
+++ b/frontend/src/ui/AgentTopology.tsx
@@ -1,7 +1,17 @@
-import { useEffect, type ReactNode, type RefObject } from "react";
-import type { AgentInfo, AgentNode, AgentNodeType } from "../adk/client";
+import { useEffect, useState, type RefObject } from "react";
+import type {
+  AddSessionCapability,
+  AgentInfo,
+  AgentNode,
+  AgentNodeType,
+  SessionCapabilities,
+} from "../adk/client";
 import { AgentIdentityIcon } from "./AgentIdentityIcon";
-import { SkillCapabilityIcon, ToolCapabilityIcon } from "./CapabilityIcons";
+import {
+  sessionToolLabel,
+  SkillCapabilityDialog,
+  ToolCapabilityDialog,
+} from "./SessionCapabilityDialogs";
 import { TextShimmer } from "./text-shimmer/TextShimmer";
 
 const TYPE_LABELS: Record<AgentNodeType, string> = {
@@ -114,14 +124,12 @@ function TopoNode({
 
 interface ModuleTitleProps {
   title: string;
-  icon: ReactNode;
   count: number;
 }
 
-function ModuleTitle({ title, icon, count }: ModuleTitleProps) {
+function ModuleTitle({ title, count }: ModuleTitleProps) {
   return (
     <div className="topo-module-title">
-      {icon}
       <span className="topo-module-label" title={title}>{title}</span>
       <span className="topo-section-count" aria-label={`${count} 项`}>
         {count}
@@ -131,25 +139,40 @@ function ModuleTitle({ title, icon, count }: ModuleTitleProps) {
 }
 
 interface AgentInfoPanelProps {
+  appName: string;
   info: AgentInfo | null;
   loading: boolean;
   activeAgent: string;
   seenAgents: Set<string>;
   execPath?: string[];
   variant?: "rail" | "drawer";
+  capabilities?: SessionCapabilities | null;
+  capabilityLoading?: boolean;
+  capabilityMutating?: boolean;
+  builtinTools?: string[];
+  onAddCapability?: (capability: AddSessionCapability) => Promise<boolean>;
+  onRemoveCapability?: (capabilityId: string) => void;
 }
 
 /** Agent metadata and optional multi-Agent topology shown in the conversation's
  * right whitespace. The parent owns metadata loading so this display component
  * never issues a duplicate `/web/agent-info` request. */
 export function AgentInfoPanel({
+  appName,
   info,
   loading,
   activeAgent,
   seenAgents,
   execPath = [],
   variant = "rail",
+  capabilities = null,
+  capabilityLoading = false,
+  capabilityMutating = false,
+  builtinTools = [],
+  onAddCapability,
+  onRemoveCapability,
 }: AgentInfoPanelProps) {
+  const [dialog, setDialog] = useState<"tool" | "skill" | null>(null);
   if (loading && !info) {
     return (
       <aside
@@ -179,9 +202,20 @@ export function AgentInfoPanel({
       children: [],
     },
   );
-  const hasTopology = graph.children.length > 0;
-  const tools = uniqueValues(info.tools);
-  const skills = uniqueSkills(info.skills);
+  const tools = capabilities?.tools ?? uniqueValues(info.tools).map((name) => ({
+    id: `base:tool:${name}`,
+    kind: "tool" as const,
+    name,
+    custom: false,
+  }));
+  const skills = capabilities?.skills ?? uniqueSkills(info.skills).map((skill) => ({
+    id: `base:skill:${skill.name}`,
+    kind: "skill" as const,
+    name: skill.name,
+    description: skill.description,
+    custom: false,
+  }));
+  const canCustomize = Boolean(capabilities && onAddCapability && onRemoveCapability);
   const pathSet = new Set(execPath);
   const displayNames = new Map<string, string>();
   collectDisplayNames(graph, displayNames);
@@ -210,7 +244,6 @@ export function AgentInfoPanel({
           <ModuleTitle
             title="工具"
             count={tools.length}
-            icon={<ToolCapabilityIcon className="topo-section-icon" />}
           />
           <div
             className="topo-module-scroll topo-tools-scroll"
@@ -221,22 +254,53 @@ export function AgentInfoPanel({
             {tools.length > 0 ? (
               <div className="topo-tool-list">
                 {tools.map((tool) => (
-                  <span key={tool} className="topo-tool" title={tool}>
-                    {tool}
-                  </span>
+                  <div key={tool.id} className="topo-tool" title={tool.name}>
+                    <span className="topo-capability-title">
+                      <span className="topo-capability-copy">
+                        <span className="topo-capability-name">{sessionToolLabel(tool.name)}</span>
+                        <code>{tool.name}</code>
+                      </span>
+                      {tool.custom && <span className="topo-custom-badge">自定义</span>}
+                    </span>
+                    {tool.custom && (
+                      <button
+                        type="button"
+                        className="topo-remove-capability"
+                        aria-label={`移除工具 ${tool.name}`}
+                        title="移除"
+                        disabled={capabilityMutating}
+                        onClick={() => onRemoveCapability?.(tool.id)}
+                      >
+                        ×
+                      </button>
+                    )}
+                  </div>
                 ))}
               </div>
             ) : (
               <div className="topo-empty">未配置</div>
             )}
           </div>
+          {canCustomize && (
+            <div className="topo-capability-add-dock">
+              <button
+                type="button"
+                className="topo-capability-add-slot"
+                aria-label="添加内置工具"
+                disabled={capabilityLoading || capabilityMutating}
+                onClick={() => setDialog("tool")}
+              >
+                <span aria-hidden="true">＋</span>
+                <span>在此对话中添加工具</span>
+              </button>
+            </div>
+          )}
         </section>
 
         <section className="topo-module-card topo-skills-card" aria-label="技能">
           <ModuleTitle
             title="技能"
             count={skills.length}
-            icon={<SkillCapabilityIcon className="topo-section-icon" />}
           />
           <div
             className="topo-module-scroll topo-skills-scroll"
@@ -252,7 +316,22 @@ export function AgentInfoPanel({
                     className="topo-skill"
                     title={skill.description || skill.name}
                   >
-                    <span className="topo-skill-name">{skill.name}</span>
+                    <div className="topo-skill-title">
+                      <span className="topo-skill-name">{skill.name}</span>
+                      {skill.custom && <span className="topo-custom-badge">自定义</span>}
+                      {skill.custom && (
+                        <button
+                          type="button"
+                          className="topo-remove-capability"
+                          aria-label={`移除技能 ${skill.name}`}
+                          title="移除"
+                          disabled={capabilityMutating}
+                          onClick={() => onRemoveCapability?.(skill.id)}
+                        >
+                          ×
+                        </button>
+                      )}
+                    </div>
                     {skill.description && (
                       <span className="topo-skill-description">
                         {skill.description}
@@ -265,13 +344,26 @@ export function AgentInfoPanel({
               <div className="topo-empty">未配置</div>
             )}
           </div>
+          {canCustomize && (
+            <div className="topo-capability-add-dock">
+              <button
+                type="button"
+                className="topo-capability-add-slot"
+                aria-label="添加技能"
+                disabled={capabilityLoading || capabilityMutating}
+                onClick={() => setDialog("skill")}
+              >
+                <span aria-hidden="true">＋</span>
+                <span>在此对话中添加技能</span>
+              </button>
+            </div>
+          )}
         </section>
 
         <section className="topo-module-card topo-topology" aria-label="Agent 拓扑">
           <ModuleTitle
             title="拓扑"
             count={totalNodes(graph)}
-            icon={<AgentIdentityIcon className="topo-section-icon" />}
           />
           <div
             className="topo-module-scroll topo-topology-scroll"
@@ -279,43 +371,54 @@ export function AgentInfoPanel({
             aria-label="Agent 拓扑列表"
             tabIndex={0}
           >
-            {hasTopology ? (
-              <>
-                {execPath.length > 0 && (
-                  <div className="topo-path" aria-label="执行路径">
-                    {execPath.map((name, index) => (
-                      <span key={`${name}-${index}`} className="topo-path-seg">
-                        <span
-                          className={
-                            index === execPath.length - 1
-                              ? "topo-path-name is-current"
-                              : "topo-path-name"
-                          }
-                        >
-                          {displayNames.get(name) ?? name}
-                        </span>
-                      </span>
-                    ))}
-                  </div>
-                )}
-                <div className="topo-tree">
-                  <TopoNode
-                    node={graph}
-                    activeAgent={activeAgent}
-                    seen={seenAgents}
-                    path={pathSet}
-                  />
-                </div>
-              </>
-            ) : (
-              <div className="topo-topology-empty">
-                <span className="topo-topology-line" aria-hidden="true" />
-                <span>单 Agent，无协作拓扑</span>
+            {execPath.length > 1 && (
+              <div className="topo-path" aria-label="执行路径">
+                {execPath.map((name, index) => (
+                  <span key={`${name}-${index}`} className="topo-path-seg">
+                    <span
+                      className={
+                        index === execPath.length - 1
+                          ? "topo-path-name is-current"
+                          : "topo-path-name"
+                      }
+                    >
+                      {displayNames.get(name) ?? name}
+                    </span>
+                  </span>
+                ))}
               </div>
             )}
+            <div className="topo-tree">
+              <TopoNode
+                node={graph}
+                activeAgent={activeAgent}
+                seen={seenAgents}
+                path={pathSet}
+              />
+            </div>
           </div>
         </section>
       </div>
+      {dialog === "tool" && onAddCapability && (
+        <ToolCapabilityDialog
+          agentName={info.name}
+          tools={builtinTools}
+          selectedNames={tools.map((tool) => tool.name)}
+          mutating={capabilityMutating}
+          onAdd={onAddCapability}
+          onClose={() => setDialog(null)}
+        />
+      )}
+      {dialog === "skill" && onAddCapability && (
+        <SkillCapabilityDialog
+          appName={appName}
+          agentName={info.name}
+          selectedNames={skills.map((skill) => skill.name)}
+          mutating={capabilityMutating}
+          onAdd={onAddCapability}
+          onClose={() => setDialog(null)}
+        />
+      )}
     </aside>
   );
 }
@@ -337,19 +440,33 @@ function CloseIcon() {
 }
 
 export function AgentInfoDrawer({
+  appName,
   info,
   loading,
   activeAgent,
   seenAgents,
   execPath,
+  capabilities,
+  capabilityLoading,
+  capabilityMutating,
+  builtinTools,
+  onAddCapability,
+  onRemoveCapability,
   onClose,
   returnFocusRef,
 }: {
+  appName: string;
   info: AgentInfo | null;
   loading: boolean;
   activeAgent: string;
   seenAgents: Set<string>;
   execPath: string[];
+  capabilities?: SessionCapabilities | null;
+  capabilityLoading?: boolean;
+  capabilityMutating?: boolean;
+  builtinTools?: string[];
+  onAddCapability?: (capability: AddSessionCapability) => Promise<boolean>;
+  onRemoveCapability?: (capabilityId: string) => void;
   onClose: () => void;
   returnFocusRef: RefObject<HTMLButtonElement>;
 }) {
@@ -396,11 +513,18 @@ export function AgentInfoDrawer({
         <div className="agent-info-drawer-body">
           {info || loading ? (
             <AgentInfoPanel
+              appName={appName}
               info={info}
               loading={loading}
               activeAgent={activeAgent}
               seenAgents={seenAgents}
               execPath={execPath}
+              capabilities={capabilities}
+              capabilityLoading={capabilityLoading}
+              capabilityMutating={capabilityMutating}
+              builtinTools={builtinTools}
+              onAddCapability={onAddCapability}
+              onRemoveCapability={onRemoveCapability}
               variant="drawer"
             />
           ) : (

--- a/frontend/src/ui/Blocks.tsx
+++ b/frontend/src/ui/Blocks.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { ChevronRight, Loader2, ShieldCheck } from "lucide-react";
 import { motion } from "motion/react";
 import type { Block } from "../blocks";
@@ -14,6 +14,99 @@ import { ToolDisclosureIcon } from "./builtin-tools/icons";
 import { getBuiltinToolDefinition } from "./builtin-tools/registry";
 
 const A2UI_TOOL = "send_a2ui_json_to_client";
+const STREAM_FRAME_INTERVAL_MS = 28;
+
+function advanceCodePoints(text: string, start: number, count: number): number {
+  let index = start;
+  for (let step = 0; step < count && index < text.length; step += 1) {
+    const codePoint = text.codePointAt(index);
+    index += codePoint !== undefined && codePoint > 0xffff ? 2 : 1;
+  }
+  return index;
+}
+
+function streamChunkSize(remaining: number): number {
+  if (remaining <= 4) return 1;
+  return Math.min(18, Math.max(2, Math.ceil(remaining / 6)));
+}
+
+function useSmoothStreamingText(
+  text: string,
+  streaming: boolean,
+  onFrame?: () => void,
+): string {
+  const [displayed, setDisplayed] = useState(() => (streaming ? "" : text));
+  const displayedRef = useRef(displayed);
+  const targetRef = useRef(text);
+  const frameRef = useRef<number | null>(null);
+  const lastFrameRef = useRef(0);
+  const onFrameRef = useRef(onFrame);
+  targetRef.current = text;
+  onFrameRef.current = onFrame;
+
+  useEffect(() => {
+    const current = displayedRef.current;
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (!streaming || reduceMotion || !text.startsWith(current)) {
+      if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+      if (current !== text) {
+        displayedRef.current = text;
+        setDisplayed(text);
+      }
+      return;
+    }
+    if (current === text || frameRef.current !== null) return;
+
+    const renderFrame = (timestamp: number) => {
+      const target = targetRef.current;
+      const visible = displayedRef.current;
+      if (!target.startsWith(visible)) {
+        displayedRef.current = target;
+        setDisplayed(target);
+        frameRef.current = null;
+        return;
+      }
+      if (timestamp - lastFrameRef.current < STREAM_FRAME_INTERVAL_MS) {
+        frameRef.current = window.requestAnimationFrame(renderFrame);
+        return;
+      }
+
+      const remaining = target.length - visible.length;
+      if (remaining <= 0) {
+        frameRef.current = null;
+        return;
+      }
+      const end = advanceCodePoints(
+        target,
+        visible.length,
+        streamChunkSize(remaining),
+      );
+      const next = target.slice(0, end);
+      displayedRef.current = next;
+      lastFrameRef.current = timestamp;
+      setDisplayed(next);
+      frameRef.current = next === target
+        ? null
+        : window.requestAnimationFrame(renderFrame);
+    };
+
+    frameRef.current = window.requestAnimationFrame(renderFrame);
+  }, [streaming, text]);
+
+  useLayoutEffect(() => {
+    onFrameRef.current?.();
+  }, [displayed]);
+
+  useEffect(() => () => {
+    if (frameRef.current !== null) {
+      window.cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    }
+  }, []);
+
+  return displayed;
+}
 
 /** Hand-drawn "spark" icon for the thinking indicator. */
 function SparkIcon({ className }: { className?: string }) {
@@ -41,7 +134,26 @@ function GenericToolIcon() {
   );
 }
 
-export function ThinkingBlock({ text, done }: { text: string; done: boolean }) {
+function loadSkillLabel(name: string, args: unknown): string | undefined {
+  if (name !== "load_skill" || args == null || typeof args !== "object" || Array.isArray(args)) {
+    return undefined;
+  }
+  const skillName = (args as Record<string, unknown>).skill_name;
+  if (typeof skillName !== "string" || !skillName.trim()) return undefined;
+  return `使用 ${skillName.trim()} 技能`;
+}
+
+export function ThinkingBlock({
+  text,
+  done,
+  streaming = false,
+  onStreamFrame,
+}: {
+  text: string;
+  done: boolean;
+  streaming?: boolean;
+  onStreamFrame?: () => void;
+}) {
   // Expanded while thinking; auto-collapses when done. A manual toggle wins.
   const [open, setOpen] = useState(!done);
   const touched = useRef(false);
@@ -53,7 +165,8 @@ export function ThinkingBlock({ text, done }: { text: string; done: boolean }) {
     setOpen((o) => !o);
   };
   const body = text.replace(/^\s+/, "");
-  const { ref, onScroll } = useStickToBottom<HTMLDivElement>(body);
+  const displayedBody = useSmoothStreamingText(body, !done || streaming, onStreamFrame);
+  const { ref, onScroll } = useStickToBottom<HTMLDivElement>(displayedBody);
   return (
     <div className="block-thinking">
       <button className="think-head" onClick={toggle} type="button">
@@ -69,10 +182,10 @@ export function ThinkingBlock({ text, done }: { text: string; done: boolean }) {
         )}
         <ChevronRight className={`chev ${open ? "open" : ""}`} />
       </button>
-      <div className={`think-collapse ${open && body ? "open" : ""}`}>
+      <div className={`think-collapse ${open && displayedBody ? "open" : ""}`}>
         <div className="think-collapse-inner">
           <div className="think-body scroll" ref={ref} onScroll={onScroll}>
-            {body}
+            {displayedBody}
           </div>
         </div>
       </div>
@@ -85,6 +198,23 @@ export function ThinkingBlock({ text, done }: { text: string; done: boolean }) {
 export function ThinkingPlaceholder() {
   return <ThinkingBlock text="" done={false} />;
 }
+
+const StreamingTextBlock = memo(function StreamingTextBlock({
+  text,
+  streaming,
+  onStreamFrame,
+}: {
+  text: string;
+  streaming: boolean;
+  onStreamFrame?: () => void;
+}) {
+  const displayedText = useSmoothStreamingText(text, streaming, onStreamFrame);
+  return displayedText ? (
+    <div className="bubble">
+      <Markdown text={displayedText} />
+    </div>
+  ) : null;
+});
 
 /** Tool-call row. Dedicated built-ins use their registered icon and Chinese
  *  status copy; other tools use a neutral repository-drawn tool icon. Both
@@ -121,6 +251,7 @@ function ToolBlock({
       {builtinTool ? (
         <BuiltinToolHeader
           definition={builtinTool}
+          label={loadSkillLabel(name, args)}
           done={done}
           open={open}
           onToggle={() => setOpen((value) => !value)}
@@ -268,24 +399,44 @@ function AuthCard({
 export interface BlocksProps {
   blocks: Block[];
   appName?: string;
+  streaming?: boolean;
+  onStreamFrame?: () => void;
   onAction: (action: A2uiAction | undefined, node: A2uiComponent) => void;
   /** Handle an MCP/tool OAuth request (opens auth URL, resumes the run). */
   onAuth?: (block: AuthBlock) => Promise<void>;
 }
 
-export function Blocks({ blocks, appName = "", onAction, onAuth }: BlocksProps) {
+export function Blocks({
+  blocks,
+  appName = "",
+  streaming = false,
+  onStreamFrame,
+  onAction,
+  onAuth,
+}: BlocksProps) {
   return (
     <>
       {blocks.map((b, i) => {
         switch (b.kind) {
           case "thinking":
-            return <ThinkingBlock key={i} text={b.text} done={b.done} />;
+            return (
+              <ThinkingBlock
+                key={i}
+                text={b.text}
+                done={b.done}
+                streaming={streaming}
+                onStreamFrame={onStreamFrame}
+              />
+            );
           case "text": {
             const t = b.text.replace(/^\s+/, "");
             return t ? (
-              <div key={i} className="bubble">
-                <Markdown text={t} />
-              </div>
+              <StreamingTextBlock
+                key={i}
+                text={t}
+                streaming={streaming}
+                onStreamFrame={onStreamFrame}
+              />
             ) : null;
           }
           case "attachment":

--- a/frontend/src/ui/SessionCapabilityDialogs.tsx
+++ b/frontend/src/ui/SessionCapabilityDialogs.tsx
@@ -1,0 +1,556 @@
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import {
+  listSessionSkillsInSpace,
+  listSessionSkillSpaces,
+  searchSessionPublicSkills,
+  type AddSessionCapability,
+  type SessionPublicSkill,
+  type SessionSkillCatalogItem,
+  type SessionSkillSpace,
+} from "../adk/client";
+import { BUILTIN_TOOLS } from "../create/veadkCatalog";
+import { ToolCapabilityIcon } from "./CapabilityIcons";
+
+const SESSION_TOOL_LABELS: Record<string, string> = {
+  coding: "智能编程",
+  get_city_weather: "城市天气查询",
+  get_location_weather: "位置天气查询",
+  web_fetch: "网页内容获取",
+};
+
+export function sessionToolLabel(name: string): string {
+  const catalogTool = BUILTIN_TOOLS.find(
+    (tool) => tool.id === name || tool.toolNames.includes(name),
+  );
+  return SESSION_TOOL_LABELS[name] ?? catalogTool?.label ?? name;
+}
+
+function sessionToolDescription(name: string): string {
+  const catalogTool = BUILTIN_TOOLS.find(
+    (tool) => tool.id === name || tool.toolNames.includes(name),
+  );
+  const description = catalogTool?.desc ?? "由 VeADK 提供的内置工具";
+  return description.replace(/[。.]+$/, "");
+}
+
+function CloseIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="m7 7 10 10M17 7 7 17" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="10.8" cy="10.8" r="5.8" stroke="currentColor" strokeWidth="1.7" />
+      <path d="m15.2 15.2 4 4" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function PlusIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M12 5.5v13M5.5 12h13" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function DialogShell({
+  title,
+  description,
+  icon,
+  wide = false,
+  onClose,
+  children,
+}: {
+  title: string;
+  description: string;
+  icon?: ReactNode;
+  wide?: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  const titleId = useRef(`session-capability-${Math.random().toString(36).slice(2)}`);
+
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [onClose]);
+
+  return createPortal(
+    <div className="session-capability-dialog-layer">
+      <button
+        type="button"
+        className="session-capability-dialog-scrim"
+        aria-label="关闭弹窗"
+        onClick={onClose}
+      />
+      <section
+        className={`session-capability-dialog${wide ? " is-wide" : ""}`}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId.current}
+      >
+        <header className={`session-capability-dialog-head${icon ? "" : " is-iconless"}`}>
+          {icon && <span className="session-capability-dialog-mark">{icon}</span>}
+          <div>
+            <h2 id={titleId.current}>{title}</h2>
+            <p>{description}</p>
+          </div>
+          <button
+            type="button"
+            className="session-capability-dialog-close"
+            aria-label={`关闭${title}`}
+            onClick={onClose}
+          >
+            <CloseIcon />
+          </button>
+        </header>
+        {children}
+      </section>
+    </div>,
+    document.body,
+  );
+}
+
+function SearchField({
+  value,
+  placeholder,
+  label,
+  onChange,
+  autoFocus = false,
+}: {
+  value: string;
+  placeholder: string;
+  label: string;
+  onChange: (value: string) => void;
+  autoFocus?: boolean;
+}) {
+  return (
+    <label className="session-capability-search">
+      <SearchIcon />
+      <input
+        value={value}
+        aria-label={label}
+        placeholder={placeholder}
+        autoFocus={autoFocus}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    </label>
+  );
+}
+
+export function ToolCapabilityDialog({
+  agentName,
+  tools,
+  selectedNames,
+  mutating,
+  onAdd,
+  onClose,
+}: {
+  agentName: string;
+  tools: string[];
+  selectedNames: string[];
+  mutating: boolean;
+  onAdd: (capability: AddSessionCapability) => Promise<boolean>;
+  onClose: () => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [pending, setPending] = useState("");
+  const selected = useMemo(() => new Set(selectedNames), [selectedNames]);
+  const filteredTools = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    return tools.filter((name) => {
+      if (!normalized) return true;
+      return `${sessionToolLabel(name)} ${name} ${sessionToolDescription(name)}`
+        .toLowerCase()
+        .includes(normalized);
+    });
+  }, [query, tools]);
+
+  const addTool = async (name: string) => {
+    setPending(name);
+    const added = await onAdd({ kind: "tool", name });
+    setPending("");
+    if (added) onClose();
+  };
+
+  return (
+    <DialogShell
+      title="添加内置工具"
+      description={`添加后仅对 ${agentName} 的当前会话生效`}
+      icon={<ToolCapabilityIcon />}
+      onClose={onClose}
+    >
+      <div className="session-tool-dialog-body">
+        <SearchField
+          value={query}
+          label="搜索内置工具"
+          placeholder="搜索中文名称或工具标识"
+          onChange={setQuery}
+          autoFocus
+        />
+        <div className="session-tool-picker" role="list" aria-label="可用内置工具">
+          {filteredTools.length === 0 ? (
+            <div className="session-capability-empty">没有匹配的内置工具</div>
+          ) : (
+            filteredTools.map((name) => {
+              const added = selected.has(name);
+              const isPending = pending === name;
+              return (
+                <article key={name} className="session-tool-option" role="listitem">
+                  <span className="session-tool-option-icon"><ToolCapabilityIcon /></span>
+                  <span className="session-tool-option-copy">
+                    <strong>{sessionToolLabel(name)}</strong>
+                    <code>{name}</code>
+                    <span>{sessionToolDescription(name)}</span>
+                  </span>
+                  <button
+                    type="button"
+                    disabled={added || mutating || Boolean(pending)}
+                    onClick={() => void addTool(name)}
+                  >
+                    {added ? "已添加" : isPending ? "添加中…" : "添加"}
+                  </button>
+                </article>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </DialogShell>
+  );
+}
+
+export function SkillCapabilityDialog({
+  appName,
+  agentName,
+  selectedNames,
+  mutating,
+  onAdd,
+  onClose,
+}: {
+  appName: string;
+  agentName: string;
+  selectedNames: string[];
+  mutating: boolean;
+  onAdd: (capability: AddSessionCapability) => Promise<boolean>;
+  onClose: () => void;
+}) {
+  const [sourceTab, setSourceTab] = useState<"public" | "agentkit">("public");
+  const [publicQuery, setPublicQuery] = useState("");
+  const [publicSkills, setPublicSkills] = useState<SessionPublicSkill[]>([]);
+  const [publicTotal, setPublicTotal] = useState(0);
+  const [publicLoading, setPublicLoading] = useState(true);
+  const [publicError, setPublicError] = useState("");
+  const [spaces, setSpaces] = useState<SessionSkillSpace[]>([]);
+  const [selectedSpace, setSelectedSpace] = useState<SessionSkillSpace | null>(null);
+  const [skills, setSkills] = useState<SessionSkillCatalogItem[]>([]);
+  const [spaceQuery, setSpaceQuery] = useState("");
+  const [skillQuery, setSkillQuery] = useState("");
+  const [spacesLoading, setSpacesLoading] = useState(true);
+  const [skillsLoading, setSkillsLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [pending, setPending] = useState("");
+  const selected = useMemo(() => new Set(selectedNames), [selectedNames]);
+
+  useEffect(() => {
+    if (sourceTab !== "public") return;
+    let active = true;
+    const timer = window.setTimeout(() => {
+      setPublicLoading(true);
+      setPublicError("");
+      void searchSessionPublicSkills(appName, publicQuery.trim())
+        .then((result) => {
+          if (!active) return;
+          setPublicSkills(result.items);
+          setPublicTotal(result.totalCount);
+        })
+        .catch((reason: unknown) => {
+          if (!active) return;
+          setPublicSkills([]);
+          setPublicTotal(0);
+          setPublicError(reason instanceof Error ? reason.message : "搜索 Skill Hub 失败");
+        })
+        .finally(() => {
+          if (active) setPublicLoading(false);
+        });
+    }, 250);
+    return () => {
+      active = false;
+      window.clearTimeout(timer);
+    };
+  }, [appName, publicQuery, sourceTab]);
+
+  useEffect(() => {
+    if (sourceTab !== "agentkit") return;
+    let active = true;
+    setSpacesLoading(true);
+    setError("");
+    void listSessionSkillSpaces(appName)
+      .then((items) => {
+        if (!active) return;
+        setSpaces(items);
+        setSelectedSpace(items[0] ?? null);
+      })
+      .catch((reason: unknown) => {
+        if (active) setError(reason instanceof Error ? reason.message : "读取 Skill Space 失败");
+      })
+      .finally(() => {
+        if (active) setSpacesLoading(false);
+      });
+    return () => { active = false; };
+  }, [appName, sourceTab]);
+
+  useEffect(() => {
+    if (sourceTab !== "agentkit") return;
+    if (!selectedSpace) {
+      setSkills([]);
+      return;
+    }
+    let active = true;
+    setSkillsLoading(true);
+    setError("");
+    void listSessionSkillsInSpace(appName, selectedSpace.id, selectedSpace.region)
+      .then((items) => {
+        if (active) setSkills(items);
+      })
+      .catch((reason: unknown) => {
+        if (active) setError(reason instanceof Error ? reason.message : "读取技能失败");
+      })
+      .finally(() => {
+        if (active) setSkillsLoading(false);
+      });
+    return () => { active = false; };
+  }, [appName, selectedSpace, sourceTab]);
+
+  const filteredSpaces = useMemo(() => {
+    const normalized = spaceQuery.trim().toLowerCase();
+    if (!normalized) return spaces;
+    return spaces.filter((space) =>
+      `${space.name} ${space.id} ${space.description}`.toLowerCase().includes(normalized),
+    );
+  }, [spaceQuery, spaces]);
+
+  const filteredSkills = useMemo(() => {
+    const normalized = skillQuery.trim().toLowerCase();
+    if (!normalized) return skills;
+    return skills.filter((skill) =>
+      `${skill.skillName} ${skill.skillDescription}`.toLowerCase().includes(normalized),
+    );
+  }, [skillQuery, skills]);
+
+  const addSkill = async (skill: SessionSkillCatalogItem) => {
+    if (!selectedSpace) return;
+    setPending(skill.skillId);
+    const added = await onAdd({
+      kind: "skill",
+      name: skill.skillName,
+      skillSourceId: selectedSpace.id,
+      description: skill.skillDescription,
+      version: skill.version,
+    });
+    setPending("");
+    if (added) onClose();
+  };
+
+  const addPublicSkill = async (skill: SessionPublicSkill) => {
+    setPending(skill.slug);
+    const added = await onAdd({
+      kind: "skill",
+      name: skill.name,
+      skillSourceId: `findskill:${skill.slug}`,
+      description: skill.description,
+      version: skill.version || skill.updatedAt,
+    });
+    setPending("");
+    if (added) onClose();
+  };
+
+  return (
+    <DialogShell
+      title="添加技能"
+      description={`从公域 Skill Hub 或 AgentKit Skill 中心添加到 ${agentName} 当前会话`}
+      wide
+      onClose={onClose}
+    >
+      <div className="session-skill-dialog-body">
+        <div className="session-skill-source-tabs" role="tablist" aria-label="技能来源">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={sourceTab === "public"}
+            className={sourceTab === "public" ? "is-active" : ""}
+            onClick={() => setSourceTab("public")}
+          >
+            Skill Hub
+            <span>公域</span>
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={sourceTab === "agentkit"}
+            className={sourceTab === "agentkit" ? "is-active" : ""}
+            onClick={() => setSourceTab("agentkit")}
+          >
+            AgentKit Skill 中心
+          </button>
+        </div>
+
+        {sourceTab === "public" ? (
+          <section className="session-public-skill-browser" aria-label="Skill Hub 公域技能">
+            <div className="session-public-skill-head">
+              <SearchField
+                value={publicQuery}
+                label="搜索 Skill Hub"
+                placeholder="搜索技能名称、用途或关键词"
+                onChange={setPublicQuery}
+                autoFocus
+              />
+              <span>{publicTotal.toLocaleString()} 个公域技能</span>
+            </div>
+            <div className="session-public-skill-list">
+              {publicError ? (
+                <div className="session-capability-error">{publicError}</div>
+              ) : publicLoading ? (
+                <div className="session-capability-loading">正在搜索 Skill Hub…</div>
+              ) : publicSkills.length === 0 ? (
+                <div className="session-capability-empty">没有匹配的公域技能</div>
+              ) : (
+                publicSkills.map((skill) => {
+                  const added = selected.has(skill.name);
+                  const isPending = pending === skill.slug;
+                  return (
+                    <article key={skill.slug} className="session-skill-option session-public-skill-option">
+                      <span className="session-skill-option-copy">
+                        <strong>{skill.name}</strong>
+                        <span>{skill.description || "暂无描述"}</span>
+                        <small>
+                          {skill.sourceRepo || skill.sourceType || "FindSkill"}
+                          <span aria-hidden="true"> · </span>
+                          {skill.downloadCount.toLocaleString()} 次下载
+                          {skill.evaluationScore > 0 && (
+                            <><span aria-hidden="true"> · </span>{skill.evaluationScore.toFixed(1)} 分</>
+                          )}
+                        </small>
+                      </span>
+                      <button
+                        type="button"
+                        disabled={added || mutating || Boolean(pending)}
+                        onClick={() => void addPublicSkill(skill)}
+                      >
+                        {added ? "已添加" : isPending ? "添加中…" : <><PlusIcon />添加</>}
+                      </button>
+                    </article>
+                  );
+                })
+              )}
+            </div>
+          </section>
+        ) : (
+          <div className="session-skill-browser">
+            <section className="session-skill-spaces" aria-label="Skill Space 列表">
+              <div className="session-skill-pane-head">
+                <div>
+                  <strong>Skill Space</strong>
+                  <span>{spaces.length}</span>
+                </div>
+                <SearchField
+                  value={spaceQuery}
+                  label="搜索 Skill Space"
+                  placeholder="搜索空间"
+                  onChange={setSpaceQuery}
+                  autoFocus
+                />
+              </div>
+              <div className="session-skill-pane-list">
+                {spacesLoading ? (
+                  <div className="session-capability-loading">正在读取 Skill Space…</div>
+                ) : filteredSpaces.length === 0 ? (
+                  <div className="session-capability-empty">没有匹配的 Skill Space</div>
+                ) : (
+                  filteredSpaces.map((space) => (
+                    <button
+                      type="button"
+                      key={`${space.projectName ?? "default"}:${space.id}`}
+                      className={`session-skill-space${selectedSpace?.id === space.id ? " is-active" : ""}`}
+                      onClick={() => {
+                        setSelectedSpace(space);
+                        setSkillQuery("");
+                      }}
+                    >
+                      <span>
+                        <strong>{space.name || space.id}</strong>
+                        <small>{space.description || space.id}</small>
+                        <em>{space.skillCount ?? 0} 个技能</em>
+                      </span>
+                    </button>
+                  ))
+                )}
+              </div>
+            </section>
+
+            <section className="session-skill-results" aria-label="AgentKit Skill 列表">
+              <div className="session-skill-pane-head">
+                <div>
+                  <strong title={selectedSpace?.name}>{selectedSpace?.name || "选择 Skill Space"}</strong>
+                  <span>{skills.length}</span>
+                </div>
+                <SearchField
+                  value={skillQuery}
+                  label="搜索 AgentKit 技能"
+                  placeholder="搜索技能名称或描述"
+                  onChange={setSkillQuery}
+                />
+              </div>
+              <div className="session-skill-pane-list">
+                {error ? (
+                  <div className="session-capability-error">{error}</div>
+                ) : !selectedSpace ? (
+                  <div className="session-capability-empty">选择一个 Skill Space 查看技能</div>
+                ) : skillsLoading ? (
+                  <div className="session-capability-loading">正在读取技能…</div>
+                ) : filteredSkills.length === 0 ? (
+                  <div className="session-capability-empty">没有匹配的技能</div>
+                ) : (
+                  filteredSkills.map((skill) => {
+                    const added = selected.has(skill.skillName);
+                    const isPending = pending === skill.skillId;
+                    return (
+                      <article key={`${skill.skillId}:${skill.version}`} className="session-skill-option">
+                        <span className="session-skill-option-copy">
+                          <strong>{skill.skillName}</strong>
+                          <span>{skill.skillDescription || "暂无描述"}</span>
+                          <small>版本 {skill.version || "—"}</small>
+                        </span>
+                        <button
+                          type="button"
+                          disabled={added || mutating || Boolean(pending)}
+                          onClick={() => void addSkill(skill)}
+                        >
+                          {added ? "已添加" : isPending ? "添加中…" : <><PlusIcon />添加</>}
+                        </button>
+                      </article>
+                    );
+                  })
+                )}
+              </div>
+            </section>
+          </div>
+        )}
+      </div>
+    </DialogShell>
+  );
+}

--- a/frontend/src/ui/builtin-tools/BuiltinToolHeader.tsx
+++ b/frontend/src/ui/builtin-tools/BuiltinToolHeader.tsx
@@ -5,16 +5,19 @@ import "./builtin-tools.css";
 
 export function BuiltinToolHeader({
   definition,
+  label,
   done,
   open,
   onToggle,
 }: {
   definition: BuiltinToolDefinition;
+  label?: string;
   done: boolean;
   open: boolean;
   onToggle: () => void;
 }) {
   const Icon = definition.icon;
+  const statusLabel = label ?? (done ? definition.doneLabel : definition.runningLabel);
 
   return (
     <button
@@ -28,7 +31,7 @@ export function BuiltinToolHeader({
         <Icon />
       </span>
       {done ? (
-        <span className="builtin-tool-label">{definition.doneLabel}</span>
+        <span className="builtin-tool-label">{statusLabel}</span>
       ) : (
         <TextShimmer
           className="builtin-tool-label"
@@ -36,7 +39,7 @@ export function BuiltinToolHeader({
           spread={18}
           aria-live="polite"
         >
-          {definition.runningLabel}
+          {statusLabel}
         </TextShimmer>
       )}
       <ToolDisclosureIcon className={`builtin-tool-chevron${open ? " is-open" : ""}`} />

--- a/frontend/src/ui/builtin-tools/builtin-tools.css
+++ b/frontend/src/ui/builtin-tools/builtin-tools.css
@@ -34,6 +34,10 @@
   --builtin-tool-accent: 225 48% 45%;
 }
 
+.builtin-tool-head[data-tool-tone="skill"] {
+  --builtin-tool-accent: 154 50% 34%;
+}
+
 .builtin-tool-head[data-tool-tone="sandbox"] {
   --builtin-tool-accent: 32 67% 42%;
 }
@@ -58,7 +62,7 @@
 }
 
 .builtin-tool-label {
-  font-size: 13.5px;
+  font-size: 14.5px;
   font-weight: 400;
   line-height: 1.35;
 }

--- a/frontend/src/ui/builtin-tools/icons.tsx
+++ b/frontend/src/ui/builtin-tools/icons.tsx
@@ -98,6 +98,26 @@ export function LoadKnowledgebaseIcon(props: ToolIconProps) {
   );
 }
 
+/** An open skill card with a small activation spark. */
+export function LoadSkillIcon(props: ToolIconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M4.25 6.25h6.25c1 0 1.5.55 1.5 1.45v11.05c0-.9-.5-1.45-1.5-1.45H4.25V6.25Z" />
+      <path d="M19.75 9.1v8.2H13.5c-1 0-1.5.55-1.5 1.45V7.7c0-.9.5-1.45 1.5-1.45h2.15" />
+      <path d="m19 3.2.58 1.62 1.62.58-1.62.58L19 7.6l-.58-1.62-1.62-.58 1.62-.58L19 3.2Z" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
 /** A hand-drawn sandbox with a small code prompt inside. */
 export function RunCodeIcon(props: ToolIconProps) {
   return (

--- a/frontend/src/ui/builtin-tools/registry.ts
+++ b/frontend/src/ui/builtin-tools/registry.ts
@@ -3,6 +3,7 @@ import {
   ImageGenerateIcon,
   LoadKnowledgebaseIcon,
   LoadMemoryIcon,
+  LoadSkillIcon,
   RunCodeIcon,
   VideoGenerateIcon,
   WebSearchIcon,
@@ -14,6 +15,7 @@ export type BuiltinToolTone =
   | "video"
   | "memory"
   | "knowledge"
+  | "skill"
   | "sandbox";
 
 export interface BuiltinToolDefinition {
@@ -66,6 +68,13 @@ const BUILTIN_TOOLS: Readonly<Record<string, BuiltinToolDefinition>> = {
     doneLabel: "已完成知识库检索",
     tone: "knowledge",
     icon: LoadKnowledgebaseIcon,
+  },
+  load_skill: {
+    name: "load_skill",
+    runningLabel: "正在加载技能",
+    doneLabel: "已加载技能",
+    tone: "skill",
+    icon: LoadSkillIcon,
   },
 };
 

--- a/frontend/tests/agentInfoRail.test.mjs
+++ b/frontend/tests/agentInfoRail.test.mjs
@@ -10,6 +10,14 @@ const railSource = readFileSync(
   new URL("../src/ui/AgentTopology.tsx", import.meta.url),
   "utf8",
 );
+const capabilityDialogsSource = readFileSync(
+  new URL("../src/ui/SessionCapabilityDialogs.tsx", import.meta.url),
+  "utf8",
+);
+const clientSource = readFileSync(
+  new URL("../src/adk/client.ts", import.meta.url),
+  "utf8",
+);
 const navbarSource = readFileSync(
   new URL("../src/ui/Navbar.tsx", import.meta.url),
   "utf8",
@@ -27,19 +35,34 @@ test("reuses loaded Agent metadata for the conversation information rail", () =>
   assert.match(appSource, /<AgentInfoPanel[\s\S]*?info=\{agentInfo\}/);
   assert.match(appSource, /<AgentInfoPanel[\s\S]*?loading=\{capabilitiesLoading\}/);
   assert.match(railSource, /info: AgentInfo \| null/);
-  assert.doesNotMatch(railSource, /getAgentInfo|useState/);
+  assert.doesNotMatch(railSource, /getAgentInfo/);
 });
 
-test("shows Agent tools and skills before the optional topology", () => {
+test("shows Agent tools, skills, and topology for every Agent", () => {
   assert.match(railSource, /Agent 信息/);
   assert.match(railSource, /title="工具"/);
   assert.match(railSource, /title="技能"/);
   assert.match(railSource, /未配置/);
-  assert.match(railSource, /const hasTopology = graph\.children\.length > 0/);
+  assert.doesNotMatch(railSource, /const hasTopology/);
   assert.match(railSource, /className="topo-module-card topo-tools-card"/);
   assert.match(railSource, /className="topo-module-card topo-skills-card"/);
   assert.match(railSource, /className="topo-module-card topo-topology"/);
-  assert.match(railSource, /单 Agent，无协作拓扑/);
+  assert.doesNotMatch(railSource, /单 Agent，无协作拓扑/);
+  assert.match(
+    railSource,
+    /className="topo-tree"[\s\S]*?<TopoNode[\s\S]*?node=\{graph\}[\s\S]*?activeAgent=\{activeAgent\}/,
+  );
+  assert.match(railStyles, /\.topo-node\.is-active/);
+  const activeNodeStyles = railStyles.slice(
+    railStyles.indexOf(".topo-node.is-active {"),
+    railStyles.indexOf(".topo-node.is-active .topo-icon"),
+  );
+  assert.match(activeNodeStyles, /background:\s*hsl\(var\(--foreground\) \/ 0\.08\)/);
+  assert.match(activeNodeStyles, /animation:\s*topo-active-fade 1\.8s ease-in-out infinite/);
+  assert.doesNotMatch(activeNodeStyles, /box-shadow/);
+  assert.match(railStyles, /@keyframes topo-active-fade[\s\S]*?background:/);
+  assert.doesNotMatch(railStyles, /@keyframes topo-pulse/);
+  assert.match(appSource, /setActiveAgentBySession\(\(m\) => \(\{ \.\.\.m, \[sid\]: who \}\)\)/);
   assert.doesNotMatch(railSource, /className="topo-kicker"/);
   assert.match(railSource, /className="topo-module-scroll topo-tools-scroll"/);
   assert.match(railSource, /className="topo-module-scroll topo-skills-scroll"/);
@@ -54,6 +77,15 @@ test("shows Agent tools and skills before the optional topology", () => {
   );
   assert.match(railSource, /aria-label=\{`\$\{count\} 项`\}/);
   assert.doesNotMatch(railSource, /\{count\} 项<\/span>/);
+  assert.match(
+    railStyles,
+    /\.topo-capability-name\s*\{[^}]*font-size:\s*13px;/,
+  );
+  assert.match(
+    railStyles,
+    /\.topo-skill-name\s*\{[^}]*font-size:\s*13px;/,
+  );
+  assert.match(railStyles, /\.topo-name\s*\{[^}]*font-size:\s*13px;/);
 
   const agentCard = railSource.slice(
     railSource.indexOf('<section className="topo-agent-card"'),
@@ -71,7 +103,7 @@ test("shows Agent tools and skills before the optional topology", () => {
 test("keeps Agent information out of the new-session empty state", () => {
   const emptyState = appSource.slice(
     appSource.indexOf(": turns.length === 0 ? ("),
-    appSource.indexOf(") : (\n              <>\n                <div className=\"transcript\""),
+    appSource.indexOf("className={`transcript"),
   );
   assert.doesNotMatch(emptyState, /<AgentInfoPanel/);
   assert.match(appSource, /turns\.length > 0[\s\S]*?className="agent-info-trigger"/);
@@ -131,9 +163,102 @@ test("opens the same Agent information from a narrow-screen title trigger", () =
   assert.match(railStyles, /@media \(min-width:\s*1280px\)[\s\S]*?\.agent-info-trigger/);
 });
 
-test("uses repository-owned capability icons in the updated rail", () => {
+test("keeps capability section titles text-only", () => {
   assert.match(railSource, /AgentIdentityIcon/);
-  assert.match(railSource, /ToolCapabilityIcon/);
-  assert.match(railSource, /SkillCapabilityIcon/);
+  assert.doesNotMatch(railSource, /ToolCapabilityIcon/);
+  assert.doesNotMatch(railSource, /SkillCapabilityIcon/);
+  assert.doesNotMatch(railSource, /topo-section-icon/);
+  assert.doesNotMatch(railStyles, /\.topo-section-icon/);
   assert.doesNotMatch(railSource, /from "lucide-react"/);
+});
+
+test("mixes session capabilities into the existing lists with custom badges", () => {
+  assert.match(railSource, /capabilities\?\.tools/);
+  assert.match(railSource, /capabilities\?\.skills/);
+  assert.match(railSource, /tool\.custom && <span className="topo-custom-badge">自定义<\/span>/);
+  assert.match(railSource, /skill\.custom && <span className="topo-custom-badge">自定义<\/span>/);
+  assert.match(railSource, /tool\.custom && \([\s\S]*?topo-remove-capability/);
+  assert.match(railSource, /skill\.custom && \([\s\S]*?topo-remove-capability/);
+  assert.doesNotMatch(railSource, /本会话添加/);
+  assert.match(appSource, /getSessionCapabilities\(appName, userId, sessionId\)/);
+  assert.match(appSource, /sessionCapabilities:\s*sessionCapabilities !== null/);
+});
+
+test("offers session-scoped tool and skill controls in both information views", () => {
+  assert.match(railSource, /aria-label="添加内置工具"/);
+  assert.match(railSource, /aria-label="添加技能"/);
+  assert.match(railSource, /<span>在此对话中添加工具<\/span>/);
+  assert.match(railSource, /<span>在此对话中添加技能<\/span>/);
+  assert.match(railSource, /className="topo-capability-add-slot"/);
+  assert.match(railSource, /<ToolCapabilityDialog/);
+  assert.match(railSource, /<SkillCapabilityDialog/);
+  assert.doesNotMatch(railSource, /placeholder="Skill Space ID"/);
+  assert.match(appSource, /<AgentInfoPanel[\s\S]*?capabilities=\{sessionCapabilities\}/);
+  assert.match(appSource, /<AgentInfoDrawer[\s\S]*?capabilities=\{sessionCapabilities\}/);
+  assert.match(railStyles, /\.topo-custom-badge/);
+  assert.match(
+    railStyles,
+    /\.topo-skill-name\s*\{[^}]*font-family:\s*-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;/,
+  );
+  assert.match(
+    railStyles,
+    /\.session-skill-option-copy strong\s*\{[^}]*font-family:\s*-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;/,
+  );
+  assert.match(railStyles, /\.topo-capability-add-slot/);
+  assert.match(
+    railStyles,
+    /\.topo-capability-add-slot\s*\{[^}]*min-height:\s*34px;/,
+  );
+  assert.equal(
+    (railSource.match(/className="topo-capability-add-dock"/g) ?? []).length,
+    2,
+  );
+  assert.match(
+    railStyles,
+    /\.topo-capability-add-dock\s*\{[^}]*flex:\s*0 0 auto;/,
+  );
+  assert.match(railStyles, /\.topo-remove-capability/);
+});
+
+test("uses searchable dialogs for public Skill Hub and AgentKit Skill Center", () => {
+  assert.match(capabilityDialogsSource, /get_city_weather: "城市天气查询"/);
+  assert.match(capabilityDialogsSource, /get_location_weather: "位置天气查询"/);
+  assert.ok(
+    capabilityDialogsSource.includes('return description.replace(/[。.]+$/, "");'),
+  );
+  assert.match(capabilityDialogsSource, /title="添加内置工具"/);
+  assert.match(capabilityDialogsSource, /label="搜索内置工具"/);
+  assert.match(capabilityDialogsSource, /title="添加技能"/);
+  assert.match(capabilityDialogsSource, /role="tablist" aria-label="技能来源"/);
+  assert.match(capabilityDialogsSource, />\s*Skill Hub\s*<span>公域<\/span>/);
+  assert.match(capabilityDialogsSource, /AgentKit Skill 中心/);
+  assert.match(capabilityDialogsSource, /searchSessionPublicSkills\(appName, publicQuery\.trim\(\)\)/);
+  assert.match(capabilityDialogsSource, /skillSourceId: `findskill:\$\{skill\.slug\}`/);
+  assert.match(clientSource, /\/harness\/skills\/findskill/);
+  assert.match(capabilityDialogsSource, /listSessionSkillSpaces\(appName\)/);
+  assert.match(capabilityDialogsSource, /listSessionSkillsInSpace\(appName, selectedSpace\.id/);
+  assert.match(capabilityDialogsSource, /label="搜索 Skill Space"/);
+  assert.match(capabilityDialogsSource, /label="搜索 AgentKit 技能"/);
+  assert.match(capabilityDialogsSource, /skillSourceId: selectedSpace\.id/);
+  assert.match(capabilityDialogsSource, /name: skill\.skillName/);
+  assert.match(stylesSource, /\.session-skill-browser\s*\{[\s\S]*?grid-template-columns:/);
+  assert.match(stylesSource, /\.session-capability-dialog-layer\s*\{[\s\S]*?z-index:\s*110;/);
+  assert.match(
+    stylesSource,
+    /\.session-capability-dialog\.is-wide\s*\{[^}]*height:\s*min\(720px, calc\(100dvh - 48px\)\);/,
+  );
+  assert.doesNotMatch(capabilityDialogsSource, /SkillCapabilityIcon|SkillSpaceIcon/);
+  assert.match(capabilityDialogsSource, /session-capability-dialog-head\$\{icon \? "" : " is-iconless"\}/);
+  assert.doesNotMatch(
+    stylesSource,
+    /\.session-public-skill-head\s*\{[^}]*border-bottom:/,
+  );
+  assert.doesNotMatch(
+    stylesSource,
+    /\.session-skill-pane-head\s*\{[^}]*border-bottom:/,
+  );
+  assert.match(
+    stylesSource,
+    /\.session-capability-search\s*\{[\s\S]*?flex:\s*0 0 40px;[\s\S]*?height:\s*40px;[\s\S]*?border-radius:\s*6px;/,
+  );
 });

--- a/frontend/tests/builtinToolStatus.test.mjs
+++ b/frontend/tests/builtinToolStatus.test.mjs
@@ -43,6 +43,7 @@ test("maps supported built-in tools to dedicated Chinese running and done labels
     ["run_code", "正在 AgentKit 沙箱中执行代码", "已在 AgentKit 沙箱中完成代码执行"],
     ["load_memory", "正在检索长期记忆", "已完成记忆检索"],
     ["load_knowledgebase", "正在检索知识库", "已完成知识库检索"],
+    ["load_skill", "正在加载技能", "已加载技能"],
   ];
 
   for (const [name, running, done] of expected) {
@@ -58,6 +59,11 @@ test("renders built-in tool calls through the extensible dedicated header", () =
   assert.match(headerSource, /definition\.doneLabel/);
   assert.match(headerSource, /aria-expanded=\{open\}/);
   assert.match(toolStylesSource, /data-tool-tone="search"/);
+  assert.match(toolStylesSource, /data-tool-tone="skill"/);
+  assert.match(blocksSource, /function loadSkillLabel/);
+  assert.match(blocksSource, /label=\{loadSkillLabel\(name, args\)\}/);
+  assert.match(blocksSource, /`使用 \$\{skillName\.trim\(\)\} 技能`/);
+  assert.match(headerSource, /label\?: string/);
   assert.doesNotMatch(headerSource, /builtin-tool-state/);
   assert.doesNotMatch(toolStylesSource, /builtin-tool-state|builtin-tool-breathe/);
 });
@@ -124,6 +130,7 @@ test("uses repository-owned current-color SVG icons for every special tool", () 
     "VideoGenerateIcon",
     "LoadMemoryIcon",
     "LoadKnowledgebaseIcon",
+    "LoadSkillIcon",
     "RunCodeIcon",
   ]) {
     assert.match(iconsSource, new RegExp(`export function ${icon}`));
@@ -154,11 +161,11 @@ test("aligns thinking and special-tool headers on the same visual grid", () => {
   );
   assert.match(
     sharedStylesSource,
-    /\.think-label\s*\{[^}]*font-size:\s*13\.5px[^}]*font-weight:\s*400[^}]*line-height:\s*1\.35/,
+    /\.think-label\s*\{[^}]*font-size:\s*14\.5px[^}]*font-weight:\s*400[^}]*line-height:\s*1\.35/,
   );
   assert.match(
     sharedStylesSource,
-    /\.tool-name\s*\{[^}]*font-size:\s*13\.5px[^}]*font-weight:\s*400[^}]*line-height:\s*1\.35/,
+    /\.tool-name\s*\{[^}]*font-size:\s*14\.5px[^}]*font-weight:\s*400[^}]*line-height:\s*1\.35/,
   );
   assert.match(blocksSource, /<TextShimmer className="think-label" duration=\{2\.4\} spread=\{18\}>/);
 });

--- a/frontend/tests/composerPresentation.test.mjs
+++ b/frontend/tests/composerPresentation.test.mjs
@@ -14,10 +14,80 @@ const sidebarSource = readFileSync(
   new URL("../src/ui/Sidebar.tsx", import.meta.url),
   "utf8",
 );
+const blocksSource = readFileSync(
+  new URL("../src/ui/Blocks.tsx", import.meta.url),
+  "utf8",
+);
 const stylesSource = readFileSync(
   new URL("../src/styles.css", import.meta.url),
   "utf8",
 );
+
+test("uses ChatGPT-scale typography for conversation copy", () => {
+  assert.match(stylesSource, /\.bubble\s*\{[^}]*font-size:\s*16px/);
+  assert.match(stylesSource, /\.md\s*\{[^}]*font-size:\s*16px/);
+  assert.match(stylesSource, /\.md\s*\{[^}]*line-height:\s*1\.65/);
+});
+
+test("smoothly positions new turns and follows streamed output until interrupted", () => {
+  assert.match(
+    appSource,
+    /el\.scrollTo\(\{ top: el\.scrollHeight, behavior: "smooth" \}\)/,
+  );
+  assert.match(
+    appSource,
+    /className=\{`transcript\$\{activeConversationPresenting \? " is-streaming" : ""\}`\}/,
+  );
+  assert.doesNotMatch(appSource, /useStickToBottom<HTMLDivElement>\(turns\)/);
+  assert.match(
+    appSource,
+    /conversationAutoFollowRef\.current =\s*el\.scrollHeight - el\.scrollTop - el\.clientHeight < 32/,
+  );
+  assert.match(
+    appSource,
+    /!conversationAutoFollowRef\.current \|\|[\s\S]*?conversationSmoothScrollRef\.current[\s\S]*?el\.scrollTop = el\.scrollHeight/,
+  );
+  assert.match(
+    stylesSource,
+    /\.transcript\.is-streaming\s*\{[^}]*overflow-anchor:\s*none/,
+  );
+  assert.match(
+    stylesSource,
+    /\.transcript\.is-streaming > \.turn--assistant:last-child\s*\{[^}]*min-height:\s*max\(0px, calc\(100% - 180px\)\)/,
+  );
+  assert.match(blocksSource, /STREAM_FRAME_INTERVAL_MS = 28/);
+  assert.match(blocksSource, /window\.requestAnimationFrame\(renderFrame\)/);
+  assert.match(blocksSource, /Math\.min\(18, Math\.max\(2, Math\.ceil\(remaining \/ 6\)\)\)/);
+  assert.match(blocksSource, /prefers-reduced-motion: reduce/);
+  assert.match(
+    blocksSource,
+    /cancelAnimationFrame\(frameRef\.current\);\s*frameRef\.current = null/,
+  );
+  assert.match(
+    appSource,
+    /streaming=\{isLast && \(activeConversationBusy \|\| presentingStream\)\}/,
+  );
+  assert.match(appSource, /finishStreamPresentation[\s\S]*?2400/);
+  assert.match(appSource, /onStreamFrame=\{isLast \? followConversationStreamFrame : undefined\}/);
+  assert.match(blocksSource, /!done \|\| streaming/);
+});
+
+test("keeps thinking and tool status copy legible below the answer hierarchy", () => {
+  const builtinStylesSource = readFileSync(
+    new URL("../src/ui/builtin-tools/builtin-tools.css", import.meta.url),
+    "utf8",
+  );
+  assert.match(stylesSource, /\.think-label\s*\{[^}]*font-size:\s*14\.5px/);
+  assert.match(stylesSource, /\.tool-name\s*\{[^}]*font-size:\s*14\.5px/);
+  assert.match(stylesSource, /\.think-body\s*\{[^}]*font-size:\s*14px/);
+  assert.match(
+    builtinStylesSource,
+    /\.builtin-tool-label\s*\{[^}]*font-size:\s*14\.5px/,
+  );
+  assert.match(stylesSource, /\.think-body\s*\{[^}]*margin:\s*0/);
+  assert.match(stylesSource, /\.think-body\s*\{[^}]*padding:\s*0/);
+  assert.match(stylesSource, /\.think-body\s*\{[^}]*border-left:\s*0/);
+});
 
 test("shows session metadata only after the conversation starts", () => {
   assert.match(appSource, /showMeta=\{turns\.length > 0 && !sandboxSession\}/);

--- a/frontend/tests/viteProxy.test.mjs
+++ b/frontend/tests/viteProxy.test.mjs
@@ -10,3 +10,7 @@ const source = readFileSync(
 test("proxies the session trace API in development", () => {
   assert.match(source, /["']\/dev["']\s*:\s*API_TARGET/);
 });
+
+test("proxies session capability APIs in development", () => {
+  assert.match(source, /["']\/harness["']\s*:\s*API_TARGET/);
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       "/apps": API_TARGET,
       "/run_sse": API_TARGET,
       "/run": API_TARGET,
+      "/harness": API_TARGET,
       "/debug": API_TARGET,
       "/dev": API_TARGET,
       "/oauth2": API_TARGET,

--- a/tests/integrations/agentkit/test_session_capabilities.py
+++ b/tests/integrations/agentkit/test_session_capabilities.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from google.adk.agents import LlmAgent
+from google.adk.sessions import InMemorySessionService
+
+import veadk.integrations.agentkit.app as agentkit_app
+from veadk.integrations.agentkit import session_capabilities as capabilities
+
+
+async def _service() -> tuple[
+    capabilities.SessionCapabilityService,
+    InMemorySessionService,
+    LlmAgent,
+]:
+    root_agent = LlmAgent(name="agent", model="gemini-2.0-flash")
+    session_service = InMemorySessionService()
+    service = capabilities.SessionCapabilityService(
+        root_agent=root_agent,
+        session_service=session_service,
+    )
+    return service, session_service, root_agent
+
+
+@pytest.mark.asyncio
+async def test_tool_overlay_persists_in_session_state_and_is_isolated() -> None:
+    service, session_service, _ = await _service()
+    await session_service.create_session(
+        app_name="agent", user_id="user-1", session_id="session-a"
+    )
+    await session_service.create_session(
+        app_name="agent", user_id="user-1", session_id="session-b"
+    )
+
+    updated = await service.add_capability(
+        app_name="agent",
+        user_id="user-1",
+        session_id="session-a",
+        request=capabilities.AddCapabilityRequest(
+            kind="tool",
+            name="get_city_weather",
+            expected_revision=0,
+        ),
+    )
+
+    assert updated.revision == 1
+    assert [item.name for item in updated.tools if item.custom] == ["get_city_weather"]
+    stored = await session_service.get_session(
+        app_name="agent", user_id="user-1", session_id="session-a"
+    )
+    assert stored is not None
+    assert stored.state[capabilities.SESSION_CAPABILITIES_STATE_KEY] == {
+        "schema_version": 1,
+        "revision": 1,
+        "tools": [{"ref": "builtin:get_city_weather"}],
+        "skills": [],
+    }
+    isolated = await service.get_capabilities(
+        app_name="agent", user_id="user-1", session_id="session-b"
+    )
+    assert isolated.revision == 0
+    assert not any(item.custom for item in isolated.tools)
+
+
+@pytest.mark.asyncio
+async def test_base_capability_cannot_be_added_or_removed() -> None:
+    def base_tool(city: str) -> str:
+        return city
+
+    root_agent = LlmAgent(
+        name="agent",
+        model="gemini-2.0-flash",
+        tools=[base_tool],
+    )
+    session_service = InMemorySessionService()
+    service = capabilities.SessionCapabilityService(
+        root_agent=root_agent,
+        session_service=session_service,
+    )
+    await session_service.create_session(
+        app_name="agent", user_id="user-1", session_id="session-a"
+    )
+
+    response = await service.get_capabilities(
+        app_name="agent", user_id="user-1", session_id="session-a"
+    )
+    assert [(item.name, item.custom) for item in response.tools] == [
+        ("base_tool", False)
+    ]
+    with pytest.raises(capabilities.CapabilityConflictError):
+        await service.remove_capability(
+            app_name="agent",
+            user_id="user-1",
+            session_id="session-a",
+            capability_id="base:tool:base_tool",
+        )
+
+
+@pytest.mark.asyncio
+async def test_remove_custom_capability_and_reject_stale_revision() -> None:
+    service, session_service, _ = await _service()
+    await session_service.create_session(
+        app_name="agent", user_id="user-1", session_id="session-a"
+    )
+    added = await service.add_capability(
+        app_name="agent",
+        user_id="user-1",
+        session_id="session-a",
+        request=capabilities.AddCapabilityRequest(kind="tool", name="get_city_weather"),
+    )
+
+    with pytest.raises(capabilities.CapabilityConflictError):
+        await service.remove_capability(
+            app_name="agent",
+            user_id="user-1",
+            session_id="session-a",
+            capability_id="session:tool:get_city_weather",
+            expected_revision=0,
+        )
+
+    removed = await service.remove_capability(
+        app_name="agent",
+        user_id="user-1",
+        session_id="session-a",
+        capability_id="session:tool:get_city_weather",
+        expected_revision=added.revision,
+    )
+    assert removed.revision == 2
+    assert not any(item.custom for item in removed.tools)
+
+
+@pytest.mark.asyncio
+async def test_build_agent_mounts_tool_without_mutating_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, session_service, root_agent = await _service()
+    await session_service.create_session(
+        app_name="agent", user_id="user-1", session_id="session-a"
+    )
+    await service.add_capability(
+        app_name="agent",
+        user_id="user-1",
+        session_id="session-a",
+        request=capabilities.AddCapabilityRequest(kind="tool", name="get_city_weather"),
+    )
+
+    def mounted_tool(city: str) -> str:
+        return city
+
+    monkeypatch.setattr(capabilities, "get_builtin_tool", lambda name: mounted_tool)
+
+    run_agent = await service.build_agent(
+        app_name="agent", user_id="user-1", session_id="session-a"
+    )
+
+    assert [capabilities._tool_name(tool) for tool in run_agent.tools] == [
+        "mounted_tool"
+    ]
+    assert root_agent.tools == []
+
+
+@pytest.mark.asyncio
+async def test_skill_reference_is_persisted_as_metadata_only() -> None:
+    service, session_service, _ = await _service()
+    await session_service.create_session(
+        app_name="agent", user_id="user-1", session_id="session-a"
+    )
+
+    response = await service.add_capability(
+        app_name="agent",
+        user_id="user-1",
+        session_id="session-a",
+        request=capabilities.AddCapabilityRequest(
+            kind="skill",
+            name="pdf-reader",
+            skill_source_id="skill-space-1",
+            description="Read PDF files.",
+            version="1.2.0",
+        ),
+    )
+
+    custom_skill = response.skills[0]
+    assert custom_skill.custom is True
+    assert custom_skill.name == "pdf-reader"
+    stored = await session_service.get_session(
+        app_name="agent", user_id="user-1", session_id="session-a"
+    )
+    assert stored is not None
+    raw_skill = stored.state[capabilities.SESSION_CAPABILITIES_STATE_KEY]["skills"][0]
+    assert raw_skill == {
+        "id": custom_skill.id,
+        "skill_source_id": "skill-space-1",
+        "name": "pdf-reader",
+        "description": "Read PDF files.",
+        "version": "1.2.0",
+    }
+
+
+@pytest.mark.asyncio
+async def test_build_agent_loads_skill_without_mutating_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, session_service, root_agent = await _service()
+    await session_service.create_session(
+        app_name="agent", user_id="user-1", session_id="session-a"
+    )
+    await service.add_capability(
+        app_name="agent",
+        user_id="user-1",
+        session_id="session-a",
+        request=capabilities.AddCapabilityRequest(
+            kind="skill",
+            name="pdf-reader",
+            skill_source_id="skill-space-1",
+        ),
+    )
+    loaded = []
+
+    async def load_skill(skill_source_id: str, name: str, version: str) -> object:
+        loaded.append((skill_source_id, name, version))
+        return SimpleNamespace(name=name, description="Read PDF files.")
+
+    monkeypatch.setattr(capabilities, "_load_remote_skill", load_skill)
+
+    run_agent = await service.build_agent(
+        app_name="agent", user_id="user-1", session_id="session-a"
+    )
+
+    assert loaded == [("skill-space-1", "pdf-reader", "")]
+    assert len(run_agent.tools) == 1
+    assert type(run_agent.tools[0]).__name__ == "SkillToolset"
+    assert "`pdf-reader`" in run_agent.instruction
+    assert "call list_skills" in run_agent.instruction
+    assert root_agent.tools == []
+    assert root_agent.instruction == ""
+
+
+@pytest.mark.asyncio
+async def test_findskill_reference_uses_slug_loader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loaded = []
+
+    def load_findskill(slug: str, name: str, version: str) -> object:
+        loaded.append((slug, name, version))
+        return SimpleNamespace(name=name, description="Public skill.")
+
+    monkeypatch.setattr(capabilities, "_load_findskill_skill", load_findskill)
+
+    skill = await capabilities._load_remote_skill(
+        "findskill:volcengine/example/public-skill",
+        "public-skill",
+        "1.2.3",
+    )
+
+    assert skill.name == "public-skill"
+    assert loaded == [("volcengine/example/public-skill", "public-skill", "1.2.3")]
+
+
+@pytest.mark.asyncio
+async def test_harness_routes_are_prioritized_before_agentkit_root_mount() -> None:
+    service, session_service, _ = await _service()
+    await session_service.create_session(
+        app_name="agent", user_id="user-1", session_id="session-a"
+    )
+    app = FastAPI()
+    app.mount("/", FastAPI())
+    capabilities.mount_session_capability_routes(app=app, service=service)
+    agentkit_app._prioritize_platform_routes(app)
+
+    response = TestClient(app).get(
+        "/harness/apps/agent/users/user-1/sessions/session-a/capabilities"
+    )
+    harness_route_index = next(
+        index
+        for index, route in enumerate(app.router.routes)
+        if getattr(route, "path", "").startswith("/harness/")
+        or any(
+            getattr(included_route, "path", "").startswith("/harness/")
+            for included_route in getattr(
+                getattr(route, "original_router", None), "routes", ()
+            )
+        )
+    )
+    root_mount_index = next(
+        index
+        for index, route in enumerate(app.router.routes)
+        if getattr(route, "path", None) == ""
+    )
+
+    assert response.status_code == 200
+    assert response.json()["revision"] == 0
+    assert harness_route_index < root_mount_index
+
+
+@pytest.mark.asyncio
+async def test_harness_skill_catalog_routes_list_spaces_and_skills(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _, _ = await _service()
+
+    class FakeSkillClient:
+        def __init__(self, region: str) -> None:
+            self.region = region
+
+        def list_skill_spaces(self, request: object) -> SimpleNamespace:
+            del request
+            return SimpleNamespace(
+                items=[
+                    SimpleNamespace(
+                        id=f"space-{self.region}",
+                        name=f"{self.region} Skills",
+                        description="Shared skills",
+                        status="active",
+                        project_name="default",
+                        update_time_stamp="",
+                        relations=[object()],
+                    )
+                ]
+            )
+
+        def list_skills_by_skill_space(self, request: object) -> SimpleNamespace:
+            del request
+            return SimpleNamespace(
+                items=[
+                    SimpleNamespace(
+                        skill_id="skill-1",
+                        skill_name="writer",
+                        skill_description="Write content",
+                        version="1.0.0",
+                        skill_status="active",
+                    )
+                ],
+                total_count=1,
+            )
+
+    monkeypatch.setattr(
+        capabilities,
+        "_skill_catalog_client",
+        lambda region: FakeSkillClient(region),
+    )
+    app = FastAPI()
+    capabilities.mount_session_capability_routes(app=app, service=service)
+    client = TestClient(app)
+
+    spaces = client.get("/harness/skills/spaces?region=all")
+    skills = client.get(
+        "/harness/skills/spaces/space-cn-beijing/skills?region=cn-beijing"
+    )
+
+    assert spaces.status_code == 200
+    assert [item["region"] for item in spaces.json()["items"]] == [
+        "cn-beijing",
+        "cn-shanghai",
+    ]
+    assert skills.status_code == 200
+    assert skills.json()["items"][0] == {
+        "skillId": "skill-1",
+        "skillName": "writer",
+        "skillDescription": "Write content",
+        "version": "1.0.0",
+        "skillStatus": "active",
+    }
+
+
+@pytest.mark.asyncio
+async def test_harness_findskill_route_returns_public_slugs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _, _ = await _service()
+
+    async def search_findskill(**kwargs: object) -> dict[str, object]:
+        assert kwargs == {"query": "pdf", "page_number": 1, "page_size": 20}
+        return {
+            "items": [
+                {
+                    "slug": "volcengine/las/pdf-reader",
+                    "name": "pdf-reader",
+                    "description": "Read PDF files",
+                    "sourceType": "volcengine",
+                    "sourceRepo": "volcengine/las",
+                    "downloadCount": 42,
+                    "evaluationScore": 4.8,
+                    "version": "1.0.0",
+                    "updatedAt": "2026-07-26T00:00:00+08:00",
+                }
+            ],
+            "totalCount": 1,
+        }
+
+    monkeypatch.setattr(capabilities, "_search_findskill", search_findskill)
+    app = FastAPI()
+    capabilities.mount_session_capability_routes(app=app, service=service)
+
+    response = TestClient(app).get("/harness/skills/findskill?query=pdf")
+
+    assert response.status_code == 200
+    assert response.json()["items"][0]["slug"] == "volcengine/las/pdf-reader"

--- a/tests/integrations/agentkit/test_session_capabilities.py
+++ b/tests/integrations/agentkit/test_session_capabilities.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from types import SimpleNamespace

--- a/veadk/integrations/agentkit/app.py
+++ b/veadk/integrations/agentkit/app.py
@@ -33,10 +33,10 @@ from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from google.adk.agents import LoopAgent, ParallelAgent, RunConfig, SequentialAgent
 from google.adk.agents.base_agent import BaseAgent
-from google.adk.agents.run_config import StreamingMode
-from google.adk.cli.adk_web_server import RunAgentRequest
 from google.adk.agents.remote_a2a_agent import RemoteA2aAgent
+from google.adk.agents.run_config import StreamingMode
 from google.adk.apps.app import App
+from google.adk.cli.adk_web_server import RunAgentRequest
 from google.adk.runners import Runner as AdkRunner
 from google.adk.utils.context_utils import Aclosing
 from google.genai import types
@@ -47,6 +47,11 @@ from veadk.agent_metadata import (
     agent_skill_summaries,
 )
 from veadk.agent_search import search_agent_component
+from veadk.integrations.agentkit.session_capabilities import (
+    CapabilityError,
+    SessionCapabilityService,
+    mount_session_capability_routes,
+)
 from veadk.memory.short_term_memory import ShortTermMemory
 
 if TYPE_CHECKING:
@@ -56,6 +61,7 @@ _MAX_AGENT_GRAPH_DEPTH = 8
 _SERVER_STATE_KEY = "_veadk_agentkit_server"
 _ADK_SERVER_STATE_KEY = "_veadk_adk_server"
 _DYNAMIC_A2A_ROUTES_ENABLED_STATE_KEY = "_veadk_dynamic_a2a_routes_enabled"
+_SESSION_CAPABILITY_SERVICE_STATE_KEY = "_veadk_session_capability_service"
 _REGISTRY_CONFIG_ATTR = "_veadk_a2a_registry_config"
 
 
@@ -470,15 +476,27 @@ def _prioritize_platform_routes(app: FastAPI) -> None:
         "/web/agent-info/{app_name}",
         "/web/agent-graph",
         "/web/search",
+        "/harness/capabilities/tools",
+        "/harness/skills/spaces",
+        "/harness/skills/spaces/{space_id}/skills",
+        "/harness/apps/{app_name}/users/{user_id}/sessions/{session_id}/capabilities",
+        "/harness/apps/{app_name}/users/{user_id}/sessions/{session_id}/capabilities/{capability_id}",
+        "/harness/run_sse",
         "/assets",
         "/webui",
         "/webui/{path:path}",
     }
-    priority_routes = [
-        route
-        for route in app.router.routes
-        if getattr(route, "path", None) in priority_paths
-    ]
+
+    def is_priority_route(route: Any) -> bool:
+        if getattr(route, "path", None) in priority_paths:
+            return True
+        included_router = getattr(route, "original_router", None)
+        return any(
+            getattr(included_route, "path", None) in priority_paths
+            for included_route in getattr(included_router, "routes", ())
+        )
+
+    priority_routes = [route for route in app.router.routes if is_priority_route(route)]
     if priority_routes:
         app.router.routes[:] = priority_routes + [
             route for route in app.router.routes if route not in priority_routes
@@ -798,6 +816,96 @@ def _configure_dynamic_a2a_routes(
     setattr(app.state, _DYNAMIC_A2A_ROUTES_ENABLED_STATE_KEY, True)
 
 
+def _configure_session_capability_routes(
+    app: FastAPI,
+    root_agent: BaseAgent,
+) -> None:
+    services = _RuntimeServices(app)
+    if services.session_service is None:
+        return
+
+    capability_service = SessionCapabilityService(
+        root_agent=root_agent,
+        session_service=services.session_service,
+    )
+    setattr(app.state, _SESSION_CAPABILITY_SERVICE_STATE_KEY, capability_service)
+    mount_session_capability_routes(app=app, service=capability_service)
+
+    @app.post("/harness/run_sse")
+    async def run_agent_sse_with_session_capabilities(
+        req: RunAgentRequest,
+    ) -> StreamingResponse:
+        app_name = _resolve_run_app_name(services, root_agent, req)
+        try:
+            run_agent = await capability_service.build_agent(
+                app_name=app_name,
+                user_id=req.user_id,
+                session_id=req.session_id,
+            )
+        except CapabilityError as exc:
+            raise HTTPException(
+                status_code=exc.status_code,
+                detail=str(exc),
+            ) from exc
+
+        _add_dynamic_a2a_agent_tools(run_agent, _content_text(req.new_message))
+        runner = AdkRunner(
+            app=App(name=app_name, root_agent=run_agent, plugins=[]),
+            artifact_service=services.artifact_service,
+            session_service=services.session_service,
+            memory_service=services.memory_service,
+            credential_service=services.credential_service,
+            auto_create_session=services.auto_create_session,
+        )
+        stream_mode = StreamingMode.SSE if req.streaming else StreamingMode.NONE
+        custom_metadata = _run_request_custom_metadata(req)
+
+        async def event_generator():
+            try:
+                async with Aclosing(
+                    runner.run_async(
+                        user_id=req.user_id,
+                        session_id=req.session_id,
+                        new_message=req.new_message,
+                        state_delta=req.state_delta,
+                        run_config=RunConfig(
+                            streaming_mode=stream_mode,
+                            custom_metadata=custom_metadata,
+                        ),
+                        invocation_id=req.invocation_id,
+                    )
+                ) as agen:
+                    async for event in agen:
+                        events_to_stream = [event]
+                        if (
+                            not req.function_call_event_id
+                            and event.actions.artifact_delta
+                            and event.content
+                            and event.content.parts
+                        ):
+                            content_event = event.model_copy(deep=True)
+                            content_event.actions.artifact_delta = {}
+                            artifact_event = event.model_copy(deep=True)
+                            artifact_event.content = None
+                            events_to_stream = [content_event, artifact_event]
+
+                        for event_to_stream in events_to_stream:
+                            yield (
+                                "data: "
+                                + event_to_stream.model_dump_json(
+                                    exclude_none=True,
+                                    by_alias=True,
+                                )
+                                + "\n\n"
+                            )
+            except Exception as exc:  # noqa: BLE001 - SSE surfaces errors as data.
+                yield f"data: {json.dumps({'error': str(exc)})}\n\n"
+
+        return StreamingResponse(event_generator(), media_type="text/event-stream")
+
+    _promote_route(app, run_agent_sse_with_session_capabilities)
+
+
 def create_agentkit_app(
     root_agent: BaseAgent,
     display_names: Mapping[str, str] | None = None,
@@ -831,6 +939,7 @@ def create_agentkit_app(
     app = cast(FastAPI, agent_server.app)
     setattr(app.state, _SERVER_STATE_KEY, agent_server)
     _configure_dynamic_a2a_routes(app, root_agent)
+    _configure_session_capability_routes(app, root_agent)
 
     if enable_feishu:
         _configure_feishu_lifecycle(app, root_agent, short_term_memory)

--- a/veadk/integrations/agentkit/session_capabilities.py
+++ b/veadk/integrations/agentkit/session_capabilities.py
@@ -1,0 +1,730 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Session-scoped tool and skill overlays for AgentKit applications."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Literal
+from uuid import uuid4
+
+from fastapi import APIRouter, FastAPI, HTTPException, Query
+from google.adk.agents.base_agent import BaseAgent
+from google.adk.events import Event, EventActions
+from google.adk.sessions import BaseSessionService, Session
+from google.adk.tools.skill_toolset import SkillToolset
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from veadk.agent_metadata import agent_skill_summaries
+from veadk.tools import get_builtin_tool, list_builtin_tools
+
+SESSION_CAPABILITIES_STATE_KEY = "__agentkit_harness__"
+SESSION_CAPABILITIES_SCHEMA_VERSION = 1
+FINDSKILL_SOURCE_PREFIX = "findskill:"
+FINDSKILL_SEARCH_URL = os.getenv(
+    "FINDSKILL_SEARCH_URL", "https://skills.volces.com/v1/skills"
+)
+
+
+class StoredTool(BaseModel):
+    """A lazily resolved built-in tool reference."""
+
+    ref: str
+
+
+class StoredSkill(BaseModel):
+    """A lazily resolved remote skill reference."""
+
+    id: str
+    skill_source_id: str
+    name: str
+    description: str = ""
+    version: str = ""
+
+
+class SessionCapabilityOverlay(BaseModel):
+    """The versioned value persisted in ``Session.state``."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    schema_version: int = SESSION_CAPABILITIES_SCHEMA_VERSION
+    revision: int = 0
+    tools: list[StoredTool] = Field(default_factory=list)
+    skills: list[StoredSkill] = Field(default_factory=list)
+
+
+class AddCapabilityRequest(BaseModel):
+    """Add one built-in tool or one remote skill to a session."""
+
+    kind: Literal["tool", "skill"]
+    name: str
+    skill_source_id: str | None = None
+    description: str = ""
+    version: str = ""
+    expected_revision: int | None = None
+
+    @model_validator(mode="after")
+    def validate_reference(self) -> AddCapabilityRequest:
+        self.name = self.name.strip()
+        if not self.name:
+            raise ValueError("name is required")
+        if self.kind == "skill":
+            self.skill_source_id = (self.skill_source_id or "").strip()
+            if not self.skill_source_id:
+                raise ValueError("skill_source_id is required for a skill")
+        return self
+
+
+class CapabilityItem(BaseModel):
+    id: str
+    kind: Literal["tool", "skill"]
+    name: str
+    custom: bool
+    description: str = ""
+    skill_source_id: str | None = None
+    version: str = ""
+
+
+class SessionCapabilitiesResponse(BaseModel):
+    schema_version: int
+    revision: int
+    tools: list[CapabilityItem]
+    skills: list[CapabilityItem]
+
+
+class CapabilityError(Exception):
+    status_code = 400
+
+
+class SessionNotFoundError(CapabilityError):
+    status_code = 404
+
+
+class CapabilityConflictError(CapabilityError):
+    status_code = 409
+
+
+def _tool_name(tool: object) -> str:
+    name = getattr(tool, "name", None) or getattr(tool, "__name__", None)
+    return str(name or type(tool).__name__)
+
+
+def _skill_id(skill_source_id: str, name: str) -> str:
+    digest = hashlib.sha256(f"{skill_source_id}\0{name}".encode()).hexdigest()[:16]
+    return f"session:skill:{digest}"
+
+
+async def _load_remote_skill(
+    skill_source_id: str,
+    name: str,
+    version: str = "",
+) -> object:
+    if skill_source_id.startswith(FINDSKILL_SOURCE_PREFIX):
+        slug = skill_source_id.removeprefix(FINDSKILL_SOURCE_PREFIX).strip("/")
+        if not slug:
+            raise CapabilityError("FindSkill slug is empty.")
+        return await asyncio.to_thread(
+            _load_findskill_skill,
+            slug,
+            name,
+            version,
+        )
+
+    from veadk.skills.registry import VeSkillRegistry
+
+    registry = VeSkillRegistry(skill_source_id=skill_source_id)
+    return await registry.get_skill(name=name)
+
+
+def _load_findskill_skill(slug: str, name: str, version: str) -> object:
+    from google.adk.skills import load_skill_from_dir
+
+    from veadk.cloud.harness_app.utils import _download_and_extract_skill
+
+    cache_key = hashlib.sha256(f"{slug}\0{version}".encode()).hexdigest()[:16]
+    cache_dir = Path(tempfile.gettempdir()) / "veadk" / "session-skills" / cache_key
+    expected_dir = cache_dir / name
+    if (expected_dir / "SKILL.md").is_file() or (expected_dir / "skill.md").is_file():
+        return load_skill_from_dir(expected_dir)
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return load_skill_from_dir(_download_and_extract_skill(slug, cache_dir))
+
+
+async def _search_findskill(
+    *,
+    query: str,
+    page_number: int,
+    page_size: int,
+) -> dict[str, Any]:
+    import httpx
+
+    params: dict[str, str | int] = {
+        "pageNumber": page_number,
+        "pageSize": page_size,
+    }
+    if query.strip():
+        params["query"] = query.strip()
+    async with httpx.AsyncClient(timeout=20, follow_redirects=True) as client:
+        response = await client.get(FINDSKILL_SEARCH_URL, params=params)
+        response.raise_for_status()
+    payload = response.json()
+    raw_items = payload.get("Skills", []) if isinstance(payload, dict) else []
+    items = []
+    for raw in raw_items if isinstance(raw_items, list) else []:
+        if not isinstance(raw, dict):
+            continue
+        slug = str(raw.get("Slug") or "").strip("/")
+        name = str(raw.get("Name") or "").strip()
+        if not slug or not name:
+            continue
+        metadata = raw.get("Metadata") if isinstance(raw.get("Metadata"), dict) else {}
+        evaluation = (
+            raw.get("EvaluationMetadata")
+            if isinstance(raw.get("EvaluationMetadata"), dict)
+            else {}
+        )
+        items.append(
+            {
+                "slug": slug,
+                "name": name,
+                "description": str(
+                    metadata.get("DisplayDescription") or raw.get("Description") or ""
+                ),
+                "sourceType": str(raw.get("SourceType") or ""),
+                "sourceRepo": str(raw.get("SourceRepo") or ""),
+                "downloadCount": int(raw.get("DownloadCount") or 0),
+                "evaluationScore": float(raw.get("EvaluationScore") or 0),
+                "version": str(evaluation.get("skill_version") or ""),
+                "updatedAt": str(raw.get("UpdatedAt") or ""),
+            }
+        )
+    total = (
+        int(payload.get("Total") or len(items))
+        if isinstance(payload, dict)
+        else len(items)
+    )
+    return {"items": items, "totalCount": total}
+
+
+def _skill_catalog_client(region: str) -> Any:
+    from agentkit.sdk.skills.client import AgentkitSkillsClient
+
+    from veadk.skills.utils import _get_cloud_credentials
+
+    access_key, secret_key, session_token = _get_cloud_credentials()
+    return AgentkitSkillsClient(
+        access_key=access_key,
+        secret_key=secret_key,
+        region=region,
+        session_token=session_token,
+    )
+
+
+async def _list_skill_spaces(region: str) -> dict[str, Any]:
+    from agentkit.sdk.skills.types import ListSkillSpacesRequest
+
+    regions = ["cn-beijing", "cn-shanghai"] if region == "all" else [region]
+    items: list[dict[str, Any]] = []
+    for current_region in regions:
+        client = _skill_catalog_client(current_region)
+        response = await asyncio.to_thread(
+            client.list_skill_spaces,
+            ListSkillSpacesRequest(PageNumber=1, PageSize=100),
+        )
+        for space in response.items or []:
+            items.append(
+                {
+                    "id": space.id or "",
+                    "name": space.name or "",
+                    "description": space.description or "",
+                    "status": space.status or "",
+                    "region": current_region,
+                    "projectName": space.project_name or "",
+                    "updatedAt": space.update_time_stamp or "",
+                    "skillCount": len(space.relations or []),
+                }
+            )
+    return {"items": items, "totalCount": len(items)}
+
+
+async def _list_skills_in_space(
+    *,
+    space_id: str,
+    region: str,
+) -> dict[str, Any]:
+    from agentkit.sdk.skills.types import ListSkillsBySkillSpaceRequest
+
+    client = _skill_catalog_client(region)
+    response = await asyncio.to_thread(
+        client.list_skills_by_skill_space,
+        ListSkillsBySkillSpaceRequest(
+            SkillSpaceId=space_id,
+            PageNumber=1,
+            PageSize=100,
+        ),
+    )
+    items = list(response.items or [])
+    return {
+        "items": [
+            {
+                "skillId": skill.skill_id or "",
+                "skillName": skill.skill_name or "",
+                "skillDescription": skill.skill_description or "",
+                "version": skill.version or "",
+                "skillStatus": skill.skill_status or "",
+            }
+            for skill in items
+        ],
+        "totalCount": (
+            response.total_count if response.total_count is not None else len(items)
+        ),
+    }
+
+
+class SessionCapabilityService:
+    """Persist capability overlays and assemble an agent for a single run."""
+
+    def __init__(
+        self,
+        *,
+        root_agent: BaseAgent,
+        session_service: BaseSessionService,
+    ) -> None:
+        self.root_agent = root_agent
+        self.session_service = session_service
+
+    async def get_session(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        session_id: str,
+    ) -> Session:
+        session = await self.session_service.get_session(
+            app_name=app_name,
+            user_id=user_id,
+            session_id=session_id,
+        )
+        if session is None:
+            raise SessionNotFoundError(f"Session not found: {session_id}")
+        return session
+
+    def overlay_from_session(self, session: Session) -> SessionCapabilityOverlay:
+        raw = (session.state or {}).get(SESSION_CAPABILITIES_STATE_KEY)
+        if raw is None:
+            return SessionCapabilityOverlay()
+        try:
+            overlay = SessionCapabilityOverlay.model_validate(raw)
+        except ValidationError as exc:
+            raise CapabilityConflictError(
+                "The session capability configuration is invalid."
+            ) from exc
+        if overlay.schema_version != SESSION_CAPABILITIES_SCHEMA_VERSION:
+            raise CapabilityConflictError(
+                f"Unsupported capability schema version: {overlay.schema_version}"
+            )
+        return overlay
+
+    async def get_capabilities(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        session_id: str,
+    ) -> SessionCapabilitiesResponse:
+        session = await self.get_session(
+            app_name=app_name,
+            user_id=user_id,
+            session_id=session_id,
+        )
+        return self._response(self.overlay_from_session(session))
+
+    async def add_capability(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        session_id: str,
+        request: AddCapabilityRequest,
+    ) -> SessionCapabilitiesResponse:
+        session = await self.get_session(
+            app_name=app_name,
+            user_id=user_id,
+            session_id=session_id,
+        )
+        overlay = self.overlay_from_session(session)
+        self._check_revision(overlay, request.expected_revision)
+
+        if request.kind == "tool":
+            self._add_tool(overlay, request.name)
+        else:
+            self._add_skill(overlay, request)
+
+        overlay.revision += 1
+        await self._persist(session, overlay)
+        return self._response(overlay)
+
+    async def remove_capability(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        session_id: str,
+        capability_id: str,
+        expected_revision: int | None = None,
+    ) -> SessionCapabilitiesResponse:
+        session = await self.get_session(
+            app_name=app_name,
+            user_id=user_id,
+            session_id=session_id,
+        )
+        overlay = self.overlay_from_session(session)
+        self._check_revision(overlay, expected_revision)
+
+        if capability_id.startswith("base:"):
+            raise CapabilityConflictError("Base capabilities cannot be removed.")
+
+        before = len(overlay.tools) + len(overlay.skills)
+        overlay.tools = [
+            tool
+            for tool in overlay.tools
+            if f"session:tool:{tool.ref.removeprefix('builtin:')}" != capability_id
+        ]
+        overlay.skills = [
+            skill for skill in overlay.skills if skill.id != capability_id
+        ]
+        if len(overlay.tools) + len(overlay.skills) == before:
+            raise SessionNotFoundError(f"Capability not found: {capability_id}")
+
+        overlay.revision += 1
+        await self._persist(session, overlay)
+        return self._response(overlay)
+
+    async def build_agent(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        session_id: str,
+    ) -> BaseAgent:
+        session = await self.get_session(
+            app_name=app_name,
+            user_id=user_id,
+            session_id=session_id,
+        )
+        overlay = self.overlay_from_session(session)
+        agent = self.root_agent.clone(update={})
+
+        agent_tools = getattr(agent, "tools", None)
+        if agent_tools is None and (overlay.tools or overlay.skills):
+            raise CapabilityConflictError(
+                "Session capabilities can only be mounted on an agent with tools."
+            )
+        if agent_tools is None:
+            agent_tools = []
+        existing_tools = {_tool_name(tool) for tool in agent_tools}
+        for stored_tool in overlay.tools:
+            name = stored_tool.ref.removeprefix("builtin:")
+            if name not in existing_tools:
+                agent_tools.append(get_builtin_tool(name))
+                existing_tools.add(name)
+
+        loaded_skills = []
+        for stored_skill in overlay.skills:
+            loaded_skills.append(
+                await _load_remote_skill(
+                    stored_skill.skill_source_id,
+                    stored_skill.name,
+                    stored_skill.version,
+                )
+            )
+        if loaded_skills:
+            agent_tools.append(SkillToolset(skills=loaded_skills))
+            instruction = getattr(agent, "instruction", None)
+            if isinstance(instruction, str):
+                skill_names = ", ".join(
+                    f"`{getattr(skill, 'name', stored.name)}`"
+                    for skill, stored in zip(loaded_skills, overlay.skills)
+                )
+                skill_hint = (
+                    "Session-mounted skills available in this conversation: "
+                    f"{skill_names}. Before calling load_skill, call list_skills "
+                    "and pass the exact skill name it returns; do not abbreviate "
+                    "or translate the name."
+                )
+                agent.instruction = (
+                    f"{instruction.rstrip()}\n\n{skill_hint}"
+                    if instruction.strip()
+                    else skill_hint
+                )
+        return agent
+
+    def _base_tool_names(self) -> list[str]:
+        return sorted(
+            {_tool_name(tool) for tool in getattr(self.root_agent, "tools", None) or []}
+        )
+
+    def _base_skills(self) -> list[dict[str, str]]:
+        return agent_skill_summaries(self.root_agent)
+
+    def _response(
+        self, overlay: SessionCapabilityOverlay
+    ) -> SessionCapabilitiesResponse:
+        tools = [
+            CapabilityItem(
+                id=f"base:tool:{name}",
+                kind="tool",
+                name=name,
+                custom=False,
+            )
+            for name in self._base_tool_names()
+        ]
+        tools.extend(
+            CapabilityItem(
+                id=f"session:tool:{tool.ref.removeprefix('builtin:')}",
+                kind="tool",
+                name=tool.ref.removeprefix("builtin:"),
+                custom=True,
+            )
+            for tool in overlay.tools
+        )
+
+        skills = [
+            CapabilityItem(
+                id=f"base:skill:{skill['name']}",
+                kind="skill",
+                name=skill["name"],
+                description=skill.get("description", ""),
+                custom=False,
+            )
+            for skill in self._base_skills()
+        ]
+        skills.extend(
+            CapabilityItem(
+                id=skill.id,
+                kind="skill",
+                name=skill.name,
+                description=skill.description,
+                skill_source_id=skill.skill_source_id,
+                version=skill.version,
+                custom=True,
+            )
+            for skill in overlay.skills
+        )
+        return SessionCapabilitiesResponse(
+            schema_version=overlay.schema_version,
+            revision=overlay.revision,
+            tools=tools,
+            skills=skills,
+        )
+
+    def _add_tool(self, overlay: SessionCapabilityOverlay, name: str) -> None:
+        if name not in list_builtin_tools():
+            raise CapabilityError(f"Unknown built-in tool: {name}")
+        if name in self._base_tool_names():
+            raise CapabilityConflictError(
+                f"Tool is already provided by the base agent: {name}"
+            )
+        ref = f"builtin:{name}"
+        if any(tool.ref == ref for tool in overlay.tools):
+            raise CapabilityConflictError(f"Tool is already mounted: {name}")
+        overlay.tools.append(StoredTool(ref=ref))
+
+    def _add_skill(
+        self,
+        overlay: SessionCapabilityOverlay,
+        request: AddCapabilityRequest,
+    ) -> None:
+        base_skill_names = {skill["name"] for skill in self._base_skills()}
+        if request.name in base_skill_names:
+            raise CapabilityConflictError(
+                f"Skill is already provided by the base agent: {request.name}"
+            )
+        if any(skill.name == request.name for skill in overlay.skills):
+            raise CapabilityConflictError(f"Skill is already mounted: {request.name}")
+        skill_source_id = request.skill_source_id or ""
+        overlay.skills.append(
+            StoredSkill(
+                id=_skill_id(skill_source_id, request.name),
+                skill_source_id=skill_source_id,
+                name=request.name,
+                description=request.description.strip(),
+                version=request.version.strip(),
+            )
+        )
+
+    @staticmethod
+    def _check_revision(
+        overlay: SessionCapabilityOverlay,
+        expected_revision: int | None,
+    ) -> None:
+        if expected_revision is not None and expected_revision != overlay.revision:
+            raise CapabilityConflictError(
+                f"Capability revision changed: expected {expected_revision}, "
+                f"current {overlay.revision}"
+            )
+
+    async def _persist(
+        self,
+        session: Session,
+        overlay: SessionCapabilityOverlay,
+    ) -> None:
+        event = Event(
+            invocation_id=f"harness-config-{uuid4().hex}",
+            author=str(getattr(self.root_agent, "name", "") or "system"),
+            actions=EventActions(
+                state_delta={
+                    SESSION_CAPABILITIES_STATE_KEY: overlay.model_dump(mode="json")
+                }
+            ),
+        )
+        await self.session_service.append_event(session, event)
+
+
+def mount_session_capability_routes(
+    *,
+    app: FastAPI,
+    service: SessionCapabilityService,
+) -> None:
+    """Mount the capability management API under the reserved harness prefix."""
+
+    router = APIRouter(prefix="/harness")
+
+    @router.get("/capabilities/tools")
+    async def list_tools() -> dict[str, list[dict[str, str]]]:
+        return {
+            "tools": [
+                {"name": name, "ref": f"builtin:{name}"}
+                for name in list_builtin_tools()
+            ]
+        }
+
+    @router.get("/skills/spaces")
+    async def list_skill_spaces(region: str = "all") -> dict[str, Any]:
+        try:
+            return await _list_skill_spaces(region)
+        except FileNotFoundError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail="服务端未配置火山引擎凭证，无法读取 Skill Hub。",
+            ) from exc
+        except Exception as exc:
+            raise HTTPException(
+                status_code=502,
+                detail="暂时无法加载 Skill Space，请稍后重试。",
+            ) from exc
+
+    @router.get("/skills/findskill")
+    async def search_findskill(
+        query: str = "",
+        page_number: int = Query(default=1, ge=1),
+        page_size: int = Query(default=20, ge=1, le=50),
+    ) -> dict[str, Any]:
+        try:
+            return await _search_findskill(
+                query=query,
+                page_number=page_number,
+                page_size=page_size,
+            )
+        except Exception as exc:
+            raise HTTPException(
+                status_code=502,
+                detail="暂时无法搜索 Skill Hub，请稍后重试。",
+            ) from exc
+
+    @router.get("/skills/spaces/{space_id}/skills")
+    async def list_skills_in_space(
+        space_id: str,
+        region: str = "cn-beijing",
+    ) -> dict[str, Any]:
+        try:
+            return await _list_skills_in_space(
+                space_id=space_id,
+                region=region,
+            )
+        except FileNotFoundError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail="服务端未配置火山引擎凭证，无法读取 Skill Hub。",
+            ) from exc
+        except Exception as exc:
+            raise HTTPException(
+                status_code=502,
+                detail="暂时无法加载该 Skill Space 的技能，请稍后重试。",
+            ) from exc
+
+    @router.get("/apps/{app_name}/users/{user_id}/sessions/{session_id}/capabilities")
+    async def get_capabilities(
+        app_name: str,
+        user_id: str,
+        session_id: str,
+    ) -> SessionCapabilitiesResponse:
+        return await _translate_errors(
+            service.get_capabilities(
+                app_name=app_name,
+                user_id=user_id,
+                session_id=session_id,
+            )
+        )
+
+    @router.post("/apps/{app_name}/users/{user_id}/sessions/{session_id}/capabilities")
+    async def add_capability(
+        app_name: str,
+        user_id: str,
+        session_id: str,
+        request: AddCapabilityRequest,
+    ) -> SessionCapabilitiesResponse:
+        return await _translate_errors(
+            service.add_capability(
+                app_name=app_name,
+                user_id=user_id,
+                session_id=session_id,
+                request=request,
+            )
+        )
+
+    @router.delete(
+        "/apps/{app_name}/users/{user_id}/sessions/{session_id}/capabilities/{capability_id}"
+    )
+    async def remove_capability(
+        app_name: str,
+        user_id: str,
+        session_id: str,
+        capability_id: str,
+        expected_revision: int | None = Query(default=None),
+    ) -> SessionCapabilitiesResponse:
+        return await _translate_errors(
+            service.remove_capability(
+                app_name=app_name,
+                user_id=user_id,
+                session_id=session_id,
+                capability_id=capability_id,
+                expected_revision=expected_revision,
+            )
+        )
+
+    app.include_router(router)
+
+
+async def _translate_errors(awaitable: Any) -> Any:
+    try:
+        return await awaitable
+    except CapabilityError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc

--- a/veadk/skills/registry.py
+++ b/veadk/skills/registry.py
@@ -19,8 +19,16 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
-from google.adk.skills import Frontmatter, Skill as ADKSkill, SkillRegistry
-from google.adk.skills import load_skill_from_dir
+from google.adk.skills import Frontmatter, load_skill_from_dir
+from google.adk.skills import Skill as ADKSkill
+
+try:
+    from google.adk.skills import SkillRegistry
+except ImportError:  # google-adk 1.32 does not export the registry base yet.
+
+    class SkillRegistry:  # type: ignore[no-redef]
+        pass
+
 
 from veadk.skills.materializer import materialize_remote_skill
 from veadk.skills.skill import Skill as VeADKSkill


### PR DESCRIPTION
## Summary

- persist session-scoped built-in tool and skill overlays in ADK session state
- add `/harness` capability, skill catalog, and session-aware streaming routes
- let users add or remove tools and skills from the conversation capability panel, with separate Skill Hub and AgentKit Skill Center sources
- show single-Agent topology and refine thinking, tool-call, scrolling, and smooth streaming presentation

## Verification

- `pre-commit run --all-files`
- `uv run pytest -n 16` (875 passed, 2 skipped)
- `npm test` (169 passed)
- `npm run build`
- browser end-to-end verification for session capability changes and progressive reasoning/answer rendering