### PR TITLE
feat(ci): cache Studio release dependencies

### DIFF
--- a/.github/workflows/publish-studio-release.yaml
+++ b/.github/workflows/publish-studio-release.yaml
@@ -90,8 +90,11 @@ jobs:
           npm run build --prefix frontend -- \
             --outDir "$prepared_root/frontend"
           python -m veadk.cli.studio_dependencies \
-            --output-dir "$prepared_root/wheels"
-          tar -C "$source_parent" -czf "$archive" \
+            --output-dir "$prepared_root/wheels" \
+            --manifest "$prepared_root/dependencies.json"
+          tar -C "$source_parent" \
+            --exclude="veadk-python-${GITHUB_SHA}/.studio-release/wheels" \
+            -czf "$archive" \
             "veadk-python-${GITHUB_SHA}"
           echo "archive=$archive" >> "$GITHUB_OUTPUT"
           echo "source_root=$source_root" >> "$GITHUB_OUTPUT"

--- a/frontend/service/studio_release_server/app.py
+++ b/frontend/service/studio_release_server/app.py
@@ -38,6 +38,7 @@ from frontend.service.studio_release_server.service import (
     ReleaseService,
 )
 from frontend.service.studio_release_server.tos_store import (
+    TosDependencyStore,
     TosJobStore,
     TosSourceStore,
 )
@@ -64,6 +65,7 @@ def create_app(
                 builder=StudioReleaseBuilder(
                     resolved_settings,
                     source_store=source_store,
+                    dependency_store=TosDependencyStore(resolved_settings),
                 ),
                 source_store=source_store,
             )

--- a/frontend/service/studio_release_server/builder.py
+++ b/frontend/service/studio_release_server/builder.py
@@ -40,6 +40,7 @@ from frontend.service.studio_release_server.models import (
     ReleaseServerSettings,
 )
 from frontend.service.studio_release_server.tos_store import (
+    DependencyStore,
     SourceStore,
     resolve_credentials,
 )
@@ -80,9 +81,11 @@ class StudioReleaseBuilder:
         settings: ReleaseServerSettings,
         *,
         source_store: SourceStore | None = None,
+        dependency_store: DependencyStore | None = None,
     ) -> None:
         self._settings = settings
         self._source_store = source_store
+        self._dependency_store = dependency_store
 
     def build(
         self,
@@ -100,7 +103,11 @@ class StudioReleaseBuilder:
 
             prepared_root = source_root / ".studio-release"
             frontend_assets = prepared_root / "frontend"
-            dependency_wheels = prepared_root / "wheels"
+            dependency_wheels = self._prepare_dependency_wheels(
+                prepared_root,
+                workspace,
+                on_progress,
+            )
             tools_started = time.monotonic()
             if (frontend_assets / "index.html").is_file():
                 on_progress("preparing", "正在校验预构建前端与依赖包")
@@ -130,7 +137,9 @@ class StudioReleaseBuilder:
                     else None
                 ),
                 dependency_wheels=(
-                    dependency_wheels if dependency_wheels.is_dir() else None
+                    dependency_wheels
+                    if dependency_wheels is not None and dependency_wheels.is_dir()
+                    else None
                 ),
             )
             publish_seconds = time.monotonic() - publish_started
@@ -153,6 +162,23 @@ class StudioReleaseBuilder:
                     "totalSeconds": round(total_seconds, 3),
                 },
             )
+
+    def _prepare_dependency_wheels(
+        self,
+        prepared_root: Path,
+        workspace: Path,
+        on_progress: ProgressCallback,
+    ) -> Path | None:
+        dependency_manifest = prepared_root / "dependencies.json"
+        if dependency_manifest.is_file():
+            if self._dependency_store is None:
+                raise RuntimeError("Studio dependency cache is not configured.")
+            on_progress("preparing", "正在从 TOS 缓存恢复 Studio 依赖包")
+            destination = workspace / "dependency-wheels"
+            self._dependency_store.materialize(dependency_manifest, destination)
+            return destination
+        prepared_wheels = prepared_root / "wheels"
+        return prepared_wheels if prepared_wheels.is_dir() else None
 
     def _download_source(
         self,

--- a/frontend/service/studio_release_server/tos_store.py
+++ b/frontend/service/studio_release_server/tos_store.py
@@ -16,8 +16,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
+import urllib.request
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -30,6 +32,7 @@ from frontend.service.studio_release_server.models import (
 )
 
 _IAM_CREDENTIAL_PATH = Path("/var/run/secrets/iam/credential")
+_MAX_DEPENDENCY_WHEEL_BYTES = 128 * 1024 * 1024
 
 
 @dataclass(frozen=True)
@@ -97,6 +100,18 @@ class SourceStore(Protocol):
         on_progress: Callable[[int], None],
     ) -> None:
         """Download one source archive and remove its staging object."""
+        ...
+
+
+class DependencyStore(Protocol):
+    """Materialize verified Studio dependency wheels from a durable cache."""
+
+    def materialize(
+        self,
+        manifest: Path,
+        destination: Path,
+    ) -> tuple[Path, ...]:
+        """Restore cached wheels, populating missing entries from their origin."""
         ...
 
 
@@ -229,9 +244,124 @@ class TosSourceStore:
         )
 
 
+class TosDependencyStore:
+    """Cache pinned Studio wheels in TOS by their immutable checksum."""
+
+    def __init__(
+        self,
+        settings: ReleaseServerSettings,
+        *,
+        client_factory: Callable[[], Any] | None = None,
+    ) -> None:
+        self._settings = settings
+        self._client_factory = client_factory or self._new_client
+
+    def materialize(
+        self,
+        manifest: Path,
+        destination: Path,
+    ) -> tuple[Path, ...]:
+        """Restore every verified wheel, downloading only cache misses."""
+        wheels = self._load_manifest(manifest)
+        destination.mkdir(parents=True, exist_ok=True)
+        client = self._client_factory()
+        staged: list[Path] = []
+        for filename, url, sha256 in wheels:
+            key = self._cache_key(filename, sha256)
+            content = self._get_cached(client, key, sha256)
+            if content is None:
+                content = self._download(url, sha256)
+                client.put_object(
+                    bucket=self._settings.bucket,
+                    key=key,
+                    content=content,
+                    content_type="application/octet-stream",
+                )
+            target = destination / filename
+            target.write_bytes(content)
+            staged.append(target)
+        return tuple(staged)
+
+    def _load_manifest(self, manifest: Path) -> tuple[tuple[str, str, str], ...]:
+        payload = json.loads(manifest.read_text(encoding="utf-8"))
+        raw_wheels = payload.get("wheels") if isinstance(payload, dict) else None
+        if not isinstance(raw_wheels, list) or not raw_wheels or len(raw_wheels) > 32:
+            raise ValueError("Studio dependency manifest is invalid.")
+        wheels: list[tuple[str, str, str]] = []
+        for raw in raw_wheels:
+            if not isinstance(raw, dict):
+                raise ValueError("Studio dependency manifest is invalid.")
+            filename = raw.get("filename")
+            url = raw.get("url")
+            sha256 = raw.get("sha256")
+            if (
+                not isinstance(filename, str)
+                or Path(filename).name != filename
+                or not filename.endswith(".whl")
+                or not isinstance(url, str)
+                or not url.startswith("https://")
+                or not isinstance(sha256, str)
+                or len(sha256) != 64
+            ):
+                raise ValueError("Studio dependency manifest is invalid.")
+            try:
+                int(sha256, 16)
+            except ValueError as error:
+                raise ValueError("Studio dependency manifest is invalid.") from error
+            wheels.append((filename, url, sha256.lower()))
+        return tuple(wheels)
+
+    def _cache_key(self, filename: str, sha256: str) -> str:
+        prefix = self._settings.job_prefix.strip().strip("/")
+        return f"{prefix}/dependency-cache/{sha256}/{filename}"
+
+    def _get_cached(self, client: Any, key: str, sha256: str) -> bytes | None:
+        try:
+            response = client.get_object(bucket=self._settings.bucket, key=key)
+        except Exception as error:  # noqa: BLE001
+            if getattr(error, "status_code", None) == 404:
+                return None
+            raise
+        content = self._read_limited(response)
+        if hashlib.sha256(content).hexdigest() != sha256:
+            return None
+        return content
+
+    def _download(self, url: str, sha256: str) -> bytes:
+        with urllib.request.urlopen(url, timeout=120) as response:
+            content = response.read(_MAX_DEPENDENCY_WHEEL_BYTES + 1)
+        if len(content) > _MAX_DEPENDENCY_WHEEL_BYTES:
+            raise ValueError("Studio dependency wheel exceeds 128 MiB.")
+        if hashlib.sha256(content).hexdigest() != sha256:
+            raise ValueError("Studio dependency wheel checksum verification failed.")
+        return content
+
+    def _read_limited(self, response: Any) -> bytes:
+        content = bytearray()
+        for chunk in response:
+            if len(content) + len(chunk) > _MAX_DEPENDENCY_WHEEL_BYTES:
+                raise ValueError("Cached Studio dependency wheel exceeds 128 MiB.")
+            content.extend(chunk)
+        return bytes(content)
+
+    def _new_client(self) -> Any:
+        import tos
+
+        credentials = resolve_credentials()
+        return tos.TosClientV2(
+            credentials.access_key,
+            credentials.secret_key,
+            security_token=credentials.session_token or None,
+            endpoint=f"tos-{self._settings.region}.volces.com",
+            region=self._settings.region,
+        )
+
+
 __all__ = [
+    "DependencyStore",
     "JobStore",
     "SourceStore",
+    "TosDependencyStore",
     "TosJobStore",
     "TosSourceStore",
     "VolcengineCredentials",

--- a/tests/cli/test_studio_release.py
+++ b/tests/cli/test_studio_release.py
@@ -23,6 +23,7 @@ import pytest
 from veadk.cli.studio_dependencies import (
     StudioDependencyWheel,
     stage_studio_dependency_wheels,
+    write_studio_dependency_manifest,
 )
 from veadk.cli.studio_release import (
     StudioReleaseError,
@@ -245,6 +246,43 @@ def test_stage_dependency_wheels_copies_only_verified_content(
 
     assert [path.name for path in staged] == [dependency.filename]
     assert staged[0].read_bytes() == content
+
+
+def test_write_dependency_manifest_uses_pinned_wheel_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dependency = StudioDependencyWheel(
+        filename="prepared.whl",
+        url="https://example.com/prepared.whl",
+        sha256="a" * 64,
+    )
+    monkeypatch.setattr(
+        "veadk.cli.studio_dependencies.STUDIO_DEPENDENCY_WHEELS",
+        (dependency,),
+    )
+    manifest = tmp_path / "dependencies.json"
+
+    write_studio_dependency_manifest(manifest)
+
+    assert json.loads(manifest.read_text(encoding="utf-8")) == {
+        "wheels": [
+            {
+                "filename": dependency.filename,
+                "url": dependency.url,
+                "sha256": dependency.sha256,
+            }
+        ]
+    }
+
+
+def test_publish_workflow_excludes_wheels_from_cross_region_archive() -> None:
+    workflow = (
+        Path(__file__).parents[2] / ".github/workflows/publish-studio-release.yaml"
+    ).read_text(encoding="utf-8")
+
+    assert '--manifest "$prepared_root/dependencies.json"' in workflow
+    assert '--exclude="veadk-python-${GITHUB_SHA}/.studio-release/wheels"' in workflow
 
 
 def test_build_release_uses_prepared_frontend_and_wheels(

--- a/tests/test_studio_release_server.py
+++ b/tests/test_studio_release_server.py
@@ -16,8 +16,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.machinery
 import io
+import json
 import shutil
 import subprocess
 import tarfile
@@ -42,6 +44,7 @@ from frontend.service.studio_release_server import (
     create_app,
 )
 from frontend.service.studio_release_server import deploy as release_deploy
+from frontend.service.studio_release_server.tos_store import TosDependencyStore
 
 
 class _InlineExecutor(Executor):
@@ -119,6 +122,48 @@ class _SuccessfulBuilder:
             createdAt="2026-07-24T23:59:59+08:00",
             timings={"totalSeconds": 1.25},
         )
+
+
+class _NotFoundError(Exception):
+    status_code = 404
+
+
+class _DependencyCacheClient:
+    def __init__(self) -> None:
+        self.objects: dict[tuple[str, str], bytes] = {}
+
+    def get_object(self, *, bucket: str, key: str) -> list[bytes]:
+        try:
+            return [self.objects[(bucket, key)]]
+        except KeyError as error:
+            raise _NotFoundError(key) from error
+
+    def put_object(
+        self,
+        *,
+        bucket: str,
+        key: str,
+        content: bytes,
+        content_type: str,
+    ) -> None:
+        assert content_type == "application/octet-stream"
+        self.objects[(bucket, key)] = content
+
+
+class _MemoryDependencyStore:
+    def __init__(self) -> None:
+        self.manifest: Path | None = None
+
+    def materialize(
+        self,
+        manifest: Path,
+        destination: Path,
+    ) -> tuple[Path, ...]:
+        self.manifest = manifest
+        destination.mkdir(parents=True)
+        wheel = destination / "dependency.whl"
+        wheel.write_bytes(b"wheel")
+        return (wheel,)
 
 
 def _settings() -> ReleaseServerSettings:
@@ -313,6 +358,108 @@ def test_builder_rejects_unsafe_source_archive_entry(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="unsupported entry"):
         builder._extract_source(archive, tmp_path)
+
+
+def test_tos_dependency_store_populates_and_reuses_cached_wheel(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    content = b"dependency-wheel"
+    digest = hashlib.sha256(content).hexdigest()
+    manifest = tmp_path / "dependencies.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "wheels": [
+                    {
+                        "filename": "dependency.whl",
+                        "url": "https://example.com/dependency.whl",
+                        "sha256": digest,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    downloads = 0
+
+    def _urlopen(_url: str, *, timeout: int) -> io.BytesIO:
+        nonlocal downloads
+        assert timeout == 120
+        downloads += 1
+        return io.BytesIO(content)
+
+    monkeypatch.setattr(
+        "frontend.service.studio_release_server.tos_store.urllib.request.urlopen",
+        _urlopen,
+    )
+    client = _DependencyCacheClient()
+    store = TosDependencyStore(_settings(), client_factory=lambda: client)
+
+    first = store.materialize(manifest, tmp_path / "first")
+    second = store.materialize(manifest, tmp_path / "second")
+
+    assert [path.read_bytes() for path in first] == [content]
+    assert [path.read_bytes() for path in second] == [content]
+    assert downloads == 1
+
+
+def test_builder_restores_manifest_dependencies_from_cache(tmp_path: Path) -> None:
+    prepared_root = tmp_path / ".studio-release"
+    prepared_root.mkdir()
+    manifest = prepared_root / "dependencies.json"
+    manifest.write_text('{"wheels": []}\n', encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    dependency_store = _MemoryDependencyStore()
+    progress: list[tuple[str, str]] = []
+    builder = StudioReleaseBuilder(
+        _settings(),
+        dependency_store=dependency_store,
+    )
+
+    wheels = builder._prepare_dependency_wheels(
+        prepared_root,
+        workspace,
+        lambda stage, message: progress.append((stage, message)),
+    )
+
+    assert wheels == workspace / "dependency-wheels"
+    assert dependency_store.manifest == manifest
+    assert (wheels / "dependency.whl").read_bytes() == b"wheel"
+    assert progress == [("preparing", "正在从 TOS 缓存恢复 Studio 依赖包")]
+
+
+def test_tos_dependency_store_rejects_download_with_wrong_checksum(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = tmp_path / "dependencies.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "wheels": [
+                    {
+                        "filename": "dependency.whl",
+                        "url": "https://example.com/dependency.whl",
+                        "sha256": "a" * 64,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "frontend.service.studio_release_server.tos_store.urllib.request.urlopen",
+        lambda _url, *, timeout: io.BytesIO(b"tampered"),
+    )
+    store = TosDependencyStore(
+        _settings(),
+        client_factory=lambda: _DependencyCacheClient(),
+    )
+
+    with pytest.raises(ValueError, match="checksum"):
+        store.materialize(manifest, tmp_path / "destination")
 
 
 def test_stage_deployment_uses_frontend_service_package(

--- a/veadk/cli/studio_dependencies.py
+++ b/veadk/cli/studio_dependencies.py
@@ -101,9 +101,29 @@ def stage_studio_dependency_wheels(
     return tuple(staged)
 
 
+def write_studio_dependency_manifest(destination: Path) -> None:
+    """Write the pinned wheel metadata consumed by the release-server cache."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "wheels": [
+            {
+                "filename": dependency.filename,
+                "url": dependency.url,
+                "sha256": dependency.sha256,
+            }
+            for dependency in STUDIO_DEPENDENCY_WHEELS
+        ]
+    }
+    destination.write_text(
+        json.dumps(payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path)
     return parser
 
 
@@ -111,6 +131,8 @@ def main() -> None:
     """Download verified wheels for a prepared Studio source archive."""
     args = _parser().parse_args()
     staged = stage_studio_dependency_wheels(args.output_dir)
+    if args.manifest is not None:
+        write_studio_dependency_manifest(args.manifest)
     print(json.dumps({"wheels": [path.name for path in staged]}))
 
 
@@ -122,4 +144,5 @@ __all__ = [
     "STUDIO_DEPENDENCY_WHEELS",
     "StudioDependencyWheel",
     "stage_studio_dependency_wheels",
+    "write_studio_dependency_manifest",
 ]


### PR DESCRIPTION
## Summary

- write a pinned dependency manifest into staged Studio release sources
- exclude stable dependency wheels from the cross-region source archive
- materialize dependencies from a SHA-256-addressed TOS cache in the Beijing release server
- download, verify, and populate cache misses from the pinned HTTPS origin

## Impact

Using the source from failed run 30187787789, excluding dependency wheels reduces the compressed upload from 37 MB to 2.0 MB. Cached wheels are checksum-verified before every build.

## Validation

- `uv run --group dev pytest -q tests/test_studio_release_server.py tests/cli/test_studio_release.py` (29 passed)
- changed-file pre-commit hooks passed
- archive exclusion verified against the previous release artifact
- `git diff --check`