### PR TITLE
fix(tracing): report model reasoning to APMPlus

### DIFF
--- a/tests/test_tracing_content.py
+++ b/tests/test_tracing_content.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 from dataclasses import dataclass
 
 from opentelemetry import context as context_api
@@ -26,6 +27,7 @@ from veadk.tracing.telemetry.exporters.apmplus_exporter import MeterUploader
 @dataclass
 class _FakePart:
     text: str | None = None
+    thought: bool | None = None
     function_call: object | None = None
     function_response: object | None = None
     inline_data: object | None = None
@@ -241,6 +243,48 @@ def test_agent_root_span_skips_content_when_env_false(monkeypatch):
         assert "gen_ai.output" not in span.attributes
         assert "gen_ai.user.message" not in _event_names(span)
         assert "gen_ai.choice" not in _event_names(span)
+
+
+def test_agent_output_serializes_reasoning_for_apmplus():
+    response = _FakeLlmResponse()
+    response.content = _FakeContent(
+        "model",
+        [
+            _FakePart(text="thinking", thought=True),
+            _FakePart(text="answer"),
+        ],
+    )
+
+    with _start_test_span("invocation") as span:
+        telemetry._set_agent_output_attribute(span, response)
+
+        assert json.loads(span.attributes["gen_ai.output"]) == {
+            "messages": [
+                {
+                    "role": "model",
+                    "parts": [
+                        {"type": "reasoning", "content": "thinking"},
+                        {"type": "text", "content": "answer"},
+                    ],
+                }
+            ]
+        }
+
+
+def test_agent_output_serializes_plain_text_for_apmplus():
+    with _start_test_span("invocation") as span:
+        telemetry._set_agent_output_attribute(span, _FakeLlmResponse())
+
+        assert json.loads(span.attributes["gen_ai.output"]) == {
+            "messages": [
+                {
+                    "role": "model",
+                    "parts": [
+                        {"type": "text", "content": "assistant secret"},
+                    ],
+                }
+            ]
+        }
 
 
 def test_content_tracing_context_override_allows_content(monkeypatch):

--- a/veadk/tracing/telemetry/telemetry.py
+++ b/veadk/tracing/telemetry/telemetry.py
@@ -212,10 +212,28 @@ def _set_agent_output_attribute(span: Span, llm_response: LlmResponse) -> None:
 
     content = llm_response.content
     if content and content.parts:
+        output_parts = []
+        for part in content.parts:
+            if not part.text:
+                output_parts = []
+                break
+            output_parts.append(
+                {
+                    "type": "reasoning" if getattr(part, "thought", False) else "text",
+                    "content": part.text,
+                }
+            )
+
+        output = (
+            {"messages": [{"role": content.role, "parts": output_parts}]}
+            if output_parts
+            else content.model_dump(exclude_none=True)
+        )
+
         # set gen_ai.output attribute required by APMPlus
         span.set_attribute(
             "gen_ai.output",
-            safe_json_serialize(content.model_dump(exclude_none=True)),
+            safe_json_serialize(output),
         )
 
         for idx, part in enumerate(content.parts):


### PR DESCRIPTION
## Summary
- serialize textual agent output using the APMPlus messages and parts structure
- mark ADK parts with thought=true as reasoning while preserving the existing model role
- retain the previous serialization for non-text responses and add regression coverage

## Testing
- pre-commit run --all-files
- pytest tests/test_tracing_content.py plus the isolated Studio deployment case: 10 passed
- pytest tests -q: 1001 passed, 5 skipped, 1 failed

The full-suite failure is the existing order-dependent Studio deployment test test_studio_deploy_surfaces_redacted_provisioning_error_chain. The same failure reproduces on a clean origin/main full-suite run, while the test passes in isolation.