### PR TITLE
feat(studio): optimize agent directory experience

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1190,25 +1190,6 @@ export default function App() {
           ]),
         ),
       );
-      const failures: string[] = [];
-      for (const runtime of runtimes) {
-        try {
-          await connectRuntime(
-            runtime.runtimeId,
-            runtime.name,
-            runtime.region,
-            runtime.currentVersion,
-          );
-        } catch {
-          failures.push(runtime.name);
-        }
-      }
-      setConnections(loadConnections());
-      if (failures.length > 0) {
-        setAgentLibraryError(
-          `${failures.length} 个 Runtime 暂时无法读取，请稍后重试。`,
-        );
-      }
     } catch (cause) {
       setAgentLibraryError(cause instanceof Error ? cause.message : String(cause));
     } finally {
@@ -1537,11 +1518,17 @@ export default function App() {
   }, [access]);
 
   useEffect(() => {
-    if (authStatus !== "authenticated" || agentsSource !== "cloud" || !uiConfigLoaded) {
+    if (
+      authStatus !== "authenticated" ||
+      agentsSource !== "cloud" ||
+      !uiConfigLoaded ||
+      !manageAgents ||
+      agentDetailTarget
+    ) {
       return;
     }
     void refreshAgentLibrary();
-  }, [agentsSource, authStatus, refreshAgentLibrary, uiConfigLoaded]);
+  }, [agentDetailTarget, agentsSource, authStatus, manageAgents, refreshAgentLibrary, uiConfigLoaded]);
 
   useEffect(() => {
     document.title = siteBranding.title;
@@ -1603,25 +1590,25 @@ export default function App() {
   }
 
   useEffect(() => {
-    if (authStatus === "unauthenticated") return; // login page is shown instead
+    if (authStatus !== "authenticated") return;
+    if (agentsSource === "cloud") {
+      const saved = localStorage.getItem(LS.app);
+      const remoteIds = connections.flatMap((c) =>
+        c.apps.map((a) => remoteAppId(c.id, a)),
+      );
+      setAppName((current) => {
+        if (current && remoteIds.includes(current)) return current;
+        if (saved && remoteIds.includes(saved)) return saved;
+        return remoteIds[0] ?? "";
+      });
+      return;
+    }
     listApps()
       .then((list) => {
         setApps(list);
         // Restore the last-used agent; otherwise land on a known-good default
         // (prefer a servable, conversational agent — numbered examples like
         // 01_quickstart are standalone scripts with no root_agent and can't load).
-        if (agentsSource === "cloud") {
-          const saved = localStorage.getItem(LS.app);
-          const remoteIds = connections.flatMap((c) =>
-            c.apps.map((a) => remoteAppId(c.id, a)),
-          );
-          setAppName((current) => {
-            if (current && remoteIds.includes(current)) return current;
-            if (saved && remoteIds.includes(saved)) return saved;
-            return remoteIds[0] ?? "";
-          });
-          return;
-        }
         // Local mode: restore the last-used agent, else a known-good default
         // (prefer a servable, conversational agent — numbered examples like
         // 01_quickstart are standalone scripts with no root_agent and can't load).
@@ -1645,7 +1632,7 @@ export default function App() {
     let cancelled = false;
     setSessionCapabilities(null);
     setSessionBuiltinTools([]);
-    if (!appName || !userId || !sessionId) {
+    if (myAgents || agentDetailTarget || !appName || !userId || !sessionId) {
       setSessionCapabilitiesLoading(false);
       return;
     }
@@ -1671,12 +1658,12 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [appName, userId, sessionId]);
+  }, [agentDetailTarget, appName, myAgents, userId, sessionId]);
   useEffect(() => {
     let cancelled = false;
     setAgentInfo(null);
     setInvocation(emptyInvocation());
-    if (!appName) {
+    if (authStatus !== "authenticated" || myAgents || agentDetailTarget || !appName) {
       setCapabilitiesLoading(false);
       return;
     }
@@ -1694,7 +1681,7 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [appName, agentInfoRefreshKey]);
+  }, [agentDetailTarget, appName, agentInfoRefreshKey, authStatus, myAgents]);
   useEffect(() => {
     if (!access) return;
     localStorage.setItem(
@@ -1731,7 +1718,7 @@ export default function App() {
   // very first resolve, restore the previously-open session (if it still
   // exists and we weren't on a create view); otherwise start a fresh chat.
   useEffect(() => {
-    if (!appName || !userId) return;
+    if (myAgents || agentDetailTarget || !appName || !userId) return;
     (async () => {
       const list = await refreshSessions(appName);
       if (!restoredRef.current) {
@@ -1745,7 +1732,7 @@ export default function App() {
       startNewChat();
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [appName, userId]);
+  }, [agentDetailTarget, appName, myAgents, userId]);
 
   // After switching agent from a search result, open the target session (runs
   // after the agent-switch effect above, so it wins over its startNewChat()).
@@ -2602,6 +2589,12 @@ export default function App() {
           region: currentConn.region ?? "cn-beijing",
         }
       : undefined;
+  const connectedRuntimeId =
+    currentRuntime?.runtimeId ??
+    connections.reduce(
+      (runtimeId, connection) => connection.runtimeId ?? runtimeId,
+      "",
+    );
 
   const rateAssistantTurn = async (
     turn: Turn,
@@ -2762,12 +2755,19 @@ export default function App() {
     selectAgent(id);
   };
 
+  const detailConnection = agentDetailTarget?.runtime
+    ? connections.find(
+        (connection) =>
+          connection.runtimeId === agentDetailTarget.runtime?.runtimeId,
+      )
+    : undefined;
   const detailAgentEntry: AgentEntry | null = agentDetailTarget?.runtime
     ? {
         id: `detail:${agentDetailTarget.runtime.runtimeId}`,
         label: agentDetailTarget.name,
         app: agentDetailTarget.name,
         remote: true,
+        runtimeApp: detailConnection?.apps[0],
         runtimeId: agentDetailTarget.runtime.runtimeId,
         region: agentDetailTarget.runtime.region,
         currentVersion: agentDetailTarget.runtime.currentVersion,
@@ -3124,7 +3124,7 @@ export default function App() {
                 onCreateCodexAgent={openSandboxLaunch}
                 onUseAgent={connectMyAgent}
                 onViewAgentDetails={openMyAgentDetails}
-                connectedRuntimeId={currentRuntime?.runtimeId}
+                connectedRuntimeId={connectedRuntimeId}
               />
             ) : showManageAgents ? (
               <AgentWorkspace

--- a/frontend/src/adk/auth.ts
+++ b/frontend/src/adk/auth.ts
@@ -1,11 +1,9 @@
 // Auth forwarding for cloud deployments.
 //
-// This frontend never puts anything in the page querystring itself, so any
-// query params present on load must have been injected by the identity gateway
-// (auth token, signature, etc.) — whatever their custom names. We therefore
-// capture the entire incoming querystring, stash it, strip it from the visible
-// address bar, and re-attach it verbatim to every API request and to any page
-// navigation. Cookies (e.g. VeADK's `veadk_session`) are sent automatically.
+// Except for local development helpers, query params present on load are
+// injected by the identity gateway (auth token, signature, etc.). Capture and
+// forward those auth params while keeping local-only params in the address bar.
+// Cookies (e.g. VeADK's `veadk_session`) are sent automatically.
 
 const STORAGE_KEY = "veadk_auth_qs";
 
@@ -15,14 +13,20 @@ let cached: string | null = null;
 function authQuery(): string {
   if (cached !== null) return cached;
 
-  const incoming = window.location.search.replace(/^\?/, "");
+  const params = new URLSearchParams(window.location.search);
+  const incoming = params.toString();
   if (incoming) {
     sessionStorage.setItem(STORAGE_KEY, incoming);
-    // Keep it out of the address bar / history / bookmarks.
-    window.history.replaceState(null, "", window.location.pathname + window.location.hash);
     cached = incoming;
   } else {
     cached = sessionStorage.getItem(STORAGE_KEY) ?? "";
+  }
+  if (window.location.search) {
+    window.history.replaceState(
+      null,
+      "",
+      window.location.pathname + window.location.hash,
+    );
   }
   return cached;
 }

--- a/frontend/src/adk/client.ts
+++ b/frontend/src/adk/client.ts
@@ -413,6 +413,15 @@ const PRIVATE_RUNTIME_UNREACHABLE_MESSAGE =
   "Runtime 已部署成功，但当前 Studio 无法访问私网 Runtime。请使用已绑定相同 VPC 的 Studio 访问，或改用公网 / 公网+VPC 部署。";
 const RUNTIME_ENDPOINT_UNREACHABLE_MESSAGE =
   "Runtime 已部署成功，但 Studio 暂时无法连接服务。网关域名可能仍在生效，或当前网络/DNS 无法访问该 Runtime，请稍后在智能体管理页重试连接。";
+const RUNTIME_APPS_CACHE_TTL_MS = 30_000;
+const runtimeAppsCache = new Map<
+  string,
+  { apps: string[]; expiresAt: number }
+>();
+
+function runtimeAppsCacheKey(runtimeId: string, region: string): string {
+  return `${region}:${runtimeId}`;
+}
 
 async function runtimeProxyErrorCode(response: Response): Promise<string> {
   try {
@@ -470,7 +479,14 @@ export async function fetchRemoteApps(
   if (!res.ok) {
     throw new Error(await httpErrorMessage(res, "读取 Agent 列表失败"));
   }
-  return res.json();
+  const apps = (await res.json()) as string[];
+  if (ep?.runtimeId) {
+    runtimeAppsCache.set(runtimeAppsCacheKey(ep.runtimeId, ep.region ?? ""), {
+      apps,
+      expiresAt: Date.now() + RUNTIME_APPS_CACHE_TTL_MS,
+    });
+  }
+  return apps;
 }
 
 export async function createSession(
@@ -1011,11 +1027,15 @@ export async function removeSessionCapability(
   return normalizeSessionCapabilities(await res.json());
 }
 
-async function fetchAgentInfo(app: string, ep: AdkEndpoint): Promise<AgentInfo> {
+async function fetchAgentInfo(
+  app: string,
+  ep: AdkEndpoint,
+  loadDraft = true,
+): Promise<AgentInfo> {
   const res = await apiFetch(`/web/agent-info/${app}`, {}, ep);
   if (!res.ok) throw new Error(`agent-info failed: ${res.status}`);
   const info = (await res.json()) as Partial<AgentInfo>;
-  if (!info.draft) {
+  if (loadDraft && !info.draft) {
     try {
       const draftRes = await apiFetch(`/web/agent-draft/${app}`, {}, ep);
       if (draftRes.ok) {
@@ -1044,17 +1064,20 @@ async function fetchAgentInfo(app: string, ep: AdkEndpoint): Promise<AgentInfo> 
 
 export async function getAgentInfo(appName: string): Promise<AgentInfo> {
   const { app, ep } = resolve(appName);
-  return fetchAgentInfo(app, ep);
+  return fetchAgentInfo(app, ep, false);
 }
 
 /** Read Agent metadata for a Runtime without connecting or persisting it. */
 export async function getRuntimeAgentInfo(
   runtimeId: string,
   region: string,
+  knownApp?: string,
 ): Promise<AgentInfo> {
   const ep = { runtimeId, region };
-  const apps = await fetchRemoteApps("", "", ep);
-  const app = apps[0];
+  const cacheKey = runtimeAppsCacheKey(runtimeId, region);
+  const cached = runtimeAppsCache.get(cacheKey);
+  if (cached && cached.expiresAt <= Date.now()) runtimeAppsCache.delete(cacheKey);
+  const app = knownApp || cached?.apps[0] || (await fetchRemoteApps("", "", ep))[0];
   if (!app) throw new Error("该 Runtime 未提供可预览的 Agent。");
   return fetchAgentInfo(app, ep);
 }

--- a/frontend/src/adk/connections.ts
+++ b/frontend/src/adk/connections.ts
@@ -31,6 +31,7 @@ export interface AgentEntry {
   id: string; // selection id passed to the ADK client
   label: string; // shown in the dropdown
   app: string; // real ADK app name
+  runtimeApp?: string; // known Runtime app name, when already connected
   remote: boolean;
   host?: string; // remote host, for display
   runtimeId?: string;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -859,9 +859,9 @@ body {
   align-items: center;
   justify-content: space-between;
   padding: 8px 10px 6px 20px;
-  font-size: 12px;
-  font-weight: 500;
-  color: hsl(var(--muted-foreground));
+  font-size: 13px;
+  font-weight: 600;
+  color: hsl(var(--foreground));
 }
 .history-refresh {
   background: none; border: none; cursor: pointer; padding: 2px;

--- a/frontend/src/ui/AgentWorkspace.tsx
+++ b/frontend/src/ui/AgentWorkspace.tsx
@@ -728,6 +728,7 @@ export function AgentWorkspace({
     void getRuntimeAgentInfo(
       selectedAgent.runtimeId,
       selectedAgent.region ?? "cn-beijing",
+      selectedAgent.runtimeApp,
     )
       .then((info) => {
         if (!cancelled) setDetailAgentInfo(info);
@@ -745,6 +746,7 @@ export function AgentWorkspace({
     detailOnly,
     selectedAgent?.currentVersion,
     selectedAgent?.region,
+    selectedAgent?.runtimeApp,
     selectedAgent?.runtimeId,
   ]);
 
@@ -1517,8 +1519,7 @@ export function AgentWorkspace({
           </main>
         ) : (
           <main className="aw-main">
-            {selectedAgent && !selectedAgentInfo &&
-              (loadingAgentInfo || (detailOnly && !detailAgentInfoResolved)) && (
+            {selectedAgent && !selectedAgentInfo && loadingAgentInfo && (
               <div className="aw-detail-loading" role="status" aria-live="polite">
                 <div className="aw-detail-loading-card">
                   <span className="loading-gap-spinner" aria-hidden="true" />
@@ -1542,7 +1543,7 @@ export function AgentWorkspace({
                     <span>{selectedPendingTask.label}</span>
                   )}
                 </div>
-                <p>{draft.description || (loadingAgentInfo ? "正在读取智能体信息…" : "暂无描述")}</p>
+                <p>{draft.description || (loadingAgentInfo || (detailOnly && !detailAgentInfoResolved) ? "正在读取智能体信息…" : "暂无描述")}</p>
               </div>
               {(selectedAgent?.canDelete || selectedDraft || selectedAgentUpdateDraft) && (
                 <div className="aw-head-actions">

--- a/frontend/src/ui/MyAgents.css
+++ b/frontend/src/ui/MyAgents.css
@@ -2,342 +2,436 @@
   flex: 1;
   min-width: 0;
   min-height: 0;
-  overflow-y: auto;
-  padding: 30px 32px 56px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 32px 32px 0;
   background: hsl(var(--background));
 }
 
-.my-agents-connect-banner {
-  margin-bottom: 24px;
-  padding: 11px 14px;
-  border: 1px solid hsl(var(--border));
-  border-radius: 10px;
-  background: hsl(var(--secondary) / 0.48);
+.my-agents-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.my-agents-heading {
+  min-width: 0;
+}
+
+.my-agents-heading h1 {
+  margin: 0;
   color: hsl(var(--foreground));
+  font-size: 21px;
+  font-weight: 650;
+  line-height: 1.25;
+  letter-spacing: -0.02em;
+}
+
+.my-agents-heading p {
+  margin: 6px 0 0;
+  color: hsl(var(--muted-foreground));
   font-size: 13px;
   line-height: 1.5;
 }
 
-.my-agents-section + .my-agents-section {
-  margin-top: 16px;
-}
-
-.my-agents-section h2 {
-  margin: 0 0 16px;
-  color: hsl(var(--foreground));
-  font-size: 18px;
-  font-weight: 650;
-  letter-spacing: -0.02em;
-}
-
-.my-agent-grid {
-  position: relative;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(174px, 100%), 1fr));
-  gap: 12px;
-}
-
-.my-agent-loading {
-  position: absolute;
-  inset: 0;
-  z-index: 1;
+.my-agent-search {
+  width: min(320px, 38vw);
+  height: 36px;
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 9px;
-  min-height: 120px;
-  border-radius: 12px;
-  background: hsl(var(--background) / 0.72);
-  color: hsl(var(--muted-foreground));
-  font-size: 13px;
-  backdrop-filter: blur(2px);
-}
-
-.my-agent-section-content {
-  position: relative;
-}
-
-.my-agent-coming-soon-overlay {
-  position: absolute;
-  inset: 0;
-  z-index: 2;
-  display: grid;
-  place-items: center;
-  border: 1px solid hsl(var(--border));
-  border-radius: 12px;
-  background: hsl(var(--background) / 0.78);
-  color: hsl(var(--foreground));
-  font-size: 15px;
-  font-weight: 400;
-  backdrop-filter: blur(3px);
-}
-
-.my-agent-card,
-.my-agent-add {
-  width: 100%;
-  aspect-ratio: 1;
+  gap: 8px;
   box-sizing: border-box;
-  border-radius: 12px;
-  background: hsl(var(--card));
-}
-
-.my-agent-add {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 7px;
-  border: 1px dashed hsl(var(--border));
-  color: hsl(var(--muted-foreground));
-  cursor: pointer;
-  font: inherit;
-  font-size: 14px;
-  font-weight: 400;
-  transition: border-color 160ms ease, background-color 160ms ease, color 160ms ease, box-shadow 160ms ease;
-}
-
-.my-agent-add svg {
-  width: 17px;
-  height: 17px;
-  flex: 0 0 auto;
-  stroke-width: 1.75;
-}
-
-.my-agent-add:hover {
-  border-color: hsl(var(--foreground) / 0.35);
-  background: hsl(var(--secondary) / 0.35);
-  color: hsl(var(--foreground));
-  box-shadow: 0 1px 3px hsl(var(--foreground) / 0.08);
-}
-
-.my-agent-add:disabled {
-  cursor: default;
-  opacity: 0.55;
-}
-
-.my-agent-card {
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
+  padding: 0 12px;
   border: 1px solid hsl(var(--border));
-  box-shadow: 0 1px 2px hsl(var(--foreground) / 0.04);
+  border-radius: 999px;
+  background: hsl(var(--panel));
+  color: hsl(var(--muted-foreground));
   transition: border-color 160ms ease, box-shadow 160ms ease;
 }
 
-.my-agent-card:hover {
-  border-color: hsl(var(--foreground) / 0.2);
-  box-shadow: 0 3px 10px hsl(var(--foreground) / 0.08);
+.my-agent-search:focus-within {
+  border-color: hsl(var(--ring) / 0.62);
+  box-shadow: 0 0 0 2px hsl(var(--ring) / 0.12);
 }
 
-.my-agent-card-content {
+.my-agent-search svg {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+}
+
+.my-agent-search input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: hsl(var(--foreground));
+  font: inherit;
+  font-size: 13px;
+}
+
+.my-agent-search input::placeholder {
+  color: hsl(var(--muted-foreground));
+}
+
+.my-agent-search input::-webkit-search-cancel-button {
+  cursor: pointer;
+}
+
+.my-agent-type-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.my-agent-type-pills {
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.my-agent-type-pill {
+  min-height: 30px;
+  padding: 0 13px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: hsl(var(--secondary) / 0.7);
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease;
+}
+
+.my-agent-type-pill:hover {
+  background: hsl(var(--secondary));
+  color: hsl(var(--foreground));
+}
+
+.my-agent-type-pill.is-active {
+  border-color: hsl(var(--foreground) / 0.14);
+  background: hsl(var(--foreground));
+  color: hsl(var(--background));
+}
+
+.my-agent-add {
+  min-width: max-content;
+  height: 32px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 0 12px;
+  border: 1px solid hsl(var(--foreground));
+  border-radius: 8px;
+  background: hsl(var(--foreground));
+  color: hsl(var(--background));
+  cursor: pointer;
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease;
+}
+
+.my-agent-add:hover:not(:disabled) {
+  border-color: hsl(var(--foreground) / 0.86);
+  background: hsl(var(--foreground) / 0.86);
+}
+
+.my-agent-add:disabled {
+  border-color: hsl(var(--border));
+  background: hsl(var(--secondary));
+  color: hsl(var(--muted-foreground));
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.my-agent-add svg {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+}
+
+.my-agent-results {
   flex: 1;
   min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  margin-top: 28px;
+  padding-bottom: 56px;
+}
+
+.my-agent-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px 14px;
+}
+
+.my-agent-card {
+  min-width: 0;
+  min-height: 82px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 68px;
+  align-items: center;
+  overflow: hidden;
+  border: 1px solid hsl(var(--border));
+  border-radius: 12px;
+  background: hsl(var(--panel));
+  box-shadow: 0 1px 2px hsl(var(--foreground) / 0.025);
+  animation: my-agent-card-enter 220ms ease-out both;
+  transition: border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+}
+
+.my-agent-card:hover {
+  border-color: hsl(var(--foreground) / 0.18);
+  background: hsl(var(--panel) / 0.88);
+  box-shadow: 0 3px 12px hsl(var(--foreground) / 0.06);
+}
+
+.my-agent-card-main {
+  min-width: 0;
+  align-self: stretch;
   display: flex;
-  flex-direction: column;
-  padding: 13px 13px 7px;
+  align-items: center;
+  padding: 15px 4px 15px 16px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.my-agent-card-main:disabled {
+  cursor: default;
+}
+
+.my-agent-card-copy {
+  min-width: 0;
+  display: block;
 }
 
 .my-agent-card h3 {
   margin: 0;
   overflow: hidden;
   color: hsl(var(--foreground));
-  font-size: 15px;
-  font-weight: 650;
-  letter-spacing: -0.015em;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.45;
+  letter-spacing: -0.01em;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.my-agent-description {
-  min-height: 40px;
-  display: -webkit-box;
-  margin: 7px 0 0;
-  overflow: hidden;
-  color: hsl(var(--muted-foreground));
-  font-size: 13px;
-  line-height: 1.5;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-}
-
-.my-agent-meta {
-  margin: 9px 0 0;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 7px;
-}
-
-.my-agent-meta > div {
-  display: flex;
-  align-items: center;
-}
-
+.my-agent-meta,
 .my-agent-meta dt,
 .my-agent-meta dd {
   margin: 0;
-  font-size: 12px;
-  line-height: 1.4;
 }
 
-.my-agent-meta dt {
-  color: hsl(var(--muted-foreground));
-}
-
-.my-agent-meta dd {
-  color: hsl(var(--foreground));
-  font-weight: 600;
-}
-
-.my-agent-label {
-  gap: 3px;
-  padding: 2px 6px;
-  border-radius: 999px;
-  background: hsl(var(--secondary));
-}
-
-.my-agent-label dt,
-.my-agent-label dd {
-  color: hsl(var(--secondary-foreground));
-  font-size: 11.5px;
-  font-weight: 400;
+.my-agent-meta {
+  margin-top: 5px;
 }
 
 .my-agent-created-at {
-  width: 100%;
-  gap: 8px;
-  padding: 4px 0 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: hsl(var(--muted-foreground));
+  font-size: 11.5px;
+  line-height: 1.45;
 }
 
 .my-agent-created-at dd {
   font-weight: 400;
 }
 
-.my-agent-actions {
-  flex: 0 0 38px;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
-  padding: 0 8px 8px;
-}
-
-.my-agent-actions button {
-  min-width: 0;
-  border: 1px solid hsl(var(--border));
-  border-radius: 6px;
-  background: hsl(var(--background));
-  color: hsl(var(--foreground));
-  cursor: pointer;
-  font: inherit;
+.my-agent-connect {
+  min-width: 52px;
+  height: 32px;
+  justify-self: center;
+  display: inline-grid;
+  place-items: center;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: hsl(var(--muted-foreground));
   font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
-  transition: border-color 150ms ease, background-color 150ms ease, color 150ms ease;
+  cursor: pointer;
+  transition: background-color 150ms ease, color 150ms ease;
 }
 
-.my-agent-actions button:hover {
+.my-agent-connect:hover:not(:disabled) {
   background: hsl(var(--secondary));
+  color: hsl(var(--foreground));
 }
 
-.my-agent-actions button:disabled {
+.my-agent-connect:disabled {
   cursor: default;
   opacity: 0.48;
 }
 
-.my-agent-actions .my-agent-use {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 5px;
-  border-color: hsl(var(--foreground) / 0.68);
-  background: hsl(var(--foreground) / 0.74);
-  color: hsl(var(--background));
-}
-
-.my-agent-actions .my-agent-use:hover {
-  background: hsl(var(--foreground) / 0.84);
-}
-
-.my-agent-use-spinner {
-  width: 11px;
-  height: 11px;
-  flex: 0 0 11px;
-  box-sizing: border-box;
-  border: 1.25px solid currentColor;
-  border-right-color: transparent;
-  border-radius: 50%;
-  animation: loading-gap-spin 0.7s linear infinite;
-}
-
-.my-agent-actions .my-agent-use.is-connected,
-.my-agent-actions .my-agent-use.is-connected:disabled {
-  border-color: hsl(142 60% 38% / 0.3);
+.my-agent-connect.is-connected,
+.my-agent-connect.is-connected:disabled {
   background: hsl(142 55% 94%);
   color: hsl(142 62% 30%);
   opacity: 1;
 }
 
-.my-agent-add:focus-visible,
-.my-agent-actions button:focus-visible,
-.my-agent-pagination button:focus-visible {
-  outline: 2px solid hsl(var(--ring) / 0.6);
-  outline-offset: -3px;
+.my-agent-loading-mark {
+  box-sizing: border-box;
+  border: 1.5px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: loading-gap-spin 0.72s linear infinite;
 }
 
-.my-agent-pagination {
+.my-agent-loading-mark {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+}
+
+.my-agent-initial-loading,
+.my-agent-load-more,
+.my-agent-empty {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  min-height: 28px;
-  margin-top: 12px;
   color: hsl(var(--muted-foreground));
-  font-size: 12px;
+  font-size: 12.5px;
 }
 
-.my-agent-pagination button {
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  border: 0;
-  border-radius: 5px;
-  background: transparent;
+.my-agent-initial-loading {
+  min-height: 180px;
+  gap: 8px;
+}
+
+.my-agent-load-more {
+  min-height: 54px;
+  gap: 8px;
+  padding-top: 6px;
+}
+
+.my-agent-empty {
+  min-height: 220px;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.my-agent-empty p,
+.my-agent-empty span {
+  margin: 0;
+}
+
+.my-agent-empty p {
+  color: inherit;
+  font-size: inherit;
+  font-weight: 400;
+}
+
+.my-agent-empty button {
+  height: 30px;
+  padding: 0 11px;
+  border: 1px solid hsl(var(--border));
+  border-radius: 7px;
+  background: hsl(var(--panel));
   color: hsl(var(--foreground));
   cursor: pointer;
   font: inherit;
-  font-size: 18px;
-  font-weight: 400;
-  line-height: 1;
+  font-size: 12px;
 }
 
-.my-agent-pagination button:hover:not(:disabled) {
-  background: hsl(var(--secondary));
+.my-agent-card-main:focus-visible,
+.my-agent-connect:focus-visible,
+.my-agent-type-pill:focus-visible,
+.my-agent-add:focus-visible,
+.my-agent-empty button:focus-visible {
+  outline: 2px solid hsl(var(--ring) / 0.65);
+  outline-offset: -2px;
 }
 
-.my-agent-pagination button:disabled {
-  cursor: default;
-  opacity: 0.42;
+@keyframes my-agent-card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
-@media (max-width: 940px) {
+@media (max-width: 980px) {
+  .my-agent-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
   .my-agents-page {
-    padding: 24px 20px 44px;
+    padding: 24px 20px 0;
   }
 
+  .my-agents-header {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .my-agent-search {
+    width: 100%;
+  }
+
+  .my-agent-type-bar {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .my-agent-add {
+    align-self: flex-end;
+  }
+
+  .my-agent-results {
+    padding-bottom: 44px;
+  }
+}
+
+@media (max-width: 640px) {
+  .my-agent-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 560px) {
   .my-agents-page {
     padding-inline: 16px;
   }
-
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .my-agent-card {
-    transition: none;
+  .my-agent-card,
+  .my-agent-loading-mark {
+    animation: none;
   }
 
-  .my-agent-use-spinner {
-    animation-duration: 1.4s;
+  .my-agent-card,
+  .my-agent-connect,
+  .my-agent-type-pill,
+  .my-agent-add,
+  .my-agent-search {
+    transition: none;
   }
 }

--- a/frontend/src/ui/MyAgents.tsx
+++ b/frontend/src/ui/MyAgents.tsx
@@ -1,15 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Plus } from "lucide-react";
+import type { SVGProps } from "react";
 
-import { getRuntimeAgentInfo, getRuntimes, type CloudRuntime } from "../adk/client";
+import { getRuntimes, type CloudRuntime } from "../adk/client";
 import "./MyAgents.css";
 
 export interface MyAgentCardData {
   id: string;
   name: string;
   description: string;
-  toolCount: number;
-  skillCount: number;
   createdAt: string;
   runtime?: {
     runtimeId: string;
@@ -19,15 +17,41 @@ export interface MyAgentCardData {
   };
 }
 
-interface MyAgentSectionData {
-  title: string;
-  agents: MyAgentCardData[];
-  comingSoon?: boolean;
+type AgentType = "general" | "codex" | "openclaw" | "hermes";
+
+const AGENT_TYPES: Array<{ id: AgentType; label: string; createLabel: string }> = [
+  { id: "general", label: "通用智能体", createLabel: "添加通用智能体" },
+  { id: "codex", label: "Codex 智能体", createLabel: "添加 Codex 智能体" },
+  { id: "openclaw", label: "OpenClaw 智能体", createLabel: "添加 OpenClaw 智能体" },
+  { id: "hermes", label: "Hermes 智能体", createLabel: "添加 Hermes 智能体" },
+];
+const RUNTIME_PAGE_SIZE = 24;
+const RUNTIME_PAGE_CACHE_TTL_MS = 30_000;
+const runtimePageRequests = new Map<
+  string,
+  Promise<{ runtimes: CloudRuntime[]; nextToken: string }>
+>();
+const runtimePageCache = new Map<
+  string,
+  { page: { runtimes: CloudRuntime[]; nextToken: string }; expiresAt: number }
+>();
+
+function SearchIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true" {...props}>
+      <circle cx="10.8" cy="10.8" r="6.2" stroke="currentColor" strokeWidth="1.7" />
+      <path d="m15.4 15.4 4 4" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" />
+    </svg>
+  );
 }
 
-const MAX_ROWS = 2;
-const MIN_CARD_WIDTH = 174;
-const GRID_GAP = 12;
+function AddIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" aria-hidden="true" {...props}>
+      <path d="M8 3.25v9.5M3.25 8h9.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
 
 function formatCreatedAt(value: string): string {
   if (!value) return "—";
@@ -45,8 +69,6 @@ function runtimeToAgent(runtime: CloudRuntime): MyAgentCardData {
     id: runtime.runtimeId,
     name: runtime.name,
     description: runtime.name,
-    toolCount: 0,
-    skillCount: 0,
     createdAt: formatCreatedAt(runtime.createdAt ?? ""),
     runtime: {
       runtimeId: runtime.runtimeId,
@@ -59,42 +81,36 @@ function runtimeToAgent(runtime: CloudRuntime): MyAgentCardData {
 
 async function loadRuntimeAgents(
   nextToken: string,
-  pageSize: number,
   onList: (agents: MyAgentCardData[]) => void,
-): Promise<{ nextToken: string; count: number }> {
-  const page = await getRuntimes({
-    scope: "mine",
-    region: "all",
-    pageSize,
-    nextToken,
+): Promise<string> {
+  const requestKey = nextToken;
+  const cached = runtimePageCache.get(requestKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    onList(cached.page.runtimes.map(runtimeToAgent));
+    return cached.page.nextToken;
+  }
+  if (cached) runtimePageCache.delete(requestKey);
+  let request = runtimePageRequests.get(requestKey);
+  if (!request) {
+    request = getRuntimes({
+      scope: "mine",
+      region: "all",
+      pageSize: RUNTIME_PAGE_SIZE,
+      nextToken,
+    });
+    runtimePageRequests.set(requestKey, request);
+    void request.then(
+      () => runtimePageRequests.delete(requestKey),
+      () => runtimePageRequests.delete(requestKey),
+    );
+  }
+  const page = await request;
+  runtimePageCache.set(requestKey, {
+    page,
+    expiresAt: Date.now() + RUNTIME_PAGE_CACHE_TTL_MS,
   });
   onList(page.runtimes.map(runtimeToAgent));
-
-  void Promise.all(
-    page.runtimes.map(async (runtime) => {
-      try {
-        const info = await getRuntimeAgentInfo(runtime.runtimeId, runtime.region);
-        const agent = {
-          id: runtime.runtimeId,
-          name: info.name || runtime.name,
-          description: info.description || runtime.name,
-          toolCount: info.tools.length,
-          skillCount: info.skills.length,
-          createdAt: formatCreatedAt(runtime.createdAt ?? ""),
-          runtime: {
-            runtimeId: runtime.runtimeId,
-            region: runtime.region,
-            currentVersion: runtime.currentVersion,
-            canDelete: runtime.canDelete,
-          },
-        };
-        onList([agent]);
-      } catch {
-        // Keep the Runtime fallback card already rendered above.
-      }
-    }),
-  );
-  return { nextToken: page.nextToken, count: page.runtimes.length };
+  return page.nextToken;
 }
 
 function AgentCard({
@@ -112,173 +128,35 @@ function AgentCard({
 }) {
   return (
     <article className="my-agent-card">
-      <div className="my-agent-card-content">
-        <h3>{agent.name}</h3>
-        <p className="my-agent-description">{agent.description}</p>
-        <dl className="my-agent-meta">
-          <div className="my-agent-label">
-            <dt>工具</dt>
-            <dd>{agent.toolCount} 个</dd>
-          </div>
-          <div className="my-agent-label">
-            <dt>技能</dt>
-            <dd>{agent.skillCount} 个</dd>
-          </div>
-          <div className="my-agent-created-at">
-            <dt>创建时间</dt>
-            <dd>{agent.createdAt}</dd>
-          </div>
-        </dl>
-      </div>
-      <div className="my-agent-actions">
-        <button
-          type="button"
-          className={`my-agent-use${connected ? " is-connected" : ""}`}
-          disabled={!agent.runtime || connecting || connected}
-          aria-busy={connecting || undefined}
-          onClick={() => void onUse?.(agent)}
-        >
-          {connecting ? (
-            <>
-              <span className="my-agent-use-spinner" aria-hidden="true" />
-              <span>连接中</span>
-            </>
-          ) : connected ? "已连接" : "使用"}
-        </button>
-        <button
-          type="button"
-          className="my-agent-details"
-          disabled={!agent.runtime}
-          onClick={() => onViewDetails?.(agent)}
-        >
-          查看详情
-        </button>
-      </div>
-    </article>
-  );
-}
-
-function AgentSection({
-  section,
-  onCreateAgent,
-  onUseAgent,
-  onViewAgentDetails,
-  connectingAgentId,
-  connectedRuntimeId,
-  loading,
-  serverPagination,
-  onPageSizeChange,
-  comingSoon,
-}: {
-  section: MyAgentSectionData;
-  onCreateAgent?: () => void;
-  onUseAgent?: (agent: MyAgentCardData) => Promise<void>;
-  onViewAgentDetails?: (agent: MyAgentCardData) => void;
-  connectingAgentId?: string;
-  connectedRuntimeId?: string;
-  loading?: boolean;
-  serverPagination?: {
-    page: number;
-    hasNext: boolean;
-    onPrevious: () => void;
-    onNext: () => void;
-  };
-  onPageSizeChange?: (pageSize: number) => void;
-  comingSoon?: boolean;
-}) {
-  const gridRef = useRef<HTMLDivElement>(null);
-  const [columns, setColumns] = useState(1);
-  const [page, setPage] = useState(1);
-  const pageSize = Math.max(1, columns * MAX_ROWS - 1);
-  const pageCount = Math.max(1, Math.ceil(section.agents.length / pageSize));
-  const visibleAgents = useMemo(
-    () => serverPagination
-      ? section.agents
-      : section.agents.slice((page - 1) * pageSize, page * pageSize),
-    [page, pageSize, section.agents, serverPagination],
-  );
-  const currentPage = serverPagination?.page ?? page;
-
-  useEffect(() => {
-    const grid = gridRef.current;
-    if (!grid) return;
-    const updateColumns = () => {
-      const width = grid.getBoundingClientRect().width;
-      const nextColumns = Math.max(
-        1,
-        Math.floor((width + GRID_GAP) / (MIN_CARD_WIDTH + GRID_GAP)),
-      );
-      setColumns(nextColumns);
-      onPageSizeChange?.(Math.max(1, nextColumns * MAX_ROWS - 1));
-    };
-    updateColumns();
-    const observer = new ResizeObserver(updateColumns);
-    observer.observe(grid);
-    return () => observer.disconnect();
-  }, [onPageSizeChange]);
-
-  useEffect(() => {
-    setPage((current) => Math.min(current, pageCount));
-  }, [pageCount]);
-
-  return (
-    <section className="my-agents-section">
-      <h2>{section.title}</h2>
-      <div className="my-agent-section-content">
-        <div className="my-agent-grid" ref={gridRef}>
-          <button
-            type="button"
-            className="my-agent-add"
-            aria-label={`添加${section.title}`}
-            disabled={!onCreateAgent || comingSoon}
-            onClick={onCreateAgent}
-          >
-            <Plus aria-hidden="true" />
-            <span>添加智能体</span>
-          </button>
-          {visibleAgents.map((agent) => (
-            <AgentCard
-              key={agent.id}
-              agent={agent}
-              onUse={onUseAgent}
-              onViewDetails={onViewAgentDetails}
-              connecting={agent.id === connectingAgentId}
-              connected={agent.runtime?.runtimeId === connectedRuntimeId}
-            />
-          ))}
-          {loading && (
-            <div className="my-agent-loading" role="status" aria-live="polite">
-              <span className="loading-gap-spinner" aria-hidden="true" />
-              <span>加载中</span>
+      <button
+        type="button"
+        className="my-agent-card-main"
+        disabled={!agent.runtime}
+        onClick={() => onViewDetails?.(agent)}
+        aria-label={`查看 ${agent.name} 详情`}
+      >
+        <span className="my-agent-card-copy">
+          <h3>{agent.name}</h3>
+          <dl className="my-agent-meta">
+            <div className="my-agent-created-at">
+              <dt>创建时间</dt>
+              <dd>{agent.createdAt}</dd>
             </div>
-          )}
-        </div>
-        <nav className="my-agent-pagination" aria-label={`${section.title}分页`}>
-          <button
-            type="button"
-            aria-label="上一页"
-            disabled={currentPage === 1 || loading}
-            onClick={serverPagination?.onPrevious ?? (() => setPage(page - 1))}
-          >
-            ‹
-          </button>
-          <span>{serverPagination ? currentPage : `${page} / ${pageCount}`}</span>
-          <button
-            type="button"
-            aria-label="下一页"
-            disabled={loading || (serverPagination ? !serverPagination.hasNext : page === pageCount)}
-            onClick={serverPagination?.onNext ?? (() => setPage(page + 1))}
-          >
-            ›
-          </button>
-        </nav>
-        {comingSoon && (
-          <div className="my-agent-coming-soon-overlay" role="status">
-            敬请期待
-          </div>
-        )}
-      </div>
-    </section>
+          </dl>
+        </span>
+      </button>
+      <button
+        type="button"
+        className={`my-agent-connect${connected ? " is-connected" : ""}`}
+        disabled={!agent.runtime || connecting || connected}
+        aria-busy={connecting || undefined}
+        aria-label={connected ? `${agent.name} 已连接` : `连接 ${agent.name}`}
+        title={connected ? "已连接" : "连接智能体"}
+        onClick={() => void onUse?.(agent)}
+      >
+        {connecting ? "连接中" : connected ? "已连接" : "连接"}
+      </button>
+    </article>
   );
 }
 
@@ -297,44 +175,31 @@ export function MyAgents({
   onViewAgentDetails,
   connectedRuntimeId = "",
 }: MyAgentsProps) {
-  const [runtimeAgents, setRuntimeAgents] = useState<MyAgentCardData[]>([]);
-  const [loadingRuntimes, setLoadingRuntimes] = useState(true);
-  const [runtimePage, setRuntimePage] = useState(1);
-  const [runtimeNextToken, setRuntimeNextToken] = useState("");
-  const [runtimePageSize, setRuntimePageSize] = useState(0);
-  const [connectingAgentId, setConnectingAgentId] = useState("");
-  const runtimePageSizeRef = useRef(0);
-  const runtimePageTokensRef = useRef([""]);
+  const resultsRef = useRef<HTMLElement>(null);
+  const loadMoreRef = useRef<HTMLDivElement>(null);
   const runtimeRequestRef = useRef(0);
+  const [activeType, setActiveType] = useState<AgentType>("general");
+  const [query, setQuery] = useState("");
+  const [runtimeAgents, setRuntimeAgents] = useState<MyAgentCardData[]>([]);
+  const [runtimeNextToken, setRuntimeNextToken] = useState("");
+  const [loadingRuntimes, setLoadingRuntimes] = useState(true);
+  const [runtimeError, setRuntimeError] = useState("");
+  const [connectingAgentId, setConnectingAgentId] = useState("");
 
-  const updateRuntimePageSize = useCallback((pageSize: number) => {
-    if (runtimePageSizeRef.current === pageSize) return;
-    runtimePageSizeRef.current = pageSize;
-    setRuntimePageSize(pageSize);
-  }, []);
-
-  const fetchRuntimePage = useCallback((page: number, token: string, pageSize: number) => {
+  const fetchRuntimePage = useCallback((token: string, reset: boolean) => {
     const requestId = ++runtimeRequestRef.current;
     setLoadingRuntimes(true);
-    return loadRuntimeAgents(token, pageSize, (agents) => {
+    setRuntimeError("");
+    return loadRuntimeAgents(token, (agents) => {
       if (runtimeRequestRef.current !== requestId) return;
-      if (page > 1 && agents.length === 0) return;
-      setRuntimeAgents((current) => {
-        if (agents.length !== 1 || current.length === 0) return agents;
-        return current.map((agent) => agent.id === agents[0].id ? agents[0] : agent);
-      });
+      setRuntimeAgents((current) => reset ? agents : [...current, ...agents]);
     })
-      .then(({ nextToken, count }) => {
-        if (runtimeRequestRef.current !== requestId) return;
-        if (page > 1 && count === 0) {
-          setRuntimeNextToken("");
-          return;
-        }
-        setRuntimePage(page);
-        setRuntimeNextToken(nextToken);
+      .then((nextToken) => {
+        if (runtimeRequestRef.current === requestId) setRuntimeNextToken(nextToken);
       })
-      .catch(() => {
+      .catch((cause) => {
         if (runtimeRequestRef.current !== requestId) return;
+        setRuntimeError(cause instanceof Error ? cause.message : String(cause));
       })
       .finally(() => {
         if (runtimeRequestRef.current === requestId) setLoadingRuntimes(false);
@@ -342,27 +207,27 @@ export function MyAgents({
   }, []);
 
   useEffect(() => {
-    if (runtimePageSize === 0) return;
-    runtimePageTokensRef.current = [""];
-    setRuntimeNextToken("");
-    void fetchRuntimePage(1, "", runtimePageSize);
+    void fetchRuntimePage("", true);
     return () => {
       runtimeRequestRef.current += 1;
     };
-  }, [fetchRuntimePage, runtimePageSize]);
+  }, [fetchRuntimePage]);
 
-  const nextRuntimePage = () => {
-    if (!runtimeNextToken) return;
-    runtimePageTokensRef.current[runtimePage] = runtimeNextToken;
-    void fetchRuntimePage(runtimePage + 1, runtimeNextToken, runtimePageSize);
-  };
-
-  const previousRuntimePage = () => {
-    if (runtimePage <= 1) return;
-    const previousPage = runtimePage - 1;
-    const previousToken = runtimePageTokensRef.current[previousPage - 1] ?? "";
-    void fetchRuntimePage(previousPage, previousToken, runtimePageSize);
-  };
+  useEffect(() => {
+    const target = loadMoreRef.current;
+    const root = resultsRef.current;
+    if (!target || !root || activeType !== "general" || !runtimeNextToken || loadingRuntimes) {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) void fetchRuntimePage(runtimeNextToken, false);
+      },
+      { root, rootMargin: "180px 0px", threshold: 0.01 },
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [activeType, fetchRuntimePage, loadingRuntimes, runtimeNextToken]);
 
   const useAgent = useCallback(async (agent: MyAgentCardData) => {
     if (connectingAgentId) return;
@@ -375,49 +240,133 @@ export function MyAgents({
     }
   }, [connectingAgentId, onUseAgent]);
 
-  const sections = useMemo<MyAgentSectionData[]>(
-    () => [
-      { title: "通用智能体", agents: runtimeAgents },
-      { title: "Codex 智能体", agents: [] },
-      { title: "OpenClaw 智能体", agents: [], comingSoon: true },
-      { title: "Hermes 智能体", agents: [], comingSoon: true },
-    ],
-    [runtimeAgents],
-  );
-  const createActions = [
-    onCreateAgent,
-    onCreateCodexAgent,
-    undefined,
-    undefined,
-  ];
+  const visibleAgents = useMemo(() => {
+    if (activeType !== "general") return [];
+    const normalizedQuery = query.trim().toLocaleLowerCase();
+    const matchingAgents = normalizedQuery
+      ? runtimeAgents.filter((agent) =>
+          agent.name.toLocaleLowerCase().includes(normalizedQuery),
+        )
+      : runtimeAgents;
+    const connectedIndex = matchingAgents.findIndex(
+      (agent) => agent.runtime?.runtimeId === connectedRuntimeId,
+    );
+    if (connectedIndex <= 0) return matchingAgents;
+    return [
+      matchingAgents[connectedIndex],
+      ...matchingAgents.slice(0, connectedIndex),
+      ...matchingAgents.slice(connectedIndex + 1),
+    ];
+  }, [activeType, connectedRuntimeId, query, runtimeAgents]);
+
+  const activeTypeInfo = AGENT_TYPES.find((type) => type.id === activeType);
+  const activeLabel = activeTypeInfo?.label ?? "智能体";
+  const createLabel = activeTypeInfo?.createLabel ?? "添加智能体";
+  const showInitialLoading = activeType === "general" && loadingRuntimes && runtimeAgents.length === 0;
+  const showEmpty = !showInitialLoading && visibleAgents.length === 0;
+  const emptyMessage = activeType === "openclaw" || activeType === "hermes"
+    ? "暂未开放"
+    : query.trim() ? "没有匹配的智能体" : `${activeLabel}暂无内容`;
+  const createAgent = activeType === "general"
+    ? onCreateAgent
+    : activeType === "codex" ? onCreateCodexAgent : undefined;
 
   return (
     <div className="my-agents-page">
-      {!connectedRuntimeId && (
-        <div className="my-agents-connect-banner" role="status">
-          请选择一个智能体以对话
+      <header className="my-agents-header">
+        <div className="my-agents-heading">
+          <h1>智能体</h1>
+          <p>在此处浏览您的所有智能体</p>
         </div>
-      )}
-      {sections.map((section, index) => (
-        <AgentSection
-          section={section}
-          key={section.title}
-          onCreateAgent={createActions[index]}
-          onUseAgent={useAgent}
-          onViewAgentDetails={onViewAgentDetails}
-          connectingAgentId={connectingAgentId}
-          connectedRuntimeId={connectedRuntimeId}
-          loading={index === 0 && loadingRuntimes}
-          onPageSizeChange={index === 0 ? updateRuntimePageSize : undefined}
-          serverPagination={index === 0 ? {
-            page: runtimePage,
-            hasNext: Boolean(runtimeNextToken),
-            onPrevious: previousRuntimePage,
-            onNext: nextRuntimePage,
-          } : undefined}
-          comingSoon={section.comingSoon}
-        />
-      ))}
+        <label className="my-agent-search">
+          <SearchIcon />
+          <input
+            type="search"
+            aria-label="搜索智能体"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="搜索所有类型智能体名称"
+          />
+        </label>
+      </header>
+
+      <div className="my-agent-type-bar">
+        <nav className="my-agent-type-pills" aria-label="智能体类型">
+          {AGENT_TYPES.map((type) => (
+            <button
+              type="button"
+              key={type.id}
+              className={`my-agent-type-pill${activeType === type.id ? " is-active" : ""}`}
+              aria-pressed={activeType === type.id}
+              onClick={() => setActiveType(type.id)}
+            >
+              {type.label}
+            </button>
+          ))}
+        </nav>
+        <button
+          type="button"
+          className="my-agent-add"
+          disabled={!createAgent}
+          onClick={() => createAgent?.()}
+        >
+          <AddIcon />
+          {createLabel}
+        </button>
+      </div>
+
+      <section
+        className="my-agent-results"
+        ref={resultsRef}
+        aria-label={`${activeLabel}列表`}
+      >
+        {showInitialLoading ? (
+          <div className="my-agent-initial-loading" role="status" aria-live="polite">
+            <span className="my-agent-loading-mark" aria-hidden="true" />
+            <span>正在加载智能体</span>
+          </div>
+        ) : runtimeError && activeType === "general" ? (
+          <div className="my-agent-empty" role="alert">
+            <p>{runtimeError}</p>
+            <button type="button" onClick={() => void fetchRuntimePage("", true)}>重新加载</button>
+          </div>
+        ) : showEmpty ? (
+          <div className="my-agent-empty">
+            <p>{emptyMessage}</p>
+            {query.trim() && activeType !== "openclaw" && activeType !== "hermes" && (
+              <span>请尝试搜索其他名称</span>
+            )}
+          </div>
+        ) : (
+          <div className="my-agent-grid">
+            {visibleAgents.map((agent) => (
+              <AgentCard
+                key={agent.id}
+                agent={agent}
+                onUse={useAgent}
+                onViewDetails={onViewAgentDetails}
+                connecting={agent.id === connectingAgentId}
+                connected={agent.runtime?.runtimeId === connectedRuntimeId}
+              />
+            ))}
+          </div>
+        )}
+
+        {activeType === "general" && visibleAgents.length > 0 && (
+          <div className="my-agent-load-more" ref={loadMoreRef} aria-live="polite">
+            {loadingRuntimes ? (
+              <>
+                <span className="my-agent-loading-mark" aria-hidden="true" />
+                <span>正在加载更多智能体</span>
+              </>
+            ) : runtimeNextToken ? (
+              <span>继续滚动加载更多</span>
+            ) : (
+              <span>已加载全部智能体</span>
+            )}
+          </div>
+        )}
+      </section>
     </div>
   );
 }

--- a/frontend/tests/agentWorkspace.test.mjs
+++ b/frontend/tests/agentWorkspace.test.mjs
@@ -81,6 +81,10 @@ test("focused agent details can render without the workspace tabs or list sideba
     appSource,
     /focusedAgentId=\{detailAgentEntry\?\.id \?\? focusedWorkspaceAgentId\}[\s\S]*?detailOnly=\{!!detailAgentEntry \|\| !!focusedDeploymentTaskId\}/,
   );
+  assert.match(appSource, /runtimeApp: detailConnection\?\.apps\[0\]/);
+  assert.match(workspaceSource, /getRuntimeAgentInfo\([\s\S]*?selectedAgent\.runtimeApp/);
+  assert.match(clientSource, /loadDraft = true/);
+  assert.match(clientSource, /return fetchAgentInfo\(app, ep, false\)/);
 });
 
 test("agent details show capability badges and deployment state before the flow", () => {
@@ -123,7 +127,7 @@ test("workspace publish flow restores PR 748 deployment lifecycle hooks", () => 
   assert.match(appSource, /const finishDeployment = useCallback/);
   assert.match(appSource, /await connectRuntime\([\s\S]*?result\.runtimeId[\s\S]*?result\.version/);
   assert.match(appSource, /const \[agentInfoRefreshKey, setAgentInfoRefreshKey\] = useState\(0\)/);
-  assert.match(appSource, /}, \[appName, agentInfoRefreshKey\]\);/);
+  assert.match(appSource, /}, \[agentDetailTarget, appName, agentInfoRefreshKey, authStatus, myAgents\]\);/);
   assert.match(
     appSource,
     /const finishDeployment = useCallback[\s\S]*?setConnections\(loadConnections\(\)\);[\s\S]*?setAgentInfoRefreshKey\(\(key\) => key \+ 1\)/,

--- a/frontend/tests/myAgents.test.mjs
+++ b/frontend/tests/myAgents.test.mjs
@@ -15,6 +15,7 @@ const sidebarSource = readFileSync(
   "utf8",
 );
 const appSource = readFileSync(new URL("../src/App.tsx", import.meta.url), "utf8");
+const authSource = readFileSync(new URL("../src/adk/auth.ts", import.meta.url), "utf8");
 
 test("shows only the Agent navigation in the sidebar", () => {
   assert.match(sidebarSource, /onMyAgents: \(\) => void/);
@@ -29,16 +30,17 @@ test("shows only the Agent navigation in the sidebar", () => {
   assert.match(appSource, /myAgents \? \([\s\S]*?<MyAgents/);
 });
 
-test("shows four agent families with a dashed add card first", () => {
+test("shows the requested title, search, and agent type pills", () => {
+  assert.match(pageSource, /<h1>智能体<\/h1>/);
+  assert.match(pageSource, /在此处浏览您的所有智能体/);
+  assert.match(pageSource, /placeholder="搜索所有类型智能体名称"/);
+  assert.match(pageSource, /aria-label="搜索智能体"/);
+  assert.doesNotMatch(pageSource, /<span className="sr-only">搜索智能体<\/span>/);
   for (const title of ["通用智能体", "Codex 智能体", "OpenClaw 智能体", "Hermes 智能体"]) {
-    assert.match(pageSource, new RegExp(`title: "${title}"`));
+    assert.match(pageSource, new RegExp(`label: "${title}"`));
   }
-  assert.match(
-    pageSource,
-    /<div className="my-agent-grid" ref=\{gridRef\}>[\s\S]*?className="my-agent-add"[\s\S]*?visibleAgents\.map/,
-  );
-  assert.match(pageStyles, /\.my-agent-add\s*\{[\s\S]*?border: 1px dashed/);
-  assert.match(pageStyles, /\.my-agent-card,\s*\.my-agent-add\s*\{[\s\S]*?aspect-ratio: 1;/);
+  assert.match(pageSource, /className="my-agent-type-pill/);
+  assert.match(pageSource, /aria-pressed=\{activeType === type\.id\}/);
 });
 
 test("renders only account-backed agents and never ships placeholder cards", () => {
@@ -47,91 +49,137 @@ test("renders only account-backed agents and never ships placeholder cards", () 
     pageSource,
     /codex-code-review|codex-test-coverage|openclaw-research|hermes-data-analysis/,
   );
-  assert.equal(
-    (pageSource.match(/title: "通用智能体", agents: runtimeAgents/g) ?? []).length,
-    1,
-  );
-  for (const title of ["Codex 智能体", "OpenClaw 智能体", "Hermes 智能体"]) {
-    assert.match(pageSource, new RegExp(`title: "${title}", agents: \\[\\]`));
-  }
+  assert.match(pageSource, /if \(activeType !== "general"\) return \[\]/);
 });
 
-test("agent cards keep only requested information and actions", () => {
+test("offers the existing create action for the active agent type", () => {
+  assert.match(pageSource, /activeType === "general"[\s\S]*?onCreateAgent/);
+  assert.match(pageSource, /activeType === "codex" \? onCreateCodexAgent : undefined/);
+  assert.match(pageSource, /className="my-agent-add"/);
+  assert.match(pageSource, /createLabel: "添加通用智能体"/);
+  assert.match(pageSource, /createLabel: "添加 Codex 智能体"/);
+  assert.match(pageSource, /<AddIcon \/>[\s\S]*?\{createLabel\}/);
+  assert.match(pageSource, /disabled=\{!createAgent\}/);
+  assert.match(pageStyles, /\.my-agent-type-bar\s*\{[\s\S]*?justify-content: space-between/);
+  assert.match(pageStyles, /\.my-agent-add\s*\{[\s\S]*?background: hsl\(var\(--foreground\)\)[\s\S]*?color: hsl\(var\(--background\)\)/);
+  assert.match(pageStyles, /@media \(max-width: 720px\)[\s\S]*?\.my-agent-add\s*\{[\s\S]*?align-self: flex-end/);
+});
+
+test("agent cards show only Runtime name, creation time, and connect action", () => {
   assert.match(pageSource, /<h3>\{agent\.name\}<\/h3>/);
-  assert.match(pageSource, /\{agent\.description\}/);
-  assert.match(pageSource, /<dt>工具<\/dt>/);
-  assert.match(pageSource, /<dt>技能<\/dt>/);
   assert.match(pageSource, /<dt>创建时间<\/dt>/);
-  assert.match(pageSource, /connected \? "已连接" : "使用"/);
-  assert.match(pageSource, />\s*查看详情\s*<\/button>/);
+  assert.doesNotMatch(pageSource, /<dt>工具<\/dt>|<dt>技能<\/dt>/);
+  assert.doesNotMatch(pageSource, /toolCount|skillCount|agent\.description/);
+  assert.match(pageSource, /aria-label=\{connected \? `\$\{agent\.name\} 已连接` : `连接 \$\{agent\.name\}`\}/);
+  assert.match(pageSource, /onClick=\{\(\) => onViewDetails\?\.\(agent\)\}/);
+  assert.doesNotMatch(pageSource, />\s*查看详情\s*<\/button>/);
   assert.doesNotMatch(pageSource, /<small|<code/);
   assert.doesNotMatch(pageStyles, /font-family/);
 });
 
-test("uses a compact shadcn-style card grid with horizontal footer actions", () => {
+test("uses a compact three-column directory grid", () => {
   assert.match(
     pageStyles,
-    /\.my-agent-grid\s*\{[\s\S]*?grid-template-columns: repeat\(auto-fill, minmax\(min\(174px, 100%\), 1fr\)\)/,
+    /\.my-agent-grid\s*\{[\s\S]*?grid-template-columns: repeat\(3, minmax\(0, 1fr\)\)/,
   );
-  assert.doesNotMatch(pageStyles, /\.my-agent-grid\s*\{[^}]*justify-content:/);
-  assert.doesNotMatch(pageStyles, /justify-content: space-between/);
-  assert.match(
-    pageStyles,
-    /\.my-agent-actions\s*\{[\s\S]*?grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/,
-  );
-  assert.doesNotMatch(pageStyles, /\.my-agent-actions\s*\{[^}]*border-top:/);
-  assert.doesNotMatch(pageStyles, /\.my-agent-actions\s*\{[^}]*background:/);
-  assert.match(pageStyles, /\.my-agent-actions button\s*\{[\s\S]*?border-radius:/);
+  assert.match(pageStyles, /@media \(max-width: 980px\)[\s\S]*?repeat\(2, minmax\(0, 1fr\)\)/);
+  assert.match(pageStyles, /@media \(max-width: 640px\)[\s\S]*?grid-template-columns: 1fr/);
 });
 
-test("add card uses only the requested plus icon and regular text weight", () => {
-  assert.match(pageSource, /import \{ Plus \} from "lucide-react"/);
-  assert.match(pageSource, /<Plus aria-hidden="true" \/>[\s\S]*?<span>添加智能体<\/span>/);
-  assert.match(pageStyles, /\.my-agent-add\s*\{[\s\S]*?font-weight: 400/);
-});
-
-test("tool and skill counts render as compact labels", () => {
-  assert.match(pageSource, /<dt>工具<\/dt>[\s\S]*?<dd>\{agent\.toolCount\} 个<\/dd>/);
-  assert.match(pageSource, /<dt>技能<\/dt>[\s\S]*?<dd>\{agent\.skillCount\} 个<\/dd>/);
-  assert.match(pageStyles, /\.my-agent-label\s*\{[\s\S]*?border-radius:/);
-  assert.match(pageStyles, /\.my-agent-label dt,[\s\S]*?font-weight: 400/);
+test("creation time remains compact without data-plane metadata", () => {
+  assert.doesNotMatch(pageStyles, /\.my-agent-label/);
   assert.match(pageStyles, /\.my-agent-created-at dd\s*\{[\s\S]*?font-weight: 400/);
-});
-
-test("distributes responsive card columns across the available width", () => {
-  assert.doesNotMatch(pageStyles, /\.my-agent-card,[\s\S]*?\.my-agent-add\s*\{[^}]*max-width:/);
-  assert.match(pageSource, /const MIN_CARD_WIDTH = 174/);
 });
 
 test("loads owned runtimes into the general agents section", () => {
   assert.match(pageSource, /getRuntimes/);
   assert.match(pageSource, /scope: "mine"/);
-  assert.match(pageSource, /getRuntimeAgentInfo/);
+  assert.doesNotMatch(pageSource, /getRuntimeAgentInfo/);
   assert.match(pageSource, /id: runtime\.runtimeId/);
+  assert.match(pageSource, /name: runtime\.name/);
+  assert.match(pageSource, /description: runtime\.name/);
   assert.match(pageSource, /runtimeId: runtime\.runtimeId/);
   assert.match(pageSource, /region: runtime\.region/);
   assert.match(pageSource, /<AgentCard[\s\S]*?key=\{agent\.id\}/);
-  assert.match(pageSource, /title: "通用智能体"[\s\S]*?agents: runtimeAgents/);
-  assert.match(pageSource, /pageSize,/);
-  assert.match(
-    pageSource,
-    /onPageSizeChange\?\.\(Math\.max\(1, nextColumns \* MAX_ROWS - 1\)\)/,
-  );
+  assert.match(pageSource, /const RUNTIME_PAGE_SIZE = 24/);
   assert.match(pageSource, /onList\(page\.runtimes\.map\(runtimeToAgent\)\)/);
-  assert.match(pageSource, /void fetchRuntimePage\(runtimePage \+ 1, runtimeNextToken, runtimePageSize\)/);
   assert.match(pageSource, /runtimeRequestRef\.current !== requestId/);
-  assert.match(pageSource, /if \(page > 1 && count === 0\)/);
-  assert.match(pageSource, /className="my-agent-loading"/);
-  assert.match(pageSource, /className="loading-gap-spinner"/);
-  assert.match(pageStyles, /\.my-agent-loading\s*\{[\s\S]*?position: absolute/);
+  assert.match(pageSource, /const runtimePageRequests = new Map/);
+  assert.match(pageSource, /runtimePageRequests\.get\(requestKey\)/);
+  assert.match(pageSource, /runtimePageRequests\.set\(requestKey, request\)/);
+  assert.match(pageSource, /const RUNTIME_PAGE_CACHE_TTL_MS = 30_000/);
+  assert.match(pageSource, /runtimePageCache\.get\(requestKey\)/);
+  assert.match(pageSource, /runtimePageCache\.set\(requestKey/);
+  assert.match(pageSource, /setRuntimeAgents\(\(current\) => reset \? agents : \[\.\.\.current, \.\.\.agents\]\)/);
 });
 
-test("wires general agent creation, details, and use actions into App navigation", () => {
-  assert.match(pageSource, /onClick=\{onCreateAgent\}/);
+test("loads more Runtime cards at the scroll sentinel with accessible animation", () => {
+  assert.match(pageSource, /new IntersectionObserver/);
+  assert.match(pageSource, /loadMoreRef/);
+  assert.match(pageSource, /void fetchRuntimePage\(runtimeNextToken, false\)/);
+  assert.match(pageSource, /className="my-agent-load-more"/);
+  assert.match(pageStyles, /@keyframes my-agent-card-enter/);
+  assert.match(pageStyles, /\.my-agent-card\s*\{[\s\S]*?animation: my-agent-card-enter/);
+  assert.match(pageStyles, /@media \(prefers-reduced-motion: reduce\)[\s\S]*?animation: none/);
+});
+
+test("keeps the page controls fixed while only the Agent results scroll", () => {
+  assert.match(pageSource, /const resultsRef = useRef<HTMLElement>\(null\)/);
+  assert.match(pageSource, /const root = resultsRef\.current/);
+  assert.match(pageSource, /className="my-agent-results"[\s\S]*?ref=\{resultsRef\}/);
+  assert.match(pageStyles, /\.my-agents-page\s*\{[\s\S]*?overflow: hidden/);
+  assert.match(
+    pageStyles,
+    /\.my-agent-results\s*\{[\s\S]*?flex: 1;[\s\S]*?min-height: 0;[\s\S]*?overflow-y: auto/,
+  );
+});
+
+test("does not ship development-only Runtime fixtures", () => {
+  assert.doesNotMatch(pageSource, /mockAgents|MOCK_RUNTIME|mockRuntimePage|演示智能体/);
+  assert.doesNotMatch(authSource, /mockAgents/);
+});
+
+test("refreshes Runtime permissions without connecting to the data plane", () => {
+  const refreshStart = appSource.indexOf("const refreshAgentLibrary");
+  const refreshEnd = appSource.indexOf("\n  // Placeholder", refreshStart);
+  assert.ok(refreshStart >= 0 && refreshEnd > refreshStart);
+  const refreshSource = appSource.slice(refreshStart, refreshEnd);
+  assert.match(refreshSource, /getRuntimes/);
+  assert.match(refreshSource, /setLibraryRuntimeIds/);
+  assert.match(refreshSource, /setLibraryRuntimePermissions/);
+  assert.doesNotMatch(refreshSource, /connectRuntime|loadConnections/);
+  assert.match(
+    appSource,
+    /if \([\s\S]*?!manageAgents[\s\S]*?\) \{[\s\S]*?return;[\s\S]*?void refreshAgentLibrary\(\)/,
+  );
+});
+
+test("defers conversation data-plane requests until leaving the Agent list", () => {
+  assert.match(
+    appSource,
+    /if \(authStatus !== "authenticated"\) return;[\s\S]*?if \(agentsSource === "cloud"\) \{[\s\S]*?return;[\s\S]*?listApps\(\)/,
+  );
+  assert.match(
+    appSource,
+    /if \(myAgents \|\| agentDetailTarget \|\| !appName \|\| !userId \|\| !sessionId\)[\s\S]*?getSessionCapabilities/,
+  );
+  assert.match(
+    appSource,
+    /if \([\s\S]*?authStatus !== "authenticated"[\s\S]*?myAgents[\s\S]*?!appName[\s\S]*?\)[\s\S]*?getAgentInfo/,
+  );
+  assert.match(
+    appSource,
+    /if \(myAgents \|\| agentDetailTarget \|\| !appName \|\| !userId\) return;[\s\S]*?refreshSessions/,
+  );
+  assert.match(
+    appSource,
+    /!manageAgents \|\|[\s\S]*?agentDetailTarget[\s\S]*?void refreshAgentLibrary\(\)/,
+  );
+});
+
+test("wires card details and connect actions into App navigation", () => {
   assert.match(pageSource, /onClick=\{\(\) => void onUse\?\.\(agent\)\}/);
   assert.match(pageSource, /onClick=\{\(\) => onViewDetails\?\.\(agent\)\}/);
-  assert.match(pageSource, /onCreateAgent=\{createActions\[index\]\}/);
-  assert.match(appSource, /const openAgentCreateFromMyAgents/);
   assert.match(appSource, /const connectMyAgent[\s\S]*?connectRuntime[\s\S]*?startNewChat\(\)[\s\S]*?setAppName\(agentId\)/);
   assert.match(appSource, /const openMyAgentDetails[\s\S]*?setAgentDetailTarget\(agent\)[\s\S]*?setManageAgents\(true\)/);
   assert.doesNotMatch(appSource, /const openMyAgentDetails[\s\S]*?connectRuntime\(/);
@@ -139,23 +187,23 @@ test("wires general agent creation, details, and use actions into App navigation
   assert.match(appSource, /<MyAgents[\s\S]*?onCreateAgent=\{openAgentCreateFromMyAgents\}[\s\S]*?onUseAgent=/);
 });
 
-test("routes add cards to Codex launch and coming-soon flows", () => {
+test("keeps all requested type filters without nested category sections", () => {
   assert.match(pageSource, /onCreateCodexAgent: \(\) => void/);
+  assert.match(pageSource, /AGENT_TYPES\.map/);
+  assert.match(pageSource, /label: "Codex 智能体"/);
+  assert.match(pageSource, /label: "OpenClaw 智能体"/);
+  assert.match(pageSource, /label: "Hermes 智能体"/);
+  assert.doesNotMatch(pageSource, /AgentSection|my-agents-section|comingSoon/);
+  assert.match(pageSource, /\$\{activeLabel\}暂无内容/);
+  assert.match(pageSource, /activeType === "openclaw" \|\| activeType === "hermes"[\s\S]*?"暂未开放"/);
+  assert.doesNotMatch(pageStyles, /\.my-agent-empty\s*\{[^}]*border:/);
+  assert.doesNotMatch(pageStyles, /\.my-agent-empty\s*\{[^}]*background:/);
   assert.match(
-    pageSource,
-    /const createActions = \[[\s\S]*?onCreateAgent,[\s\S]*?onCreateCodexAgent,[\s\S]*?undefined,[\s\S]*?undefined,[\s\S]*?\]/,
+    pageStyles,
+    /\.my-agent-initial-loading,[\s\S]*?\.my-agent-empty\s*\{[\s\S]*?font-size: 12\.5px/,
   );
-  assert.match(pageSource, /onCreateAgent=\{createActions\[index\]\}/);
-  assert.match(pageSource, /title: "OpenClaw 智能体", agents: \[\], comingSoon: true/);
-  assert.match(pageSource, /title: "Hermes 智能体", agents: \[\], comingSoon: true/);
-  assert.match(pageSource, /className="my-agent-coming-soon-overlay" role="status"[\s\S]*?敬请期待/);
-  assert.match(pageStyles, /\.my-agent-coming-soon-overlay\s*\{[\s\S]*?position: absolute[\s\S]*?inset: 0/);
-  assert.match(appSource, /onCreateCodexAgent=\{openSandboxLaunch\}/);
-  assert.match(appSource, /function openSandboxLaunch\(\)[\s\S]*?setSandboxLaunchOpen\(true\)/);
-  assert.match(
-    appSource,
-    /async function launchSandboxSession\(\)[\s\S]*?setSandboxSession\(nextSession\)[\s\S]*?setAgentDetailTarget\(null\)[\s\S]*?setMyAgents\(false\)[\s\S]*?setSandboxLaunchOpen\(false\)/,
-  );
+  assert.match(pageStyles, /\.my-agent-empty p\s*\{[\s\S]*?color: inherit;[\s\S]*?font-size: inherit/);
+  assert.match(pageStyles, /\.my-agent-empty p\s*\{[\s\S]*?font-weight: 400/);
 });
 
 test("shows connecting progress and preserves the connected Runtime state", () => {
@@ -165,24 +213,24 @@ test("shows connecting progress and preserves the connected Runtime state", () =
     /setConnectingAgentId\(agent\.id\)[\s\S]*?requestAnimationFrame[\s\S]*?await onUseAgent\(agent\)[\s\S]*?setConnectingAgentId\(""\)/,
   );
   assert.match(pageSource, /aria-busy=\{connecting \|\| undefined\}/);
-  assert.match(pageSource, /className="my-agent-use-spinner"[\s\S]*?<span>连接中<\/span>/);
-  assert.match(pageSource, /connected \? "已连接" : "使用"/);
+  assert.match(pageSource, /connecting \? "连接中" : connected \? "已连接" : "连接"/);
+  assert.doesNotMatch(pageSource, /ConnectIcon|my-agent-use-spinner/);
   assert.match(pageSource, /disabled=\{!agent\.runtime \|\| connecting \|\| connected\}/);
-  assert.match(appSource, /connectedRuntimeId=\{currentRuntime\?\.runtimeId\}/);
-  assert.match(pageStyles, /\.my-agent-use-spinner\s*\{[\s\S]*?border-right-color: transparent/);
+  assert.match(appSource, /connectedRuntimeId=\{connectedRuntimeId\}/);
+  assert.match(pageStyles, /\.my-agent-loading-mark[\s\S]*?border-right-color: transparent/);
   assert.match(
     pageStyles,
-    /\.my-agent-actions \.my-agent-use\.is-connected,[\s\S]*?background: hsl\(142 55% 94%\)[\s\S]*?color: hsl\(142 62% 30%\)/,
+    /\.my-agent-connect\.is-connected,[\s\S]*?background: hsl\(142 55% 94%\)[\s\S]*?color: hsl\(142 62% 30%\)/,
   );
 });
 
-test("prompts users to choose an Agent only while disconnected", () => {
-  assert.match(
-    pageSource,
-    /!connectedRuntimeId && \([\s\S]*?className="my-agents-connect-banner" role="status"[\s\S]*?请选择一个智能体以对话/,
-  );
-  assert.match(pageStyles, /\.my-agents-connect-banner\s*\{[\s\S]*?margin-bottom:\s*24px;/);
-  assert.match(appSource, /connectedRuntimeId=\{currentRuntime\?\.runtimeId\}/);
+test("uses connected Runtime state only for the card action", () => {
+  assert.doesNotMatch(pageSource, /my-agents-connect-banner|请选择一个智能体以对话/);
+  assert.match(pageSource, /agent\.runtime\?\.runtimeId === connectedRuntimeId/);
+  assert.match(pageSource, /const connectedIndex = matchingAgents\.findIndex/);
+  assert.match(pageSource, /matchingAgents\[connectedIndex\][\s\S]*?matchingAgents\.slice\(0, connectedIndex\)/);
+  assert.match(appSource, /const connectedRuntimeId =[\s\S]*?currentRuntime\?\.runtimeId \?\?[\s\S]*?connections\.reduce/);
+  assert.match(appSource, /connectedRuntimeId=\{connectedRuntimeId\}/);
 });
 
 test("authenticated users land on the Agent page by default", () => {
@@ -191,13 +239,7 @@ test("authenticated users land on the Agent page by default", () => {
   assert.match(appSource, /defaultViewAppliedRef\.current \|\| myAgents/);
 });
 
-test("limits every agent family to two responsive rows with independent pagination", () => {
-  assert.match(pageSource, /const MAX_ROWS = 2/);
-  assert.match(pageSource, /pageSize = Math\.max\(1, columns \* MAX_ROWS - 1\)/);
-  assert.match(pageSource, /useState\(1\)/);
-  assert.match(pageSource, /className="my-agent-pagination"/);
-  assert.match(pageSource, /aria-label="上一页"[\s\S]*?>\s*‹\s*<\/button>/);
-  assert.match(pageSource, /aria-label="下一页"[\s\S]*?>\s*›\s*<\/button>/);
-  assert.match(pageStyles, /\.my-agent-pagination\s*\{[\s\S]*?justify-content: center/);
-  assert.match(pageSource, /serverPagination \? currentPage : `\$\{page\} \/ \$\{pageCount\}`/);
+test("removes numbered pagination in favor of continuous loading", () => {
+  assert.doesNotMatch(pageSource, /MAX_ROWS|my-agent-pagination|上一页|下一页/);
+  assert.doesNotMatch(pageStyles, /\.my-agent-pagination/);
 });

--- a/frontend/tests/siteBranding.test.mjs
+++ b/frontend/tests/siteBranding.test.mjs
@@ -99,7 +99,10 @@ test("history header offers a borderless new-session action", () => {
     stylesSource,
     /\.history-new-chat\s*\{[\s\S]*?border:\s*0;[\s\S]*?background:\s*transparent;/,
   );
-  assert.match(stylesSource, /\.history-head\s*\{[\s\S]*?padding:\s*8px 10px 6px 20px;/);
+  assert.match(
+    stylesSource,
+    /\.history-head\s*\{[\s\S]*?padding:\s*8px 10px 6px 20px;[\s\S]*?font-size:\s*13px;[\s\S]*?font-weight:\s*600;[\s\S]*?color:\s*hsl\(var\(--foreground\)\);/,
+  );
   assert.match(
     stylesSource,
     /\.history-new-chat:hover\s*\{[\s\S]*?background:\s*transparent;[\s\S]*?color:\s*hsl\(var\(--foreground\)\);/,

--- a/tests/cli/test_frontend_runtime_proxy.py
+++ b/tests/cli/test_frontend_runtime_proxy.py
@@ -39,7 +39,7 @@ def _create_frontend_app(
     site_title: str | None = None,
 ) -> FastAPI:
     captured: dict[str, Any] = {}
-    monkeypatch.setattr("dotenv.find_dotenv", lambda: "")
+    monkeypatch.setattr("dotenv.find_dotenv", lambda *args, **kwargs: "")
     monkeypatch.setattr(
         "uvicorn.run",
         lambda app, **kwargs: captured.setdefault("app", app),
@@ -174,6 +174,10 @@ def test_runtime_list_paginates_across_regions(
     with TestClient(app) as client:
         first = client.get("/web/runtimes", params={"region": "all", "page_size": 2})
         first_calls = list(calls)
+        cached_first = client.get(
+            "/web/runtimes", params={"region": "all", "page_size": 2}
+        )
+        cached_first_calls = list(calls)
         second = client.get(
             "/web/runtimes",
             params={
@@ -199,6 +203,8 @@ def test_runtime_list_paginates_across_regions(
         ("cn-beijing", "0", 2),
         ("cn-shanghai", "0", 2),
     ]
+    assert cached_first.json() == first.json()
+    assert cached_first_calls == first_calls
     assert first.json()["nextToken"] == "all:2"
     assert [item["name"] for item in second.json()["runtimes"]] == [
         "beijing-mid",

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -34,6 +34,7 @@ import zipfile
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from time import monotonic
 from typing import Any, Literal
 from urllib.parse import urlparse
 
@@ -3066,6 +3067,10 @@ def _run_frontend_server(
             logger.error(f"get runtime detail failed: {e}", exc_info=True)
             raise HTTPException(status_code=502, detail=str(e))
 
+    _runtime_list_cache_ttl_seconds = 30.0
+    _runtime_list_cache: dict[tuple[Any, ...], tuple[float, dict[str, Any]]] = {}
+    _runtime_list_locks: dict[tuple[Any, ...], asyncio.Lock] = {}
+
     @app.get("/web/runtimes")
     async def _web_runtimes(
         request: Request,
@@ -3087,6 +3092,22 @@ def _run_frontend_server(
         )
         page_size = max(1, min(page_size, 100))
         restrict_to_owner = scope == "mine" or role != StudioRole.ADMIN
+        principal_key = (
+            getattr(principal, "owner_id", ""),
+            getattr(principal, "display_name", ""),
+        )
+        cache_key = (
+            principal_key,
+            role,
+            scope,
+            page_size,
+            next_token,
+            region,
+        )
+        cached = _runtime_list_cache.get(cache_key)
+        if cached and monotonic() - cached[0] < _runtime_list_cache_ttl_seconds:
+            return cached[1]
+        list_lock = _runtime_list_locks.setdefault(cache_key, asyncio.Lock())
 
         # next_token format for cross-region mode: "all:<offset>".
         async def _list_region(
@@ -3153,6 +3174,16 @@ def _run_frontend_server(
                 current_token = next_page_token
             return out[:target_size], next_page_token
 
+        await list_lock.acquire()
+        cached = _runtime_list_cache.get(cache_key)
+        if cached and monotonic() - cached[0] < _runtime_list_cache_ttl_seconds:
+            list_lock.release()
+            return cached[1]
+
+        def _cache_result(payload: dict[str, Any]) -> dict[str, Any]:
+            _runtime_list_cache[cache_key] = (monotonic(), payload)
+            return payload
+
         try:
             if restrict_to_owner and principal is not None:
                 if next_token:
@@ -3192,11 +3223,11 @@ def _run_frontend_server(
                 page = owned_runtimes[offset:page_end]
                 has_more = page_end < len(owned_runtimes) or owned_has_more
                 following_token = f"mine:{page_end}" if has_more else ""
-                return {"runtimes": page, "nextToken": following_token}
+                return _cache_result({"runtimes": page, "nextToken": following_token})
 
             if len(regions) == 1:
                 out, nxt = await _list_region(regions[0], next_token)
-                return {"runtimes": out, "nextToken": nxt}
+                return _cache_result({"runtimes": out, "nextToken": nxt})
 
             if next_token:
                 match = re.fullmatch(r"all:(\d+)", next_token)
@@ -3256,12 +3287,14 @@ def _run_frontend_server(
             page = all_runtimes[offset:page_end]
             has_more = page_end < len(all_runtimes) or regional_has_more
             following_token = f"all:{page_end}" if has_more else ""
-            return {"runtimes": page, "nextToken": following_token}
+            return _cache_result({"runtimes": page, "nextToken": following_token})
         except HTTPException:
             raise
         except Exception as e:
             logger.error(f"list runtimes failed: {e}", exc_info=True)
             raise HTTPException(status_code=502, detail=str(e))
+        finally:
+            list_lock.release()
 
     # Cache resolved (endpoint, apikey, auth type) per runtime so the data-plane
     # proxy does not call GetRuntime on every request. Short TTL; cleared on a 401.


### PR DESCRIPTION
## Summary
- redesign the Studio agent directory with type filters, search, compact Runtime cards, fixed controls, and continuous loading
- keep Runtime titles stable and avoid data-plane metadata requests while browsing the directory
- deduplicate and cache Runtime list requests across the frontend and proxy to improve repeat-load performance
- streamline agent detail loading and preserve existing create, connect, and navigation flows

## Validation
- `uv run pre-commit run`
- `npm test` (265 passed)
- `npx tsc --noEmit -p tsconfig.json`
- `uv run pytest tests/cli/test_frontend_runtime_proxy.py` (7 passed)
- broader Python suite: 952 passed, 6 skipped; 4 unrelated failures require optional `llama_index` / `greenlet` dependencies in the local environment