### PR TITLE
fix(studio): include Mem0 dependency in generated agents

### DIFF
--- a/frontend/src/create/veadkCatalog.ts
+++ b/frontend/src/create/veadkCatalog.ts
@@ -304,6 +304,7 @@ export const LTM_BACKENDS: BackendOption[] = [
       { key: "DATABASE_MEM0_API_KEY", required: true },
       { key: "DATABASE_MEM0_BASE_URL", required: false },
     ],
+    pipExtra: "database",
   },
 ];
 

--- a/frontend/tests/deploymentEnv.test.mjs
+++ b/frontend/tests/deploymentEnv.test.mjs
@@ -140,6 +140,17 @@ test("collects every component parameter and enables selected tracing exporters"
   }
 });
 
+test("declares the Mem0 runtime configuration and database dependency", () => {
+  const mem0 = LTM_BACKENDS.find((option) => option.id === "mem0");
+
+  assert.ok(mem0);
+  assert.equal(mem0.pipExtra, "database");
+  assert.deepEqual(
+    mem0.env.map((env) => env.key),
+    ["DATABASE_MEM0_API_KEY", "DATABASE_MEM0_BASE_URL"],
+  );
+});
+
 test("does not request auto-resolved credentials per component", () => {
   const envKeys = [
     ...BUILTIN_TOOLS,

--- a/tests/cli/test_generated_agent_component_matrix.py
+++ b/tests/cli/test_generated_agent_component_matrix.py
@@ -63,6 +63,27 @@ def _assert_python_files_compile(project: GeneratedProject) -> None:
             ast.parse(content, filename=path)
 
 
+def _veadk_requirement(extras: set[str]) -> str:
+    extras_str = f"[{','.join(sorted(extras))}]" if extras else ""
+    return f"veadk-python{extras_str}>=1.0.5"
+
+
+EXPECTED_LTM_EXTRAS = {
+    "local": {"extensions"},
+    "opensearch": {"extensions"},
+    "redis": {"extensions"},
+    "viking": set(),
+    "mem0": {"database"},
+}
+
+EXPECTED_KB_EXTRAS = {
+    "local": {"extensions"},
+    "opensearch": {"extensions"},
+    "viking": set(),
+    "context_search": set(),
+}
+
+
 def test_component_catalog_does_not_request_auto_resolved_credentials() -> None:
     component_env_keys = _catalog_env_keys(
         *(item.env for item in BUILTIN_TOOLS),
@@ -282,7 +303,9 @@ def test_every_long_term_memory_backend_generates_code_env_and_dependency(
     assert f'LongTermMemory(backend="{backend.id}"' in agent_py
     assert "auto_save_session=True" in agent_py
     assert _env_keys(files[".env.example"]) == _catalog_env_keys(MODEL_ENV, backend.env)
-    assert ("[extensions]" in files["requirements.txt"]) == bool(backend.pip_extra)
+    assert files["requirements.txt"].splitlines()[0] == _veadk_requirement(
+        EXPECTED_LTM_EXTRAS[backend.id]
+    )
     _assert_python_files_compile(project)
 
 
@@ -302,8 +325,34 @@ def test_every_knowledgebase_backend_generates_code_env_and_dependency(
 
     assert f'KnowledgeBase(backend="{backend.id}"' in agent_py
     assert _env_keys(files[".env.example"]) == _catalog_env_keys(MODEL_ENV, backend.env)
-    assert ("[extensions]" in files["requirements.txt"]) == bool(backend.pip_extra)
+    assert files["requirements.txt"].splitlines()[0] == _veadk_requirement(
+        EXPECTED_KB_EXTRAS[backend.id]
+    )
     _assert_python_files_compile(project)
+
+
+def test_component_dependencies_are_merged_and_deduplicated() -> None:
+    project = generate_project_from_draft(
+        AgentDraft(
+            name="dependency-combination",
+            memory=MemoryConfig(longTerm=True),
+            longTermBackend="mem0",
+            subAgents=[
+                AgentDraft(
+                    name="opensearch-worker",
+                    memory=MemoryConfig(longTerm=True),
+                    longTermBackend="opensearch",
+                    knowledgebase=True,
+                    knowledgebaseBackend="opensearch",
+                )
+            ],
+        )
+    )
+
+    requirements = _files(project)["requirements.txt"].splitlines()
+
+    assert requirements[0] == _veadk_requirement({"database", "extensions"})
+    assert requirements[0].count("extensions") == 1
 
 
 def test_viking_knowledgebase_uses_selected_index() -> None:

--- a/veadk/cli/generated_agent_catalog.py
+++ b/veadk/cli/generated_agent_catalog.py
@@ -229,6 +229,7 @@ LTM_BACKENDS = (
             EnvVar("DATABASE_MEM0_API_KEY", True),
             EnvVar("DATABASE_MEM0_BASE_URL", False),
         ),
+        pip_extra="database",
     ),
 )
 


### PR DESCRIPTION
## Summary

- declare the `database` extra for the Mem0 long-term-memory option in both Studio catalogs
- verify exact optional dependencies for every generated long-term-memory and knowledge-base backend
- cover merged and deduplicated requirements such as `veadk-python[database,extensions]`
- add a frontend catalog contract for Mem0 runtime configuration

## Validation

- `uv run pre-commit run --all-files`
- `uv run pytest -q` (993 passed, 6 skipped, 6 subtests passed)
- `cd frontend && npm test` (293 passed)
- `cd frontend && npm run build`
- `uvx ruff check veadk/cli/generated_agent_catalog.py tests/cli/test_generated_agent_component_matrix.py`
- `uvx pyright --pythonpath .venv/bin/python veadk/cli/generated_agent_catalog.py tests/cli/test_generated_agent_component_matrix.py`
- Python 3.12 isolated install of `.[database,extensions]`, `uv pip check`, Mem0 import, and `MemoryClient.add/search` signature binding