### PR TITLE
fix(studio): keep application in deployment region

### DIFF
--- a/docs/content/docs/framework/frontend.en.mdx
+++ b/docs/content/docs/framework/frontend.en.mdx
@@ -296,9 +296,8 @@ veadk studio deploy \
 also supports `cn-shanghai`. Deployment checks the deployment region first and
 then searches the Beijing and Shanghai Identity regions. A cross-region match
 emits a warning and continues. `--project` selects the VeFaaS function project
-and defaults to `default`. For Shanghai deployments, the Function, APIG, and
-AgentKit resources remain in Shanghai while VeFaaS Application operations use
-the service's Beijing control-plane endpoint. The deployed Function records the
+and defaults to `default`. The VeFaaS Application, Function, APIG, and AgentKit
+resources use the selected deployment region. The deployed Function records the
 selected AgentKit Sandbox region so temporary chat and Skill-creation sessions
 query the same region as their CodeEnv Tools.
 

--- a/tests/cli/test_studio_update.py
+++ b/tests/cli/test_studio_update.py
@@ -147,7 +147,7 @@ def test_find_studio_deployments_searches_regions_and_filters_project(
     ]
 
 
-def test_list_applications_uses_application_control_plane_region(
+def test_list_applications_uses_deployment_region(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     requested_regions: list[str] = []
@@ -164,7 +164,28 @@ def test_list_applications_uses_application_control_plane_region(
     monkeypatch.setattr("veadk.integrations.ve_faas.ve_faas.ve_request", _request)
 
     assert service._list_application(app_name="studio-app") == []
-    assert requested_regions == ["cn-beijing"]
+    assert requested_regions == ["cn-shanghai"]
+
+
+def test_application_template_matches_deployment_region(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "veadk.integrations.ve_faas.ve_faas.volcenginesdkcore.ApiClient",
+        lambda _: object(),
+    )
+    monkeypatch.setattr(
+        "veadk.integrations.ve_faas.ve_faas.volcenginesdkvefaas.VEFAASApi",
+        lambda _: object(),
+    )
+    monkeypatch.setattr(
+        "veadk.integrations.ve_faas.ve_faas.APIGateway",
+        lambda *_: object(),
+    )
+
+    service = VeFaaS("ak", "sk", region="cn-shanghai")
+
+    assert service.template_id == "6943b9de4fa45c0008ea04e1"
 
 
 def test_load_deployed_site_logo_uses_current_branding_url(
@@ -515,7 +536,7 @@ def test_update_application_code_bundle_merges_only_explicit_environment(
     }
 
 
-def test_application_control_plane_uses_beijing_for_shanghai_deployment(
+def test_application_operations_use_deployment_region(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[tuple[str, str]] = []
@@ -524,25 +545,51 @@ def test_application_control_plane_uses_beijing_for_shanghai_deployment(
     cast(Any, service).ak = "ak"
     cast(Any, service).sk = "sk"
     cast(Any, service).region = "cn-shanghai"
+    cast(Any, service).template_id = "template-id"
 
     def _ve_request(**kwargs: object) -> dict[str, object]:
         action = cast(str, kwargs["action"])
         region = cast(str, kwargs["region"])
         calls.append((action, region))
+        if action == "CreateApplication":
+            request_body = cast(dict[str, Any], kwargs["request_body"])
+            config = cast(dict[str, Any], request_body["Config"])
+            assert config["Region"] == "cn-shanghai"
+            return {"Result": {"Status": "create_success", "Id": "application-id"}}
         if action == "GetApplication":
             return {"Result": {"Status": "create_success"}}
-        return {"Result": {"Items": [], "Total": 0}}
+        if action == "ListApplications":
+            return {"Result": {"Items": [], "Total": 0}}
+        if action == "GetApplicationRevisionLog":
+            return {"Result": {"LogLines": []}}
+        return {}
 
     monkeypatch.setattr("veadk.integrations.ve_faas.ve_faas.ve_request", _ve_request)
 
+    application_id = service._create_application(
+        "studio-app",
+        "studio-function",
+        "gateway",
+        "upstream",
+        "service",
+    )
+    service._start_application_release(application_id)
     status, _ = service._get_application_status("application-id")
     applications = service._list_application(app_name="studio-app")
+    service.delete("application-id")
+    logs = service._get_application_logs("application-id", revision_number=1)
 
+    assert application_id == "application-id"
     assert status == "create_success"
     assert applications == []
+    assert logs == []
     assert calls == [
-        ("GetApplication", "cn-beijing"),
-        ("ListApplications", "cn-beijing"),
+        ("CreateApplication", "cn-shanghai"),
+        ("ReleaseApplication", "cn-shanghai"),
+        ("GetApplication", "cn-shanghai"),
+        ("ListApplications", "cn-shanghai"),
+        ("DeleteApplication", "cn-shanghai"),
+        ("GetApplicationRevisionLog", "cn-shanghai"),
     ]
 
 

--- a/veadk/integrations/ve_faas/ve_faas.py
+++ b/veadk/integrations/ve_faas/ve_faas.py
@@ -43,7 +43,10 @@ from veadk.utils.volcengine_sign import ve_request
 
 logger = get_logger(__name__)
 
-_APPLICATION_CONTROL_PLANE_REGION = "cn-beijing"
+_APPLICATION_TEMPLATE_IDS = {
+    "cn-beijing": "6874f3360bdbc40008ecf8c7",
+    "cn-shanghai": "6943b9de4fa45c0008ea04e1",
+}
 
 
 class VeFaaS:
@@ -76,7 +79,9 @@ class VeFaaS:
 
         self.apig_client = APIGateway(self.ak, self.sk, self.region)
 
-        self.template_id = "6874f3360bdbc40008ecf8c7"
+        self.template_id = _APPLICATION_TEMPLATE_IDS.get(
+            region, _APPLICATION_TEMPLATE_IDS["cn-beijing"]
+        )
 
     def _upload_and_mount_code(self, function_id: str, path: str):
         """Upload code to VeFaaS temp bucket and mount to function instance.
@@ -194,7 +199,7 @@ class VeFaaS:
             sk=self.sk,
             service="vefaas",
             version="2021-03-03",
-            region=_APPLICATION_CONTROL_PLANE_REGION,
+            region=self.region,
             host="open.volcengineapi.com",
             session_token=self.session_token,
         )
@@ -216,7 +221,7 @@ class VeFaaS:
             sk=self.sk,
             service="vefaas",
             version="2021-03-03",
-            region=_APPLICATION_CONTROL_PLANE_REGION,
+            region=self.region,
             host="open.volcengineapi.com",
             session_token=self.session_token,
         )
@@ -261,7 +266,7 @@ class VeFaaS:
             sk=self.sk,
             service="vefaas",
             version="2021-03-03",
-            region=_APPLICATION_CONTROL_PLANE_REGION,
+            region=self.region,
             host="open.volcengineapi.com",
             session_token=self.session_token,
         )
@@ -295,7 +300,7 @@ class VeFaaS:
                     sk=self.sk,
                     service="vefaas",
                     version="2021-03-03",
-                    region=_APPLICATION_CONTROL_PLANE_REGION,
+                    region=self.region,
                     host="open.volcengineapi.com",
                     session_token=self.session_token,
                 )
@@ -545,7 +550,7 @@ class VeFaaS:
                 sk=self.sk,
                 service="vefaas",
                 version="2021-03-03",
-                region=_APPLICATION_CONTROL_PLANE_REGION,
+                region=self.region,
                 host="open.volcengineapi.com",
                 session_token=self.session_token,
             )
@@ -951,7 +956,7 @@ class VeFaaS:
             sk=self.sk,
             service="vefaas",
             version="2021-03-03",
-            region=_APPLICATION_CONTROL_PLANE_REGION,
+            region=self.region,
             host="open.volcengineapi.com",
             session_token=self.session_token,
         )


### PR DESCRIPTION
## Summary

- route VeFaaS Application operations through the selected deployment region
- select the matching Beijing or Shanghai Application template
- document and test that Application, Function, APIG, and AgentKit resources share the deployment region

## Verification

- `uv run pytest -q tests/cli/test_studio_update.py tests/test_cloud.py` (18 passed)
- ruff format check and `git diff --check`
- live Shanghai deployment: Application, Function, APIG, and both CodeEnv Tools resolved in Shanghai and were absent from Beijing lookups