### PR TITLE
fix(studio): update Shanghai veFaaS template

### DIFF
--- a/tests/cli/test_studio_update.py
+++ b/tests/cli/test_studio_update.py
@@ -185,7 +185,7 @@ def test_application_template_matches_deployment_region(
 
     service = VeFaaS("ak", "sk", region="cn-shanghai")
 
-    assert service.template_id == "6943b9de4fa45c0008ea04e1"
+    assert service.template_id == "6a685988162bcd00083c9001"
 
 
 def test_load_deployed_site_logo_uses_current_branding_url(

--- a/veadk/integrations/ve_faas/ve_faas.py
+++ b/veadk/integrations/ve_faas/ve_faas.py
@@ -45,7 +45,7 @@ logger = get_logger(__name__)
 
 _APPLICATION_TEMPLATE_IDS = {
     "cn-beijing": "6874f3360bdbc40008ecf8c7",
-    "cn-shanghai": "6943b9de4fa45c0008ea04e1",
+    "cn-shanghai": "6a685988162bcd00083c9001",
 }
 
 


### PR DESCRIPTION
## Summary

- update the Shanghai veFaaS application template ID used by Studio deployment
- update the region template regression assertion

## Testing

- `uv run pytest tests/cli/test_studio_update.py` (15 passed)