### PR TITLE
chore(deps): require google-adk >=1.34.0

### DIFF
--- a/docs/content/docs/framework/agent/responses-api.en.mdx
+++ b/docs/content/docs/framework/agent/responses-api.en.mdx
@@ -8,20 +8,20 @@ As foundation model technology keeps advancing, the Responses API provides a mor
 
 ## Tutorial
 
-Currently only the `veadk-python` version supports the Responses API, and it has a specific requirement on the `google-adk` version (`google-adk>=1.21.0`). Make sure your environment meets the requirement.
+Currently only the `veadk-python` version supports the Responses API, and it has a specific requirement on the `google-adk` version (`google-adk>=1.34.0`). Make sure your environment meets the requirement.
 
 <Tabs items={['pip', 'uv']}>
 <Tab value="pip">
 
 ```bash
-pip install "google-adk>=1.21.0"
+pip install "google-adk>=1.34.0"
 ```
 
 </Tab>
 <Tab value="uv">
 
 ```bash
-uv pip install "google-adk>=1.21.0"
+uv pip install "google-adk>=1.34.0"
 ```
 
 </Tab>
@@ -361,7 +361,7 @@ Note: The `cached_content_token_count` of turn N is not necessarily equal to the
 
 ## Notes
 
-1. **Version requirement**: You must ensure `google-adk>=1.21.0`.
+1. **Version requirement**: You must ensure `google-adk>=1.34.0`.
 2. **Model support**: Make sure the model you use supports the Responses API (note: Doubao series models after version 0615 generally support it unless otherwise stated).
 3. **Caching mechanism**: When VeADK enables the Responses API with a Volcengine Ark model, context (session) caching is enabled by default. However, if `output_schema` is set on the Agent, caching is automatically disabled because that field conflicts with the caching mechanism.
 

--- a/docs/content/docs/framework/agent/responses-api.mdx
+++ b/docs/content/docs/framework/agent/responses-api.mdx
@@ -8,20 +8,20 @@ Responses API 是火山方舟最新推出的 API 接口，原生支持高效的�
 
 ## 使用教程
 
-目前仅 `veadk-python` 版本支持 Responses API，且对 `google-adk` 版本有特定要求（`google-adk>=1.21.0`）。请确保您的环境符合要求。
+目前仅 `veadk-python` 版本支持 Responses API，且对 `google-adk` 版本有特定要求（`google-adk>=1.34.0`）。请确保您的环境符合要求。
 
 <Tabs items={['pip', 'uv']}>
 <Tab value="pip">
 
 ```bash
-pip install "google-adk>=1.21.0"
+pip install "google-adk>=1.34.0"
 ```
 
 </Tab>
 <Tab value="uv">
 
 ```bash
-uv pip install "google-adk>=1.21.0"
+uv pip install "google-adk>=1.34.0"
 ```
 
 </Tab>
@@ -361,7 +361,7 @@ asyncio.run(
 
 ## 注意事项
 
-1. **版本要求**：必须保证 `google-adk>=1.21.0`。
+1. **版本要求**：必须保证 `google-adk>=1.34.0`。
 2. **模型支持**：请确保使用的模型支持 Responses API（注：Doubao 系列模型 0615 版本之后，除特殊说明外均支持）。
 3. **缓存机制**：VeADK 开启 Responses API 并使用火山方舟模型时默认开启上下文缓存（Session 缓存）。但若在 Agent 中设置了 `output_schema`，因该字段与缓存机制冲突，系统将自动关闭缓存。
 

--- a/examples/generated_agentkit_project/requirements.txt
+++ b/examples/generated_agentkit_project/requirements.txt
@@ -1,4 +1,4 @@
 veadk-python>=1.0.5
 agentkit-sdk-python
-google-adk
+google-adk>=1.34.0
 starlette<1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,11 @@ dependencies = [
     "pydantic-settings==2.10.1", # Config management
     "a2a-sdk==0.3.7", # For Google Agent2Agent protocol
     "deprecated==1.2.18",
-    "google-adk>=1.32.0", # For basic agent architecture
+    "google-adk>=1.34.0", # For basic agent architecture
     # litellm and sqlalchemy are required by code paths veadk always uses
     # (LiteLlm models, sessions). google-adk ships them in base on 1.x but moved
     # them behind extras ([extensions]/[db]) on 2.x, so declare them directly to
-    # stay compatible across google-adk >= 1.32.0 (including 2.x).
+    # stay compatible across google-adk >= 1.34.0 (including 2.x).
     "litellm>=1.83.7,<=1.83.14", # google-adk LiteLlm model ([extensions] on 2.x)
     "sqlalchemy>=2,<3", # google-adk sessions ([db] on 2.x)
     "opentelemetry-exporter-otlp==1.37.0",
@@ -34,7 +34,7 @@ dependencies = [
     "agent-pilot-sdk==0.1.2", # Prompt optimization by Volcengine AgentPilot/PromptPilot toolkits
     "fastmcp>=2.12.3", # For running MCP
     "trustedmcp==0.0.5", # For running TrustedMCP
-    "mcp==1.26.0", # Bumped to satisfy google-adk 1.32.0 requirement
+    "mcp==1.26.0", # Bumped to satisfy google-adk 1.34.0 requirement
     "cookiecutter==2.6.0", # For cloud deploy
     "omegaconf==2.3.0", # For agent builder
     "psycopg2-binary>=2.9.10", # For PostgreSQL database (short term memory)
@@ -88,7 +88,7 @@ pdf = [] # Backward-compatible alias; PDF support is now installed by default
 eval = [
     "prometheus-client>=0.22.1",    # For exporting data to Prometheus pushgateway
     "deepeval>=3.2.6",              # For DeepEval-based evaluation
-    "google-adk[eval]",             # For Google ADK-based evaluation
+    "google-adk[eval]>=1.34.0",     # For Google ADK-based evaluation
 ]
 harness = [
     "headroom",

--- a/veadk/cli/templates/rl/ark/requirements.txt
+++ b/veadk/cli/templates/rl/ark/requirements.txt
@@ -1,7 +1,7 @@
 https://ark-public-example-cn-beijing.tos-cn-beijing.volces.com/ark-sdk/ark_sdk-0.2.5.tar.gz
 cozeloop==0.1.18
 veadk-python==0.2.16
-google-adk==1.17.0
+google-adk>=1.34.0
 # only of bytedance fornax
 # bytedance.fornax==1.0.2
 # langchain==0.3.27

--- a/veadk/models/ark_llm.py
+++ b/veadk/models/ark_llm.py
@@ -713,8 +713,8 @@ class ArkLlm(Gemini):
         if not llm_request_has_field("previous_interaction_id"):
             raise ImportError(
                 "If using the ResponsesAPI, "
-                "please upgrade the version of google-adk to `1.21.0` or higher with the command: "
-                "`pip install -U 'google-adk>=1.21.0'`"
+                "please upgrade the version of google-adk to `1.34.0` or higher with the command: "
+                "`pip install -U 'google-adk>=1.34.0'`"
             )
         super().__init__(**kwargs)
         self.enable_responses_cache = kwargs.get("enable_responses_cache", True)


### PR DESCRIPTION
## Summary

Bump the minimum supported `google-adk` version to `1.34.0` to resolve compatibility issues around ADK `SkillRegistry`.

This updates the core dependency declaration, eval extra, runtime upgrade guidance, generated project requirements, RL template requirements, and Responses API documentation so all user-facing installation paths consistently require a compatible ADK version.

## Verification

- `UV_CACHE_DIR=/private/tmp/uv-cache uv lock --check`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv tree --depth 1`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run --extra extensions pytest`

Result: `934 passed, 3 skipped`