### PR TITLE
feat(examples): add parallel multi-agent workflow

### DIFF
--- a/examples/06_multi_agent/README.md
+++ b/examples/06_multi_agent/README.md
@@ -41,9 +41,28 @@ python main.py
 
 You'll get a polished paragraph that passed through all three stages.
 
+## Parallel case
+
+[`parallel.py`](./parallel.py) adds a fan-out/fan-in workflow:
+
+```text
+                  +-> benefits analyst -+
+user proposal ----+                     +-> synthesizer
+                  +-> risks analyst ----+
+```
+
+The two analysts have no dependency on each other, so a `ParallelAgent` runs
+them concurrently. Their `benefits` and `risks` outputs are stored in shared
+session state. The outer `SequentialAgent` waits for that parallel stage to
+finish before the synthesizer builds the final decision brief.
+
+```bash
+python parallel.py
+```
+
 ## What to try next
 
-- VeADK also ships `ParallelAgent` (run sub-agents concurrently) and `LoopAgent`
-  (repeat until a condition). Same `sub_agents=[...]` pattern.
+- VeADK also ships `LoopAgent` (repeat until a condition), using the same
+  `sub_agents=[...]` pattern.
 - For *dynamic* delegation (a coordinator that chooses which specialist to call),
   pass `sub_agents=[...]` to a regular `Agent` and let the LLM route.

--- a/examples/06_multi_agent/README.zh.md
+++ b/examples/06_multi_agent/README.zh.md
@@ -40,9 +40,27 @@ python main.py
 
 你会得到一段经过三个阶段处理、润色后的文字。
 
+## 并行案例
+
+[`parallel.py`](./parallel.py) 展示了先扇出、再汇总的工作流：
+
+```text
+              +-> 收益分析 -+
+用户提案 ------+             +-> 综合结论
+              +-> 风险分析 -+
+```
+
+两个分析任务互不依赖，因此由 `ParallelAgent` 并发执行。它们分别把结果写入共享
+会话状态的 `benefits` 和 `risks`。外层 `SequentialAgent` 会等待并行阶段全部完成，
+再让综合智能体生成最终的决策摘要。
+
+```bash
+python parallel.py
+```
+
 ## 下一步
 
-- VeADK 还提供 `ParallelAgent`（并发运行子智能体）与 `LoopAgent`（循环直到满足条件），
-  用法都是同样的 `sub_agents=[...]`。
+- VeADK 还提供 `LoopAgent`（循环直到满足条件），用法是同样的
+  `sub_agents=[...]`。
 - 若需要*动态*委派（由一个协调者智能体自行决定调用哪个专家），
   可直接给普通 `Agent` 传入 `sub_agents=[...]`，让大模型来路由。

--- a/examples/06_multi_agent/parallel.py
+++ b/examples/06_multi_agent/parallel.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run independent specialists concurrently, then combine their findings.
+
+The first stage uses `ParallelAgent` because the benefits and risks can be
+analyzed independently. A `SequentialAgent` then runs the synthesizer after
+both parallel branches have stored their results in shared session state.
+"""
+
+import asyncio
+
+from veadk import Agent, Runner
+from veadk.agents.parallel_agent import ParallelAgent
+from veadk.agents.sequential_agent import SequentialAgent
+from veadk.memory.short_term_memory import ShortTermMemory
+
+
+def build_pipeline() -> SequentialAgent:
+    benefits_analyst = Agent(
+        name="benefits_analyst",
+        instruction=(
+            "Analyze the user's proposal. Return the three strongest benefits, "
+            "including the likely impact of each one."
+        ),
+        output_key="benefits",
+    )
+
+    risks_analyst = Agent(
+        name="risks_analyst",
+        instruction=(
+            "Analyze the user's proposal. Return the three most important risks "
+            "and one practical mitigation for each risk."
+        ),
+        output_key="risks",
+    )
+
+    independent_analysis = ParallelAgent(
+        name="independent_analysis",
+        description="Analyzes benefits and risks concurrently.",
+        sub_agents=[benefits_analyst, risks_analyst],
+    )
+
+    synthesizer = Agent(
+        name="synthesizer",
+        instruction=(
+            "Turn the analyses below into a concise decision brief. Include a "
+            "recommendation, the main trade-off, and one next step.\n\n"
+            "Benefits:\n{benefits}\n\nRisks:\n{risks}"
+        ),
+        output_key="decision_brief",
+    )
+
+    return SequentialAgent(
+        name="parallel_decision_pipeline",
+        description="Runs independent analyses in parallel, then combines them.",
+        sub_agents=[independent_analysis, synthesizer],
+    )
+
+
+async def main() -> None:
+    pipeline = build_pipeline()
+    runner = Runner(
+        agent=pipeline,
+        short_term_memory=ShortTermMemory(),
+        app_name="parallel_multi_agent_demo",
+    )
+
+    result = await runner.run(
+        messages="Should our engineering team adopt a four-day on-call rotation?",
+        session_id="parallel-demo-session",
+    )
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
 ## Summary

  Add a runnable `ParallelAgent` example to the multi-agent learning path.

  ## What changed

  - Add `examples/06_multi_agent/parallel.py`.
  - Run benefits and risks analysis concurrently with `ParallelAgent`.
  - Use `output_key` to store both results in shared session state.
  - Use an outer `SequentialAgent` to run the synthesizer after both parallel branches
  finish.
  - Add usage instructions and workflow diagrams to the English and Chinese READMEs.

  ## Workflow

  ```text
                    +-> benefits analyst -+
  user proposal ----+                     +-> synthesizer
                    +-> risks analyst ----+
```

  ## Testing

  - Verified the example parses successfully.
  - Verified build_pipeline() constructs the expected workflow without making a model
    request.
