### PR TITLE
feat: add openviking_user_id support

### DIFF
--- a/OPENVIKING_CHANGE_PLAN.md
+++ b/OPENVIKING_CHANGE_PLAN.md
@@ -1,0 +1,86 @@
+# OpenViking 改动技术方案
+## 本次改动概览
+本次改动为 OpenViking 后端补齐了配置加载、资源归属、默认 URI、生命周期释放、示例工程和使用文档。
+KnowledgeBase 的 OpenViking 后端新增了 `openviking_user_id` 配置，用于区分 OpenViking 资源归属；当用户没有显式传入 `target_uri` 时，会根据 `openviking_user_id` 和知识库 `index` 生成默认资源 URI。
+LongTermMemory 的 OpenViking 后端新增了 `openviking_user_id` 和 `memory_policy` 配置，用于区分长期记忆归属并允许用户配置记忆策略。
+OpenViking 后端补齐了配置初始化能力，避免仅使用 KnowledgeBase 或 LongTermMemory 时 `.env`、`config.yaml` 中的 OpenViking 配置未被加载。
+KnowledgeBase 新增了 `close()` 释放入口，OpenViking KnowledgeBase 后端也新增了客户端关闭与再次使用时重建客户端的能力，避免长生命周期进程中连接资源无法主动释放。
+OpenViking KnowledgeBase 默认 URI 的路径片段增加了校验，避免 `openviking_user_id` 或 `index` 中包含不安全路径字符导致资源路径异常。
+配置模型新增了 OpenViking 的 `user_id` 与 `memory_policy` 字段，方便通过统一配置文件描述 OpenViking 知识库与长期记忆行为。
+示例目录新增了 `examples/13_openviking`，提供独立的 OpenViking 使用示例，覆盖 KnowledgeBase、LongTermMemory、环境变量、显式 `backend_config` 和资源释放用法。
+已有示例中的 `examples/*/.env.example` 补充了 OpenViking 相关注释，说明用户如何配置 OpenViking 服务地址、资源 URI、用户标识和记忆策略。
+README 与文档补充了 OpenViking 的配置说明、URI 规则、示例入口和使用注意事项，帮助用户从本地 RAG 或 LongTermMemory 示例切换到 OpenViking。
+## 配置优先级
+KnowledgeBase 的 `target_uri` 优先级为：调用 `add_resource`、`search`、`read` 等方法时显式传入的 `target_uri` 最高，其次是 `backend_config["target_uri"]`，再次是环境变量 `DATABASE_OPENVIKING_TARGET_URI`，最后才使用默认生成的 URI。
+KnowledgeBase 的 `openviking_user_id` 优先级为：`backend_config["openviking_user_id"]` 最高，其次兼容 `backend_config["user_id"]`，再次是环境变量 `DATABASE_OPENVIKING_USER_ID`，最后使用 `default`。
+KnowledgeBase 的 `index` 在未显式传入 `backend_config` 时可来自 `KnowledgeBase(index=...)` 或应用名；如果已经显式传入 `backend_config`，则推荐在 `backend_config["index"]` 中声明，避免资源路径不明确。
+LongTermMemory 的 `memory_policy` 优先级为：`backend_config["memory_policy"]` 最高，其次是环境变量或配置文件中的 `DATABASE_OPENVIKING_MEMORY_POLICY`，最后使用后端默认策略。
+OpenViking 服务连接配置优先级为：代码中显式传入的 `url`、`api_key` 优先，其次读取环境变量或配置文件中的 `DATABASE_OPENVIKING_URL`、`DATABASE_OPENVIKING_API_KEY`。
+`Runner.user_id` 主要用于会话和记忆使用者身份，不等同于 OpenViking 资源归属；OpenViking 资源归属应使用 `openviking_user_id` 或 `DATABASE_OPENVIKING_USER_ID` 配置。
+## URI 规则说明
+`DATABASE_OPENVIKING_URL` 是 OpenViking 服务地址，例如 HTTP API 地址；它只用于连接服务，不参与资源路径拼接。
+`target_uri` 是完整的 OpenViking 资源 URI；只要用户显式配置了 `target_uri`，后端会直接使用该值，不会再把它和 `openviking_user_id`、`index` 做二次拼接。
+当用户没有配置 `target_uri` 时，KnowledgeBase 会按 `viking://user/{openviking_user_id}/resources/{index}/` 生成默认 URI。
+当显式 `target_uri` 使用 `viking://` 协议且末尾没有 `/` 时，后端会补齐尾部 `/`，以保持资源目录语义一致。
+LongTermMemory 不使用 KnowledgeBase 的 `resources/{index}` 路径，而是按用户和 peer 维度写入记忆 URI，默认形态为 `viking://user/{openviking_user_id}/peers/{peer_id}/memories`。
+示例：不显式配置 `target_uri` 时，`openviking_user_id=demo_user` 且 `index=company_faq` 会生成如下 KnowledgeBase URI。
+```text
+viking://user/demo_user/resources/company_faq/
+```
+示例：显式配置 `target_uri` 时，后端直接使用该完整 URI，不再拼接 `openviking_user_id` 或 `index`。
+```text
+viking://user/shared/resources/company_faq/
+```
+## 推荐配置方式
+推荐通过 `.env` 或 `config.yaml` 管理 OpenViking 连接配置，通过代码中的 `KnowledgeBase(index=...)` 或 `backend_config` 管理具体业务资源。
+如果一个项目只连接一个 OpenViking 服务，建议把服务地址和 API Key 放在 `.env` 中，把业务资源 ID 放在代码或 `config.yaml` 中。
+如果一个项目需要同时访问多个 OpenViking 资源，建议在代码中为不同 KnowledgeBase 或 LongTermMemory 显式传入 `backend_config`，避免环境变量造成资源混用。
+示例 `.env` 配置如下。
+```env
+DATABASE_OPENVIKING_URL=https://example.openviking.volces.com
+DATABASE_OPENVIKING_API_KEY=your-api-key
+DATABASE_OPENVIKING_USER_ID=demo_user
+DATABASE_OPENVIKING_TARGET_URI=viking://user/demo_user/resources/company_faq/
+```
+示例 `backend_config` 配置如下。
+```python
+knowledgebase = KnowledgeBase(
+    backend_config={
+        "type": "openviking",
+        "index": "company_faq",
+        "openviking_user_id": "demo_user",
+    },
+)
+```
+示例显式 `target_uri` 配置如下。
+```python
+knowledgebase = KnowledgeBase(
+    backend_config={
+        "type": "openviking",
+        "target_uri": "viking://user/shared/resources/company_faq/",
+    },
+)
+```
+示例长期记忆策略配置如下。
+```python
+long_term_memory = LongTermMemory(
+    backend_config={
+        "type": "openviking",
+        "openviking_user_id": "demo_user",
+        "memory_policy": {
+            "max_recent_items": 20,
+            "enable_summary": True,
+        },
+    },
+)
+```
+## 示例与文档补充
+新增的 `examples/13_openviking` 是独立 OpenViking 示例，用户可以从该目录直接查看 `.env.example`、README、示例知识文件和 `main.py`。
+`examples/13_openviking/main.py` 展示了如何创建 OpenViking KnowledgeBase、添加文档资源、执行检索、启用 LongTermMemory，并在结束时调用 `knowledgebase.close()` 释放客户端资源。
+`examples/13_openviking/.env.example` 展示了 OpenViking 服务地址、API Key、默认用户 ID、完整 `target_uri` 和长期记忆策略的配置方式。
+`examples/05_knowledgebase_rag/.env.example` 和 `examples/09_long_term_memory/.env.example` 补充了 OpenViking 相关注释，说明原有示例如何切换到 OpenViking 后端。
+`examples/README.md` 和 `examples/README.zh.md` 补充了 OpenViking 示例入口，方便用户从示例总览中找到独立 OpenViking 用法。
+## 验证范围
+已补充 OpenViking KnowledgeBase 与 LongTermMemory 的单元测试，覆盖配置加载、默认 URI、显式 `target_uri`、用户 ID 优先级、记忆策略、非法路径校验和资源释放行为。
+已运行 OpenViking 相关测试并通过，覆盖文件为 `tests/test_openviking_knowledgebase.py` 和 `tests/test_openviking_long_term_memory.py`。
+已运行 pre-commit 并通过，覆盖 ruff 检查、ruff format 和 hardcoded secrets 检查。

--- a/config.yaml.full
+++ b/config.yaml.full
@@ -182,11 +182,13 @@ database:
   openviking:
     url: http://127.0.0.1:1933 # OpenViking HTTP server base URL
     api_key: your-openviking-api-key # OpenViking service owner API key
+    # user_id: default # OpenViking owner/context id used by knowledge and memory
+    # memory_policy: '{"self":{"enabled":false},"peer":{"enabled":true},"memory_types":["entities","events","preferences"]}' # JSON string; omit to keep the default policy
     # Optional knowledgebase settings:
     # account:
     # user:
     # actor_peer_id:
-    # target_uri: viking://resources/{index}/
+    # target_uri: viking://user/{OpenViking user_id or default}/resources/{index}/
     # wait: true
     # import_timeout: 300
     # hydrate_results: true

--- a/docs/content/docs/framework/knowledgebase/overview.en.mdx
+++ b/docs/content/docs/framework/knowledgebase/overview.en.mdx
@@ -125,7 +125,7 @@ See the [Volcengine Cloud Search Service docs: Create an instance](https://www.v
 
 #### config.yaml
 
-Fill the provisioned VikingDB, TOS, and OpenSearch details into `config.yaml`. Do **not** put secrets in the file — reference them via environment variables:
+Fill the provisioned VikingDB, TOS, OpenSearch, or OpenViking details into `config.yaml`. Do **not** put secrets in the file; reference them via environment variables:
 
 ```yaml
 model:
@@ -153,6 +153,14 @@ database:
     port: 9200
     username: admin
     password: ${DATABASE_OPENSEARCH_PASSWORD}
+  openviking:
+    url: http://127.0.0.1:1933
+    api_key: ${DATABASE_OPENVIKING_API_KEY}
+    # user_id is the OpenViking owner/context ID in config.yaml.
+    # When target_uri is unset, VeADK uses:
+    # viking://user/default/resources/{index}/
+    # user_id: team_a
+    # target_uri: viking://user/team_a/resources/company_faq/
 ```
 
 Provide those secrets in environment variables:
@@ -162,6 +170,7 @@ export MODEL_AGENT_API_KEY="<your Ark API key>"
 export VOLCENGINE_ACCESS_KEY="<your AK>"
 export VOLCENGINE_SECRET_KEY="<your SK>"
 export DATABASE_OPENSEARCH_PASSWORD="<your OpenSearch password>"
+export DATABASE_OPENVIKING_API_KEY="<your OpenViking API key>"
 ```
 
 ### Demo scenario
@@ -208,6 +217,37 @@ if not kb.collection_status()["existed"]:
     kb.create_collection()  # Viking requires an explicit create
 
 kb.add_from_text(mock_data)
+```
+
+### Using OpenViking as storage
+
+The OpenViking backend stores knowledge in OpenViking resource directories and does not need local embedding configuration. `index` still names the resource directory. If you do not pass `backend_config`, VeADK can fill `index` from `KnowledgeBase(index=...)` or `app_name`; when you do pass `backend_config`, include `index` in that dictionary. When `target_uri` is not configured, the default directory is:
+
+```text
+viking://user/{openviking_user_id or default}/resources/{index}/
+```
+
+`openviking_user_id` comes from `backend_config["openviking_user_id"]` or `DATABASE_OPENVIKING_USER_ID`; if both are unset, it defaults to `default`. The legacy `backend_config["user_id"]` still works as a compatibility alias. If you pass `target_uri` or set `DATABASE_OPENVIKING_TARGET_URI`, that directory is used directly.
+
+```python
+from veadk.knowledgebase import KnowledgeBase
+
+kb = KnowledgeBase(
+    backend="openviking",
+    app_name="company_faq",
+    backend_config={
+        "index": "company_faq",
+        "url": "http://127.0.0.1:1933",
+        "api_key": "your-openviking-api-key",
+        # Optional; defaults to default when omitted.
+        "openviking_user_id": "team_a",
+        # Optional; defaults to viking://user/team_a/resources/company_faq/
+        # "target_uri": "viking://user/team_a/resources/company_faq/",
+    },
+)
+
+kb.add_from_directory("./docs")
+results = kb.search("What is the remote work policy?")
 ```
 
 Complete runnable example (VikingDB backend with a date-difference tool):

--- a/docs/content/docs/framework/knowledgebase/overview.mdx
+++ b/docs/content/docs/framework/knowledgebase/overview.mdx
@@ -125,7 +125,7 @@ print(asyncio.run(runner.run(messages="年假有多少天？可以远程办公�
 
 #### config.yaml
 
-把上面开通的 VikingDB、TOS、OpenSearch 信息填入 `config.yaml`。密钥**不要**写进配置文件——用环境变量引用：
+把上面开通的 VikingDB、TOS、OpenSearch 或 OpenViking 信息填入 `config.yaml`。密钥**不要**写进配置文件，用环境变量引用：
 
 ```yaml
 model:
@@ -153,6 +153,14 @@ database:
     port: 9200
     username: admin
     password: ${DATABASE_OPENSEARCH_PASSWORD}
+  openviking:
+    url: http://127.0.0.1:1933
+    api_key: ${DATABASE_OPENVIKING_API_KEY}
+    # user_id 是 config.yaml 中的 OpenViking owner/context ID。
+    # 未配置 target_uri 时使用：
+    # viking://user/default/resources/{index}/
+    # user_id: team_a
+    # target_uri: viking://user/team_a/resources/company_faq/
 ```
 
 对应地，在环境变量中提供这些密钥：
@@ -162,6 +170,7 @@ export MODEL_AGENT_API_KEY="<你的方舟 API Key>"
 export VOLCENGINE_ACCESS_KEY="<你的 AK>"
 export VOLCENGINE_SECRET_KEY="<你的 SK>"
 export DATABASE_OPENSEARCH_PASSWORD="<你的 OpenSearch 密码>"
+export DATABASE_OPENVIKING_API_KEY="<你的 OpenViking API Key>"
 ```
 
 ### 演示场景
@@ -208,6 +217,37 @@ if not kb.collection_status()["existed"]:
     kb.create_collection()  # Viking 需要显式创建集合
 
 kb.add_from_text(mock_data)
+```
+
+### OpenViking 作为存储
+
+OpenViking 后端使用 OpenViking 的资源目录存放知识，不需要本地 embedding 配置。`index` 仍用于命名资源目录。如果不传 `backend_config`，VeADK 可以从 `KnowledgeBase(index=...)` 或 `app_name` 补齐 `index`；如果传了 `backend_config`，请在该字典内显式提供 `index`。未显式配置 `target_uri` 时，默认目录为：
+
+```text
+viking://user/{openviking_user_id or default}/resources/{index}/
+```
+
+其中 `openviking_user_id` 来自 `backend_config["openviking_user_id"]` 或 `DATABASE_OPENVIKING_USER_ID`，都未配置时使用 `default`。旧的 `backend_config["user_id"]` 仍作为兼容 alias 可用。如果传入 `target_uri` 或 `DATABASE_OPENVIKING_TARGET_URI`，则直接使用该目录。
+
+```python
+from veadk.knowledgebase import KnowledgeBase
+
+kb = KnowledgeBase(
+    backend="openviking",
+    app_name="company_faq",
+    backend_config={
+        "index": "company_faq",
+        "url": "http://127.0.0.1:1933",
+        "api_key": "your-openviking-api-key",
+        # 可选；不传时默认 default
+        "openviking_user_id": "team_a",
+        # 可选；不传时默认 viking://user/team_a/resources/company_faq/
+        # "target_uri": "viking://user/team_a/resources/company_faq/",
+    },
+)
+
+kb.add_from_directory("./docs")
+results = kb.search("远程办公政策是什么？")
 ```
 
 完整可运行示例（VikingDB 后端，配合一个日期差工具）：

--- a/docs/content/docs/framework/memory/long-term/index.en.mdx
+++ b/docs/content/docs/framework/memory/long-term/index.en.mdx
@@ -25,7 +25,7 @@ ltm = LongTermMemory(backend="viking", app_name="ltm_demo")
 
 | Parameter | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
-| `backend` | `"local" \| "opensearch" \| "redis" \| "viking" \| "mem0" \| "tos_context"` or a backend instance | `"opensearch"` | Selects the backend, or pass a `BaseLongTermMemoryBackend` instance directly. `viking_mem` is deprecated and maps to `viking`. |
+| `backend` | `"local" \| "opensearch" \| "redis" \| "viking" \| "mem0" \| "openviking" \| "tos_context"` or a backend instance | `"opensearch"` | Selects the backend, or pass a `BaseLongTermMemoryBackend` instance directly. `viking_mem` is deprecated and maps to `viking`. |
 | `backend_config` | `dict` | `{}` | Config passed to the backend constructor; if it lacks `index`, it's filled from `index` or `app_name`. |
 | `top_k` | `int` | `5` | Number of most-similar chunks to retrieve. |
 | `index` | `str` | `""` | Index/collection name for storing memories. Falls back to `app_name`, then `default_app`. |
@@ -33,7 +33,7 @@ ltm = LongTermMemory(backend="viking", app_name="ltm_demo")
 | `user_id` | `str` | `""` | **Deprecated**, kept only for backward compatibility. |
 
 <Callout type="info">
-Vector backends (`local`, `opensearch`, `redis`) embed memories, which requires `pip install "veadk-python[extensions]"` and an embedding model (env prefix `MODEL_EMBEDDING_`, falling back to `MODEL_AGENT_API_KEY`). `viking`, `mem0`, and `tos_context` are managed services and need no local embedding.
+Vector backends (`local`, `opensearch`, `redis`) embed memories, which requires `pip install "veadk-python[extensions]"` and an embedding model (env prefix `MODEL_EMBEDDING_`, falling back to `MODEL_AGENT_API_KEY`). `viking`, `mem0`, `openviking`, and `tos_context` are managed services and need no local embedding.
 </Callout>
 
 ## Backend contract: `BaseLongTermMemoryBackend`
@@ -68,9 +68,45 @@ Use `local` for debugging; prefer `viking` or `mem0` in production.
 | `local` | In-memory vector index | `extensions` + embedding | Local debugging | [In-memory](/en/docs/framework/memory/long-term/local) |
 | `viking` | VikingDB memory (managed) | Volcengine account | Recommended for production | [VikingDB](/en/docs/framework/memory/long-term/vikingdb) |
 | `mem0` | Mem0 memory (managed) | Mem0 API key | Recommended for production | [Mem0](/en/docs/framework/memory/long-term/mem0) |
+| `openviking` | OpenViking memory (managed or self-hosted OpenViking service) | OpenViking URL and API key | OpenViking unified resources and memory | [Environment variables](/en/docs/references/configuration/environment-variables#database) |
 | `opensearch` | OpenSearch vector store | OpenSearch + embedding | Self-hosted vector search | [OpenSearch](/en/docs/framework/memory/long-term/opensearch) |
 | `redis` | Redis vector store | Redis (RediSearch) + embedding | Self-hosted vector search | [Redis](/en/docs/framework/memory/long-term/redis) |
 | `tos_context` | TOS ContextBucket (managed) | Volcengine account (AK/SK; temporary credentials also need `VOLCENGINE_SESSION_TOKEN`) + `tos>=2.9.4b1` | Server-side inference/retrieval, per-user isolation | [TOS ContextBucket](/en/docs/framework/memory/long-term/tos-context#configuration) |
+
+### OpenViking configuration example
+
+The `openviking` backend writes conversations to OpenViking sessions and lets OpenViking extract long-term memories. `Runner.user_id` is used as the OpenViking `peer_id`; `DATABASE_OPENVIKING_USER_ID` or `backend_config["openviking_user_id"]` identifies the OpenViking memory owner/context and defaults to `default` when omitted.
+
+```bash
+export DATABASE_OPENVIKING_URL="http://127.0.0.1:1933"
+export DATABASE_OPENVIKING_API_KEY="your-openviking-api-key"
+export DATABASE_OPENVIKING_USER_ID="agent_context"
+```
+
+```python
+from veadk.memory.long_term_memory import LongTermMemory
+
+ltm = LongTermMemory(
+    backend="openviking",
+    app_name="support_app",
+    backend_config={
+        # url/api_key can also come from DATABASE_OPENVIKING_URL/API_KEY.
+        "openviking_user_id": "agent_context",
+        # Optional: keep VeADK's default policy when omitted.
+        "memory_policy": {
+            "self": {"enabled": False},
+            "peer": {"enabled": True},
+            "memory_types": ["entities", "events", "preferences"],
+        },
+    },
+)
+```
+
+You can also override the memory policy with an environment variable. The value must be a JSON string:
+
+```bash
+export DATABASE_OPENVIKING_MEMORY_POLICY='{"self":{"enabled":false},"peer":{"enabled":true},"memory_types":["entities","events","preferences"]}'
+```
 
 ## Binding to an Agent
 

--- a/docs/content/docs/framework/memory/long-term/index.mdx
+++ b/docs/content/docs/framework/memory/long-term/index.mdx
@@ -25,7 +25,7 @@ ltm = LongTermMemory(backend="viking", app_name="ltm_demo")
 
 | 参数 | 类型 | 默认值 | 说明 |
 | :--- | :--- | :--- | :--- |
-| `backend` | `"local" \| "opensearch" \| "redis" \| "viking" \| "mem0" \| "tos_context"` 或后端实例 | `"opensearch"` | 选择后端实现，也可直接传入一个 `BaseLongTermMemoryBackend` 实例。`viking_mem` 已废弃，自动转为 `viking`。 |
+| `backend` | `"local" \| "opensearch" \| "redis" \| "viking" \| "mem0" \| "openviking" \| "tos_context"` 或后端实例 | `"opensearch"` | 选择后端实现，也可直接传入一个 `BaseLongTermMemoryBackend` 实例。`viking_mem` 已废弃，自动转为 `viking`。 |
 | `backend_config` | `dict` | `{}` | 传给后端构造函数的配置；若不含 `index`，会用 `index` 或 `app_name` 补齐。 |
 | `top_k` | `int` | `5` | 检索时返回最相似的片段数量。 |
 | `index` | `str` | `""` | 存储记忆所用的索引/集合名。为空时回退到 `app_name`，再为空则用 `default_app`。 |
@@ -33,7 +33,7 @@ ltm = LongTermMemory(backend="viking", app_name="ltm_demo")
 | `user_id` | `str` | `""` | **已废弃**，仅为向后兼容保留。 |
 
 <Callout type="info">
-向量类后端（`local`、`opensearch`、`redis`）会对记忆做向量化（embedding），需要安装扩展依赖：`pip install "veadk-python[extensions]"`，并配置 embedding 模型（环境变量前缀 `MODEL_EMBEDDING_`，缺省时复用 `MODEL_AGENT_API_KEY`）。`viking`、`mem0` 与 `tos_context` 是托管服务，无需本地 embedding。
+向量类后端（`local`、`opensearch`、`redis`）会对记忆做向量化（embedding），需要安装扩展依赖：`pip install "veadk-python[extensions]"`，并配置 embedding 模型（环境变量前缀 `MODEL_EMBEDDING_`，缺省时复用 `MODEL_AGENT_API_KEY`）。`viking`、`mem0`、`openviking` 与 `tos_context` 是托管服务，无需本地 embedding。
 </Callout>
 
 ## 后端契约：`BaseLongTermMemoryBackend`
@@ -68,9 +68,45 @@ class BaseLongTermMemoryBackend(ABC, BaseModel):
 | `local` | 内存向量索引 | `extensions` + embedding | 本地调试 | [本地内存](/cn/docs/framework/memory/long-term/local) |
 | `viking` | VikingDB 记忆库（托管） | 火山引擎账号 | 生产推荐 | [VikingDB](/cn/docs/framework/memory/long-term/vikingdb) |
 | `mem0` | Mem0 记忆库（托管） | Mem0 API Key | 生产推荐 | [Mem0](/cn/docs/framework/memory/long-term/mem0) |
+| `openviking` | OpenViking memory（托管/自建 OpenViking 服务） | OpenViking URL 与 API Key | OpenViking 统一资源与记忆场景 | [环境变量](/cn/docs/references/configuration/environment-variables#database) |
 | `opensearch` | OpenSearch 向量库 | OpenSearch + embedding | 自建向量检索 | [OpenSearch](/cn/docs/framework/memory/long-term/opensearch) |
 | `redis` | Redis 向量库 | Redis(RediSearch) + embedding | 自建向量检索 | [Redis](/cn/docs/framework/memory/long-term/redis) |
 | `tos_context` | TOS ContextBucket（托管） | 火山引擎账号（AK/SK，临时凭证另需 `VOLCENGINE_SESSION_TOKEN`）+ `tos>=2.9.4b1` | 服务端推理与检索、按用户隔离 | [TOS ContextBucket](/cn/docs/framework/memory/long-term/tos-context#配置) |
+
+### OpenViking 配置示例
+
+`openviking` 后端会把会话写入 OpenViking session，再由 OpenViking 提取长期记忆。`Runner.user_id` 会作为 OpenViking 的 `peer_id` 使用；`DATABASE_OPENVIKING_USER_ID` 或 `backend_config["openviking_user_id"]` 表示 OpenViking 里的记忆 owner/context，未配置时使用 `default`。
+
+```bash
+export DATABASE_OPENVIKING_URL="http://127.0.0.1:1933"
+export DATABASE_OPENVIKING_API_KEY="your-openviking-api-key"
+export DATABASE_OPENVIKING_USER_ID="agent_context"
+```
+
+```python
+from veadk.memory.long_term_memory import LongTermMemory
+
+ltm = LongTermMemory(
+    backend="openviking",
+    app_name="support_app",
+    backend_config={
+        # url/api_key 也可以通过 DATABASE_OPENVIKING_URL/API_KEY 提供。
+        "openviking_user_id": "agent_context",
+        # 可选：不传时保持 VeADK 默认 policy。
+        "memory_policy": {
+            "self": {"enabled": False},
+            "peer": {"enabled": True},
+            "memory_types": ["entities", "events", "preferences"],
+        },
+    },
+)
+```
+
+也可以用环境变量覆盖 memory policy，值必须是 JSON 字符串：
+
+```bash
+export DATABASE_OPENVIKING_MEMORY_POLICY='{"self":{"enabled":false},"peer":{"enabled":true},"memory_types":["entities","events","preferences"]}'
+```
 
 ## 绑定到 Agent
 

--- a/docs/content/docs/references/configuration/environment-variables.en.mdx
+++ b/docs/content/docs/references/configuration/environment-variables.en.mdx
@@ -115,10 +115,12 @@ Prefix `DATABASE_`, grouped by storage type. Memory and the knowledge base read 
 | | `DATABASE_TOS_BUCKET` | Bucket name |
 | OpenViking | `DATABASE_OPENVIKING_URL` | OpenViking HTTP server URL |
 | | `DATABASE_OPENVIKING_API_KEY` | OpenViking service owner API key |
+| | `DATABASE_OPENVIKING_USER_ID` | OpenViking owner/context ID, default `default`; maps to `backend_config["openviking_user_id"]`, used for the knowledge directory when `target_uri` is not configured and as the long-term memory owner/context |
+| | `DATABASE_OPENVIKING_MEMORY_POLICY` | Long-term memory `memory_policy` JSON; uses the default policy when unset |
 | | `DATABASE_OPENVIKING_ACCOUNT` | Optional account for multi-tenant or trusted gateway setups |
 | | `DATABASE_OPENVIKING_USER` | Optional user for multi-tenant or trusted gateway setups |
 | | `DATABASE_OPENVIKING_ACTOR_PEER_ID` | Optional caller agent or peer identifier |
-| | `DATABASE_OPENVIKING_TARGET_URI` | Knowledge resource directory, default `viking://resources/{index}/` |
+| | `DATABASE_OPENVIKING_TARGET_URI` | Knowledge resource directory; defaults to `viking://user/{openviking_user_id or default}/resources/{index}/` when unset |
 | | `DATABASE_OPENVIKING_WAIT` | Wait for resource parsing and indexing on import, default `true` |
 | | `DATABASE_OPENVIKING_IMPORT_TIMEOUT` | Import wait timeout in seconds, default `300` |
 | | `DATABASE_OPENVIKING_HYDRATE_RESULTS` | Read full content or overview after search hits, default `true` |
@@ -144,8 +146,10 @@ database:
   openviking:
     url: http://127.0.0.1:1933
     api_key: your-openviking-api-key
+    # user_id: default
+    # memory_policy: '{"self":{"enabled":false},"peer":{"enabled":true},"memory_types":["entities","events","preferences"]}'
     # Optional for KnowledgeBase(backend="openviking"):
-    # target_uri: viking://resources/my_app/
+    # target_uri: viking://user/default/resources/my_app/
     # wait: true
     # import_timeout: 300
     # hydrate_results: true
@@ -153,6 +157,16 @@ database:
     # score_threshold: 0.3
     # use_context_search: false
 ```
+
+`KnowledgeBase(backend="openviking")` first uses an explicit `target_uri`; when it
+is unset, VeADK uses
+`viking://user/{openviking_user_id or default}/resources/{index}/`, where
+`openviking_user_id` comes from `backend_config["openviking_user_id"]` or
+`DATABASE_OPENVIKING_USER_ID`. If `backend_config` is omitted, `index` comes from
+`KnowledgeBase(index=...)` or `app_name`; if `backend_config` is provided, include
+`index` in that dictionary. For
+`LongTermMemory(backend="openviking")`, omitting `memory_policy` keeps VeADK's
+default policy; provide valid JSON only when you want to override it.
 
 ## Observability
 

--- a/docs/content/docs/references/configuration/environment-variables.mdx
+++ b/docs/content/docs/references/configuration/environment-variables.mdx
@@ -115,10 +115,12 @@ volcengine:
 | | `DATABASE_TOS_BUCKET` | 桶名称 |
 | OpenViking | `DATABASE_OPENVIKING_URL` | OpenViking HTTP 服务地址 |
 | | `DATABASE_OPENVIKING_API_KEY` | OpenViking service owner API Key |
+| | `DATABASE_OPENVIKING_USER_ID` | OpenViking owner/context 标识，默认 `default`；对应 `backend_config["openviking_user_id"]`，未配置 `target_uri` 时用于知识库目录，也用于长期记忆 owner/context |
+| | `DATABASE_OPENVIKING_MEMORY_POLICY` | 长期记忆 `memory_policy` JSON；未配置时使用默认 policy |
 | | `DATABASE_OPENVIKING_ACCOUNT` | 多租户或 trusted gateway 场景使用（可选） |
 | | `DATABASE_OPENVIKING_USER` | 多租户或 trusted gateway 场景使用（可选） |
 | | `DATABASE_OPENVIKING_ACTOR_PEER_ID` | 调用方 agent 或 peer 标识（可选） |
-| | `DATABASE_OPENVIKING_TARGET_URI` | 知识库资源目录，默认 `viking://resources/{index}/` |
+| | `DATABASE_OPENVIKING_TARGET_URI` | 知识库资源目录；未配置时使用 `viking://user/{openviking_user_id or default}/resources/{index}/` |
 | | `DATABASE_OPENVIKING_WAIT` | 导入资源时是否等待解析与索引，默认 `true` |
 | | `DATABASE_OPENVIKING_IMPORT_TIMEOUT` | 导入等待超时时间，单位秒，默认 `300` |
 | | `DATABASE_OPENVIKING_HYDRATE_RESULTS` | 搜索命中后是否读取正文或概览，默认 `true` |
@@ -144,8 +146,10 @@ database:
   openviking:
     url: http://127.0.0.1:1933
     api_key: your-openviking-api-key
+    # user_id: default
+    # memory_policy: '{"self":{"enabled":false},"peer":{"enabled":true},"memory_types":["entities","events","preferences"]}'
     # Optional for KnowledgeBase(backend="openviking"):
-    # target_uri: viking://resources/my_app/
+    # target_uri: viking://user/default/resources/my_app/
     # wait: true
     # import_timeout: 300
     # hydrate_results: true
@@ -153,6 +157,14 @@ database:
     # score_threshold: 0.3
     # use_context_search: false
 ```
+
+`KnowledgeBase(backend="openviking")` 会优先使用显式配置的 `target_uri`；未配置时使用
+`viking://user/{openviking_user_id or default}/resources/{index}/`，其中
+`openviking_user_id` 来自 `backend_config["openviking_user_id"]` 或
+`DATABASE_OPENVIKING_USER_ID`。如果未传 `backend_config`，`index` 来自
+`KnowledgeBase(index=...)` 或 `app_name`；如果传了 `backend_config`，请在该字典内提供
+`index`。`LongTermMemory(backend="openviking")` 的
+`memory_policy` 未配置时保持 VeADK 默认 policy；如需覆盖，请传入合法 JSON。
 
 ## 可观测
 

--- a/examples/05_knowledgebase_rag/.env.example
+++ b/examples/05_knowledgebase_rag/.env.example
@@ -33,7 +33,12 @@ MODEL_EMBEDDING_API_KEY=your-ark-api-key-here
 # MODEL_EMBEDDING_* is not required for this backend.
 # DATABASE_OPENVIKING_URL=http://127.0.0.1:1933
 # DATABASE_OPENVIKING_API_KEY=your-openviking-api-key-here
-# DATABASE_OPENVIKING_TARGET_URI=viking://resources/company_faq/
+# DATABASE_OPENVIKING_USER_ID=team_a
+# When unset, target_uri defaults to:
+# viking://user/{DATABASE_OPENVIKING_USER_ID or default}/resources/{index}/
+# DATABASE_OPENVIKING_TARGET_URI is a full OpenViking resource URI. When set,
+# VeADK uses it directly and does not join it with USER_ID or index.
+# DATABASE_OPENVIKING_TARGET_URI=viking://user/team_a/resources/company_faq/
 # DATABASE_OPENVIKING_WAIT=true
 # DATABASE_OPENVIKING_IMPORT_TIMEOUT=300
 # DATABASE_OPENVIKING_HYDRATE_RESULTS=true

--- a/examples/05_knowledgebase_rag/README.md
+++ b/examples/05_knowledgebase_rag/README.md
@@ -50,3 +50,28 @@ The answer about annual leave / remote work comes straight from
   production use.
 - Move on to [06 · Multi-agent workflow](../06_multi_agent/) to compose several
   agents.
+
+### OpenViking variant
+
+For OpenViking, set the service connection first:
+
+```bash
+export DATABASE_OPENVIKING_URL="http://127.0.0.1:1933"
+export DATABASE_OPENVIKING_API_KEY="your-openviking-api-key"
+# Optional. Defaults to default when omitted.
+export DATABASE_OPENVIKING_USER_ID="team_a"
+```
+
+Then switch the backend:
+
+```python
+knowledgebase = KnowledgeBase(
+    backend="openviking",
+    index="company_faq",
+)
+knowledgebase.add_from_directory("./docs")
+```
+
+Without `DATABASE_OPENVIKING_TARGET_URI`, the resources are scoped to
+`viking://user/{openviking_user_id or default}/resources/company_faq/`. Set
+`DATABASE_OPENVIKING_TARGET_URI` only when you want to pin a different directory.

--- a/examples/05_knowledgebase_rag/README.zh.md
+++ b/examples/05_knowledgebase_rag/README.zh.md
@@ -45,3 +45,28 @@ python main.py
 - 将 `backend="local"` 替换为持久化存储（如 `openviking`、`milvus`、`viking`、
   `opensearch`、`redis`，在 `.env` 或 `config.yaml` 中配置），用于生产环境。
 - 继续阅读 [06 · 多智能体工作流](../06_multi_agent/)，组合多个智能体。
+
+### OpenViking 变体
+
+使用 OpenViking 时，先配置服务连接：
+
+```bash
+export DATABASE_OPENVIKING_URL="http://127.0.0.1:1933"
+export DATABASE_OPENVIKING_API_KEY="your-openviking-api-key"
+# 可选；不配置时默认 default。
+export DATABASE_OPENVIKING_USER_ID="team_a"
+```
+
+然后切换后端：
+
+```python
+knowledgebase = KnowledgeBase(
+    backend="openviking",
+    index="company_faq",
+)
+knowledgebase.add_from_directory("./docs")
+```
+
+未配置 `DATABASE_OPENVIKING_TARGET_URI` 时，资源默认隔离在
+`viking://user/{openviking_user_id or default}/resources/company_faq/`。只有需要固定到其他目录时，才设置
+`DATABASE_OPENVIKING_TARGET_URI`。

--- a/examples/09_long_term_memory/.env.example
+++ b/examples/09_long_term_memory/.env.example
@@ -20,3 +20,6 @@ MODEL_EMBEDDING_API_KEY=your-ark-api-key-here
 # retrieval remotely, so MODEL_EMBEDDING_* is not required for this backend.
 # DATABASE_OPENVIKING_URL=http://127.0.0.1:1933
 # DATABASE_OPENVIKING_API_KEY=your-openviking-api-key-here
+# DATABASE_OPENVIKING_USER_ID=agent_context
+# Optional. Omit this to keep VeADK's default OpenViking policy.
+# DATABASE_OPENVIKING_MEMORY_POLICY={"self":{"enabled":false},"peer":{"enabled":true},"memory_types":["entities","events","preferences"]}

--- a/examples/09_long_term_memory/README.md
+++ b/examples/09_long_term_memory/README.md
@@ -51,3 +51,34 @@ preference from session #1.
   in-session kind.
 - Swap `backend="local"` for a persistent store (`openviking`, `viking`,
   `redis`, `opensearch`, `mem0`) so memories survive process restarts.
+
+### OpenViking variant
+
+For OpenViking, configure the service connection and the owner/context ID:
+
+```bash
+export DATABASE_OPENVIKING_URL="http://127.0.0.1:1933"
+export DATABASE_OPENVIKING_API_KEY="your-openviking-api-key"
+export DATABASE_OPENVIKING_USER_ID="agent_context"
+```
+
+Then switch the backend:
+
+```python
+long_term_memory = LongTermMemory(
+    backend="openviking",
+    app_name="ltm_demo",
+    backend_config={
+        # Optional. If omitted, VeADK keeps its default OpenViking policy.
+        "memory_policy": {
+            "self": {"enabled": False},
+            "peer": {"enabled": True},
+            "memory_types": ["entities", "events", "preferences"],
+        },
+    },
+)
+```
+
+`Runner.user_id` is still the end-user identifier and is sent to OpenViking as
+`peer_id`. `DATABASE_OPENVIKING_USER_ID` identifies the OpenViking memory
+owner/context and defaults to `default` when omitted.

--- a/examples/09_long_term_memory/README.zh.md
+++ b/examples/09_long_term_memory/README.zh.md
@@ -45,3 +45,34 @@ python main.py
 - 短期 vs 长期：会话内的记忆见 [03](../03_short_term_memory/)。
 - 把 `backend="local"` 换成持久化存储（`openviking`、`viking`、`redis`、
   `opensearch`、`mem0`），让记忆在进程重启后依然存在。
+
+### OpenViking 变体
+
+使用 OpenViking 时，先配置服务连接和 owner/context ID：
+
+```bash
+export DATABASE_OPENVIKING_URL="http://127.0.0.1:1933"
+export DATABASE_OPENVIKING_API_KEY="your-openviking-api-key"
+export DATABASE_OPENVIKING_USER_ID="agent_context"
+```
+
+然后切换后端：
+
+```python
+long_term_memory = LongTermMemory(
+    backend="openviking",
+    app_name="ltm_demo",
+    backend_config={
+        # 可选；不配置时保持 VeADK 默认 OpenViking policy。
+        "memory_policy": {
+            "self": {"enabled": False},
+            "peer": {"enabled": True},
+            "memory_types": ["entities", "events", "preferences"],
+        },
+    },
+)
+```
+
+`Runner.user_id` 仍表示最终用户，并会作为 OpenViking `peer_id` 传入。
+`DATABASE_OPENVIKING_USER_ID` 表示 OpenViking 里的记忆 owner/context，未配置时默认
+`default`。

--- a/examples/13_openviking/.env.example
+++ b/examples/13_openviking/.env.example
@@ -1,0 +1,35 @@
+# Copy this file to `.env` and fill in your keys.
+
+# --- Agent reasoning model (Volcengine Ark) ---
+# Get an API key at https://console.volcengine.com/ark
+MODEL_AGENT_PROVIDER=openai
+MODEL_AGENT_NAME=doubao-seed-1-6-250615
+MODEL_AGENT_API_BASE=https://ark.cn-beijing.volces.com/api/v3/
+MODEL_AGENT_API_KEY=your-ark-api-key-here
+
+# --- OpenViking service ---
+# OpenViking handles both knowledge indexing and long-term memory extraction
+# remotely, so MODEL_EMBEDDING_* is not required for this example.
+DATABASE_OPENVIKING_URL=http://127.0.0.1:1933
+DATABASE_OPENVIKING_API_KEY=your-openviking-api-key-here
+
+# Owner/context id used in viking://user/<user_id>/...
+# Keep this stable per agent/application context to isolate resources and memory.
+DATABASE_OPENVIKING_USER_ID=openviking_demo
+
+# --- Optional: knowledge base import/search tuning ---
+# When unset, the knowledge base defaults to:
+# viking://user/{DATABASE_OPENVIKING_USER_ID or default}/resources/{index}/
+# DATABASE_OPENVIKING_TARGET_URI is a full OpenViking resource URI. When set,
+# VeADK uses it directly and does not join it with USER_ID or index.
+# DATABASE_OPENVIKING_TARGET_URI=viking://user/openviking_demo/resources/company_faq/
+DATABASE_OPENVIKING_WAIT=true
+DATABASE_OPENVIKING_IMPORT_TIMEOUT=300
+DATABASE_OPENVIKING_HYDRATE_RESULTS=true
+DATABASE_OPENVIKING_READ_LIMIT=200
+# DATABASE_OPENVIKING_SCORE_THRESHOLD=
+DATABASE_OPENVIKING_USE_CONTEXT_SEARCH=false
+
+# --- Optional: long-term memory extraction policy ---
+# Omit this to keep VeADK's default OpenViking policy.
+# DATABASE_OPENVIKING_MEMORY_POLICY={"self":{"enabled":false},"peer":{"enabled":true},"memory_types":["entities","events","preferences"]}

--- a/examples/13_openviking/README.md
+++ b/examples/13_openviking/README.md
@@ -1,0 +1,202 @@
+# OpenViking Knowledge + Memory
+
+This example uses OpenViking for both VeADK knowledge base retrieval and
+long-term memory. OpenViking handles indexing and memory extraction remotely, so
+you do not need `MODEL_EMBEDDING_*` settings.
+
+> 中文版见 [README.zh.md](./README.zh.md)
+
+## Setup
+
+```bash
+cd examples/13_openviking
+cp .env.example .env
+```
+
+Fill in:
+
+```bash
+MODEL_AGENT_API_KEY=...
+DATABASE_OPENVIKING_URL=http://127.0.0.1:1933
+DATABASE_OPENVIKING_API_KEY=...
+DATABASE_OPENVIKING_USER_ID=openviking_demo
+```
+
+`DATABASE_OPENVIKING_USER_ID` is the OpenViking owner/context id used in
+`viking://user/<user_id>/...`. Keep it stable for one agent/application context
+so resources and memories stay isolated.
+
+## Run
+
+```bash
+python main.py
+```
+
+The script imports `docs/company_faq.md` into:
+
+```text
+viking://user/{DATABASE_OPENVIKING_USER_ID or default}/resources/company_faq/
+```
+
+Then it runs two sessions. Session 1 answers with the knowledge base and stores
+a user preference. Session 2 asks the agent to recall that preference via
+OpenViking long-term memory and answer another policy question.
+
+## Configuration patterns
+
+### Recommended: `.env` or `config.yaml`
+
+The example keeps OpenViking connection settings out of code:
+
+```python
+knowledgebase = KnowledgeBase(backend="openviking", index="company_faq")
+long_term_memory = LongTermMemory(backend="openviking", app_name=APP_NAME)
+```
+
+VeADK reads these settings from `.env`, system environment variables, or the
+equivalent `config.yaml` structure:
+
+```yaml
+database:
+  openviking:
+    url: http://127.0.0.1:1933
+    api_key: your-openviking-api-key
+    user_id: openviking_demo
+```
+
+This is the best default for deployment: secrets stay outside source code, and
+the same code can run against different OpenViking services or contexts.
+
+### `url` vs `target_uri`
+
+There is no `target_url` parameter. OpenViking uses two different concepts:
+
+- `url` / `DATABASE_OPENVIKING_URL`: the OpenViking HTTP service endpoint, such
+  as `http://127.0.0.1:1933`.
+- `target_uri` / `DATABASE_OPENVIKING_TARGET_URI`: the OpenViking resource
+  directory for the knowledge base, such as
+  `viking://user/openviking_demo/resources/company_faq/`.
+
+`url` is required for connecting to the service. `target_uri` is optional; when
+it is unset, VeADK generates the default resource directory from
+`openviking_user_id` and `index`.
+
+### URI construction rules
+
+For `KnowledgeBase(backend="openviking")`, VeADK chooses the knowledge resource
+directory like this:
+
+1. If `target_uri` or `DATABASE_OPENVIKING_TARGET_URI` is set, VeADK uses that
+   full OpenViking resource URI directly. It is not joined with
+   `openviking_user_id` or `index`.
+2. If `target_uri` is not set, VeADK builds:
+
+   ```text
+   viking://user/{openviking_user_id or default}/resources/{index}/
+   ```
+
+3. `openviking_user_id` is resolved from
+   `backend_config["openviking_user_id"]`, then the compatibility alias
+   `backend_config["user_id"]`, then `DATABASE_OPENVIKING_USER_ID`, then
+   `default`.
+4. `index` comes from `KnowledgeBase(index=...)` or `app_name` when
+   `backend_config` is omitted. When `backend_config` is provided, include
+   `backend_config["index"]`.
+5. If an explicit `target_uri` starts with `viking://` but does not end with
+   `/`, VeADK appends the trailing slash.
+
+Examples:
+
+```python
+KnowledgeBase(backend="openviking", index="company_faq")
+```
+
+with `DATABASE_OPENVIKING_USER_ID=team_a` uses:
+
+```text
+viking://user/team_a/resources/company_faq/
+```
+
+But:
+
+```python
+KnowledgeBase(
+    backend="openviking",
+    backend_config={
+        "index": "company_faq",
+        "target_uri": "viking://user/shared/resources/hr",
+    },
+)
+```
+
+uses exactly:
+
+```text
+viking://user/shared/resources/hr/
+```
+
+### Explicit `backend_config`
+
+Use `backend_config` when one process needs to talk to multiple OpenViking
+contexts, or when a test should override environment settings:
+
+```python
+knowledgebase = KnowledgeBase(
+    backend="openviking",
+    backend_config={
+        "index": "company_faq",
+        "url": "http://127.0.0.1:1933",
+        "api_key": "your-openviking-api-key",
+        "openviking_user_id": "openviking_demo",
+        # Optional. Use only when you want to pin an existing resource directory.
+        # "target_uri": "viking://user/openviking_demo/resources/company_faq/",
+    },
+)
+
+long_term_memory = LongTermMemory(
+    backend="openviking",
+    app_name=APP_NAME,
+    backend_config={
+        "openviking_user_id": "openviking_demo",
+    },
+)
+```
+
+When `KnowledgeBase.backend_config` is provided, include `index` in that
+dictionary. Without `backend_config`, `index` can come from
+`KnowledgeBase(index=...)` or `app_name`.
+
+### What each id changes
+
+- `DATABASE_OPENVIKING_USER_ID` / `openviking_user_id` is the OpenViking
+  owner/context id. It scopes both the default knowledge directory and
+  long-term memory namespace.
+- `Runner.user_id` is the end-user id. The OpenViking long-term-memory backend
+  sends it as `peer_id`, so different end users get separate memories under the
+  same owner/context.
+- `KnowledgeBase.index` names the default resource directory.
+
+Without `DATABASE_OPENVIKING_TARGET_URI`, knowledge resources go to:
+
+```text
+viking://user/{openviking_user_id or default}/resources/{index}/
+```
+
+Set `DATABASE_OPENVIKING_TARGET_URI` only when you want to use an existing or
+custom OpenViking resource directory. When it is set, VeADK uses that directory
+directly instead of generating one from `openviking_user_id` and `index`.
+
+### Memory policy
+
+You usually do not need to configure `DATABASE_OPENVIKING_MEMORY_POLICY`. Omit it
+to keep VeADK's default policy. Set it only when you want to change how
+OpenViking extracts self/peer memories or which memory types it stores.
+
+## Notes
+
+- Re-running the example imports the local docs again. For production, import
+  knowledge documents as part of setup or CI instead of every request path.
+- Set `DATABASE_OPENVIKING_TARGET_URI` only when you want to pin the knowledge
+  base to a custom resource directory.
+- Omit `DATABASE_OPENVIKING_MEMORY_POLICY` to keep VeADK's default OpenViking
+  memory policy.

--- a/examples/13_openviking/README.zh.md
+++ b/examples/13_openviking/README.zh.md
@@ -1,0 +1,186 @@
+# OpenViking 知识库 + 长期记忆
+
+这个示例同时使用 OpenViking 做 VeADK 知识库检索和长期记忆。OpenViking 会在远端完成
+索引与记忆抽取，因此不需要配置 `MODEL_EMBEDDING_*`。
+
+> English version: [README.md](./README.md)
+
+## 准备
+
+```bash
+cd examples/13_openviking
+cp .env.example .env
+```
+
+填入：
+
+```bash
+MODEL_AGENT_API_KEY=...
+DATABASE_OPENVIKING_URL=http://127.0.0.1:1933
+DATABASE_OPENVIKING_API_KEY=...
+DATABASE_OPENVIKING_USER_ID=openviking_demo
+```
+
+`DATABASE_OPENVIKING_USER_ID` 是 OpenViking 中的 owner/context 标识，用在
+`viking://user/<user_id>/...` 路径里。建议每个 agent/application context 保持稳定，
+从而隔离资源和记忆。
+
+## 运行
+
+```bash
+python main.py
+```
+
+脚本会把 `docs/company_faq.md` 导入到：
+
+```text
+viking://user/{DATABASE_OPENVIKING_USER_ID or default}/resources/company_faq/
+```
+
+随后运行两轮会话。第一轮用知识库回答问题，并保存用户偏好；第二轮让智能体通过
+OpenViking 长期记忆回忆该偏好，同时回答另一个制度问题。
+
+## 配置方式
+
+### 推荐：使用 `.env` 或 `config.yaml`
+
+本示例把 OpenViking 连接信息放在代码外：
+
+```python
+knowledgebase = KnowledgeBase(backend="openviking", index="company_faq")
+long_term_memory = LongTermMemory(backend="openviking", app_name=APP_NAME)
+```
+
+VeADK 会从 `.env`、系统环境变量，或等价的 `config.yaml` 结构读取配置：
+
+```yaml
+database:
+  openviking:
+    url: http://127.0.0.1:1933
+    api_key: your-openviking-api-key
+    user_id: openviking_demo
+```
+
+这是部署时的推荐方式：密钥不进入源码，同一份代码也可以切换到不同的 OpenViking
+服务或 owner/context。
+
+### `url` 与 `target_uri`
+
+没有 `target_url` 这个参数。OpenViking 里这里涉及两个不同概念：
+
+- `url` / `DATABASE_OPENVIKING_URL`：OpenViking HTTP 服务地址，例如
+  `http://127.0.0.1:1933`。
+- `target_uri` / `DATABASE_OPENVIKING_TARGET_URI`：知识库使用的 OpenViking
+  资源目录，例如 `viking://user/openviking_demo/resources/company_faq/`。
+
+`url` 用于连接服务，是必需配置。`target_uri` 是可选配置；未设置时，VeADK 会根据
+`openviking_user_id` 和 `index` 生成默认资源目录。
+
+### URI 拼接规则
+
+对于 `KnowledgeBase(backend="openviking")`，VeADK 会按以下规则选择知识资源目录：
+
+1. 如果设置了 `target_uri` 或 `DATABASE_OPENVIKING_TARGET_URI`，VeADK 会直接使用这个
+   完整的 OpenViking resource URI，不会再和 `openviking_user_id` 或 `index` 拼接。
+2. 如果没有设置 `target_uri`，VeADK 会生成：
+
+   ```text
+   viking://user/{openviking_user_id or default}/resources/{index}/
+   ```
+
+3. `openviking_user_id` 的解析顺序是
+   `backend_config["openviking_user_id"]`、兼容 alias `backend_config["user_id"]`、
+   `DATABASE_OPENVIKING_USER_ID`、最后是 `default`。
+4. 不传 `backend_config` 时，`index` 来自 `KnowledgeBase(index=...)` 或 `app_name`；
+   一旦传入 `backend_config`，请把 `index` 写在 `backend_config["index"]`。
+5. 显式 `target_uri` 如果以 `viking://` 开头但没有 `/` 结尾，VeADK 会自动补尾部 `/`。
+
+例如：
+
+```python
+KnowledgeBase(backend="openviking", index="company_faq")
+```
+
+配合 `DATABASE_OPENVIKING_USER_ID=team_a` 会使用：
+
+```text
+viking://user/team_a/resources/company_faq/
+```
+
+但如果写成：
+
+```python
+KnowledgeBase(
+    backend="openviking",
+    backend_config={
+        "index": "company_faq",
+        "target_uri": "viking://user/shared/resources/hr",
+    },
+)
+```
+
+则会直接使用：
+
+```text
+viking://user/shared/resources/hr/
+```
+
+### 显式传入 `backend_config`
+
+当一个进程需要连接多个 OpenViking context，或测试时需要覆盖环境配置，可以使用
+`backend_config`：
+
+```python
+knowledgebase = KnowledgeBase(
+    backend="openviking",
+    backend_config={
+        "index": "company_faq",
+        "url": "http://127.0.0.1:1933",
+        "api_key": "your-openviking-api-key",
+        "openviking_user_id": "openviking_demo",
+        # 可选。只有需要固定到已有资源目录时才设置。
+        # "target_uri": "viking://user/openviking_demo/resources/company_faq/",
+    },
+)
+
+long_term_memory = LongTermMemory(
+    backend="openviking",
+    app_name=APP_NAME,
+    backend_config={
+        "openviking_user_id": "openviking_demo",
+    },
+)
+```
+
+如果传入 `KnowledgeBase.backend_config`，请把 `index` 也放在这个字典里。不传
+`backend_config` 时，`index` 可以来自 `KnowledgeBase(index=...)` 或 `app_name`。
+
+### 各个 id 的影响
+
+- `DATABASE_OPENVIKING_USER_ID` / `openviking_user_id` 是 OpenViking 的
+  owner/context 标识，会影响默认知识库目录和长期记忆命名空间。
+- `Runner.user_id` 是最终用户标识。OpenViking 长期记忆后端会把它作为 `peer_id`
+  传入，因此同一个 owner/context 下，不同最终用户的记忆会隔离。
+- `KnowledgeBase.index` 用来命名默认资源目录。
+
+不设置 `DATABASE_OPENVIKING_TARGET_URI` 时，知识资源会进入：
+
+```text
+viking://user/{openviking_user_id or default}/resources/{index}/
+```
+
+只有需要使用已有目录或自定义 OpenViking 资源目录时，才设置
+`DATABASE_OPENVIKING_TARGET_URI`。一旦设置，VeADK 会直接使用该目录，而不是再根据
+`openviking_user_id` 和 `index` 生成默认目录。
+
+### Memory policy
+
+通常不需要配置 `DATABASE_OPENVIKING_MEMORY_POLICY`。不配置时会使用 VeADK 默认策略。
+只有想改变 OpenViking 如何抽取 self/peer 记忆，或调整存储的 memory types 时才需要设置。
+
+## 说明
+
+- 重复运行示例会再次导入本地文档。生产环境建议把知识导入放在初始化或 CI 流程中，
+  不要放在每次请求路径上。
+- 只有需要固定到自定义知识库目录时，才设置 `DATABASE_OPENVIKING_TARGET_URI`。
+- 不配置 `DATABASE_OPENVIKING_MEMORY_POLICY` 时，会使用 VeADK 默认的 OpenViking 记忆策略。

--- a/examples/13_openviking/docs/company_faq.md
+++ b/examples/13_openviking/docs/company_faq.md
@@ -1,0 +1,18 @@
+# Company FAQ
+
+## Annual Leave
+
+Full-time employees receive 15 days of paid annual leave each calendar year.
+Requests should be submitted at least five business days in advance. Managers
+approve requests based on team coverage.
+
+## Remote Work
+
+Employees may work remotely up to three days per week. Remote work should be
+registered in the attendance system before 10:00 each workday.
+
+## Reimbursements
+
+Travel and office-supply reimbursements must be submitted within 30 days. Attach
+receipts and select the correct project code before sending the request for
+approval.

--- a/examples/13_openviking/main.py
+++ b/examples/13_openviking/main.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Use OpenViking for both knowledge base RAG and long-term memory.
+
+This example imports local Markdown docs into an OpenViking resource directory
+and stores cross-session memories in OpenViking. OpenViking handles indexing and
+memory extraction remotely, so no embedding model configuration is required.
+"""
+
+import asyncio
+from pathlib import Path
+
+from veadk import Agent, Runner
+from veadk.knowledgebase import KnowledgeBase
+from veadk.memory.long_term_memory import LongTermMemory
+
+APP_NAME = "openviking_demo"
+USER_ID = "user-42"
+DOCS_DIR = Path(__file__).parent / "docs"
+
+
+def build_knowledgebase() -> KnowledgeBase:
+    # Recommended: keep OpenViking connection settings in .env or config.yaml.
+    # This reads DATABASE_OPENVIKING_URL/API_KEY/USER_ID automatically.
+    knowledgebase = KnowledgeBase(
+        backend="openviking",
+        index="company_faq",
+    )
+    # Equivalent explicit override when one process needs multiple contexts:
+    #
+    # knowledgebase = KnowledgeBase(
+    #     backend="openviking",
+    #     backend_config={
+    #         "index": "company_faq",
+    #         "openviking_user_id": "openviking_demo",
+    #     },
+    # )
+    knowledgebase.add_from_directory(str(DOCS_DIR))
+    return knowledgebase
+
+
+def build_runner(knowledgebase: KnowledgeBase) -> Runner:
+    # LongTermMemory also reads DATABASE_OPENVIKING_URL/API_KEY/USER_ID.
+    long_term_memory = LongTermMemory(
+        backend="openviking",
+        app_name=APP_NAME,
+    )
+    agent = Agent(
+        name="openviking_agent",
+        description="Answers with OpenViking knowledge and memory.",
+        instruction=(
+            "Use the knowledge base for company policy questions. Use the "
+            "`load_memory` tool when the user asks about preferences or facts "
+            "shared in previous sessions."
+        ),
+        knowledgebase=knowledgebase,
+        long_term_memory=long_term_memory,
+        auto_save_session=True,
+    )
+    # Runner.user_id is the end-user id. OpenViking receives it as peer_id for
+    # memory isolation; it is different from DATABASE_OPENVIKING_USER_ID.
+    return Runner(agent=agent, app_name=APP_NAME, user_id=USER_ID)
+
+
+async def main() -> None:
+    knowledgebase = build_knowledgebase()
+    try:
+        runner = build_runner(knowledgebase)
+
+        print(
+            "Session 1 ->",
+            await runner.run(
+                messages=(
+                    "请先记住：我喜欢简短直接的回答。然后告诉我公司的远程办公政策。"
+                ),
+                session_id="session-1",
+            ),
+        )
+
+        print(
+            "Session 2 ->",
+            await runner.run(
+                messages="我之前说过我偏好什么回答风格？顺便说一下报销时限。",
+                session_id="session-2",
+            ),
+        )
+    finally:
+        knowledgebase.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,7 @@ and a bilingual README (English + 中文).
 | 09 | [Long-term memory](./09_long_term_memory/) | Complex | Recall facts across sessions (`auto_save_session`) |
 | 10 | [Agent routing](./10_agent_routing/) | Complex | A coordinator that delegates to specialists dynamically |
 | 11 | [Tracing](./11_tracing/) | Complex | Observe LLM/tool calls; dump or export spans |
+| 13 | [OpenViking](./13_openviking/) | Complex | Use OpenViking for knowledge retrieval and long-term memory |
 
 There are also frontend-focused demos that run with
 `veadk frontend --agents-dir examples`:
@@ -33,15 +34,16 @@ For a deployable **full app** (web UI + agent API in one container, shipped to
 Volcengine AgentKit via `veadk agentkit`), see [`basic-app/`](./basic-app/).
 
 The examples are grouped by concept: 01–02 basics, 03 & 09 memory, 04–05 tools &
-knowledge, 06 & 10 multi-agent, 07–08 model behavior, 11 observability.
+knowledge, 06 & 10 multi-agent, 07–08 model behavior, 11 observability, and 13
+OpenViking-backed knowledge and memory.
 
 ## Common setup
 
-1. Install VeADK (examples 05 needs the `extensions` extra):
+1. Install VeADK (example 05 with the local backend needs the `extensions` extra):
 
    ```bash
    pip install veadk-python
-   # for the RAG example:
+   # for example 05's local RAG backend:
    pip install "veadk-python[extensions]"
    ```
 

--- a/examples/README.zh.md
+++ b/examples/README.zh.md
@@ -20,6 +20,7 @@
 | 09 | [长期记忆](./09_long_term_memory/) | 复杂 | 跨会话回忆事实（`auto_save_session`） |
 | 10 | [智能体路由](./10_agent_routing/) | 复杂 | 协调者动态委派给专家智能体 |
 | 11 | [链路追踪](./11_tracing/) | 复杂 | 观测大模型/工具调用；导出 span |
+| 13 | [OpenViking](./13_openviking/) | 复杂 | 使用 OpenViking 做知识检索与长期记忆 |
 
 另外还有可通过 `veadk frontend --agents-dir examples` 运行的 frontend 示例：
 
@@ -31,15 +32,15 @@
 `veadk agentkit` 部署到火山引擎 AgentKit），参见 [`basic-app/`](./basic-app/)。
 
 这些示例按概念分组：01–02 基础，03 与 09 记忆，04–05 工具与知识，
-06 与 10 多智能体，07–08 模型行为，11 可观测性。
+06 与 10 多智能体，07–08 模型行为，11 可观测性，13 为 OpenViking 知识与记忆。
 
 ## 通用准备
 
-1. 安装 VeADK（示例 05 需要 `extensions` 扩展）：
+1. 安装 VeADK（示例 05 使用 local 后端时需要 `extensions` 扩展）：
 
    ```bash
    pip install veadk-python
-   # RAG 示例需要：
+   # 示例 05 的 local RAG 后端需要：
    pip install "veadk-python[extensions]"
    ```
 

--- a/tests/test_openviking_knowledgebase.py
+++ b/tests/test_openviking_knowledgebase.py
@@ -14,6 +14,9 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -45,6 +48,14 @@ class FakeOpenVikingClient:
         self.overview_response = "overview body"
         self.fail_read = False
         self.fail_overview = False
+        self.initialize_calls = 0
+        self.close_calls = 0
+
+    def initialize(self):
+        self.initialize_calls += 1
+
+    def close(self):
+        self.close_calls += 1
 
     def add_resource(self, **kwargs):
         self.add_resource_calls.append(kwargs)
@@ -79,16 +90,23 @@ class FakeOpenVikingClient:
 
 class FakeOpenVikingKnowledgeBackend(OpenVikingKnowledgeBackend):
     fake_client: ClassVar[FakeOpenVikingClient | None] = None
+    built_clients: ClassVar[list[FakeOpenVikingClient]] = []
 
     def _build_client(self):
-        return self.fake_client or FakeOpenVikingClient()
+        client = self.fake_client or FakeOpenVikingClient()
+        self.built_clients.append(client)
+        return client
 
 
 def make_backend(
     client: FakeOpenVikingClient | None = None,
+    default_openviking_user_id: str | None = "owner",
     **kwargs,
 ) -> FakeOpenVikingKnowledgeBackend:
     FakeOpenVikingKnowledgeBackend.fake_client = client
+    FakeOpenVikingKnowledgeBackend.built_clients = []
+    if default_openviking_user_id is not None:
+        kwargs.setdefault("openviking_user_id", default_openviking_user_id)
     try:
         return FakeOpenVikingKnowledgeBackend(**kwargs)
     finally:
@@ -103,11 +121,13 @@ def test_knowledgebase_openviking_instantiates():
             "index": "demo",
             "url": "http://127.0.0.1:1933",
             "api_key": "test-key",
+            "openviking_user_id": "owner",
         },
     )
 
     assert isinstance(kb._backend, OpenVikingKnowledgeBackend)
-    assert kb._backend.target_uri == "viking://resources/demo/"
+    assert kb._backend.openviking_user_id == "owner"
+    assert kb._backend.target_uri == "viking://user/owner/resources/demo/"
 
 
 def test_missing_index_and_app_name_keeps_existing_error():
@@ -115,10 +135,203 @@ def test_missing_index_and_app_name_keeps_existing_error():
         KnowledgeBase(backend="openviking")
 
 
-def test_default_target_uri_from_index():
-    backend = make_backend(index="demo")
+def test_backend_config_requires_its_own_index_even_with_app_name():
+    with pytest.raises(Exception, match="index|Field required"):
+        KnowledgeBase(
+            backend="openviking",
+            app_name="demo",
+            backend_config={
+                "url": "http://127.0.0.1:1933",
+                "api_key": "test-key",
+                "openviking_user_id": "owner",
+            },
+        )
 
-    assert backend.target_uri == "viking://resources/demo/"
+
+def test_default_target_uri_from_openviking_user_id_and_index():
+    backend = make_backend(index="demo", openviking_user_id="alice")
+
+    assert backend.openviking_user_id == "alice"
+    assert backend.target_uri == "viking://user/alice/resources/demo/"
+
+
+def test_legacy_user_id_still_sets_default_target_uri():
+    backend = make_backend(
+        index="demo",
+        user_id="legacy_owner",
+        default_openviking_user_id=None,
+    )
+
+    assert backend.openviking_user_id == "legacy_owner"
+    assert backend.user_id == "legacy_owner"
+    assert backend.target_uri == "viking://user/legacy_owner/resources/demo/"
+
+
+def test_explicit_target_uri_is_used_without_openviking_user_id():
+    backend = make_backend(
+        index="demo",
+        target_uri="viking://resources/shared",
+        openviking_user_id=None,
+    )
+
+    assert backend.target_uri == "viking://resources/shared/"
+
+
+def test_missing_openviking_user_id_without_target_uri_defaults_to_default(monkeypatch):
+    monkeypatch.delenv("DATABASE_OPENVIKING_USER_ID", raising=False)
+    monkeypatch.delenv("OPENVIKING_USER_ID", raising=False)
+    backend = make_backend(index="demo", default_openviking_user_id=None)
+
+    assert backend.openviking_user_id == "default"
+    assert backend.user_id == "default"
+    assert backend.target_uri == "viking://user/default/resources/demo/"
+
+
+def test_default_target_uri_reads_openviking_user_id_from_env(monkeypatch):
+    monkeypatch.setenv("DATABASE_OPENVIKING_USER_ID", "env_owner")
+
+    backend = make_backend(index="demo", default_openviking_user_id=None)
+
+    assert backend.openviking_user_id == "env_owner"
+    assert backend.target_uri == "viking://user/env_owner/resources/demo/"
+
+
+def test_openviking_backend_close_releases_client():
+    client = FakeOpenVikingClient()
+    backend = make_backend(client, index="demo")
+
+    assert client.initialize_calls == 1
+
+    backend.close()
+
+    assert client.close_calls == 1
+    assert backend._client is None
+
+    backend.close()
+
+    assert client.close_calls == 1
+
+
+def test_openviking_backend_reconnects_after_close():
+    first_client = FakeOpenVikingClient()
+    backend = make_backend(first_client, index="demo")
+
+    backend.close()
+    entries = backend.search("policy")
+
+    assert entries == []
+    assert first_client.close_calls == 1
+    assert len(FakeOpenVikingKnowledgeBackend.built_clients) == 2
+    second_client = FakeOpenVikingKnowledgeBackend.built_clients[1]
+    assert second_client.initialize_calls == 1
+    assert second_client.find_calls[0]["query"] == "policy"
+    assert backend._client is second_client
+
+
+def test_knowledgebase_close_forwards_to_backend():
+    client = FakeOpenVikingClient()
+    backend = make_backend(client, index="demo")
+    kb = KnowledgeBase(backend=backend)
+
+    kb.close()
+
+    assert client.close_calls == 1
+    assert backend._client is None
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("openviking_user_id", "team/a"),
+        ("openviking_user_id", "team:alpha"),
+        ("openviking_user_id", "team alpha"),
+        ("openviking_user_id", "."),
+        ("openviking_user_id", ".."),
+        ("index", "docs/faq"),
+        ("index", "../faq"),
+        ("index", "docs:faq"),
+        ("index", "docs faq"),
+    ],
+)
+def test_default_target_uri_rejects_unsafe_path_segments(field, value):
+    kwargs = {"index": "demo", "openviking_user_id": "owner"}
+    kwargs[field] = value
+
+    with pytest.raises(Exception, match="safe single path segment"):
+        make_backend(**kwargs)
+
+
+def test_openviking_backends_load_config_yaml(tmp_path):
+    (tmp_path / "config.yaml").write_text(
+        """database:
+  openviking:
+    url: http://config-yaml.example
+    api_key: config-key
+    user_id: config-owner
+""",
+        encoding="utf-8",
+    )
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    for name in [
+        "DATABASE_OPENVIKING_URL",
+        "DATABASE_OPENVIKING_API_KEY",
+        "DATABASE_OPENVIKING_USER_ID",
+        "DATABASE_OPENVIKING_TARGET_URI",
+        "OPENVIKING_URL",
+        "OPENVIKING_API_KEY",
+        "OPENVIKING_USER_ID",
+        "OPENVIKING_TARGET_URI",
+    ]:
+        env.pop(name, None)
+    env["PYTHONPATH"] = (
+        str(repo_root)
+        if not env.get("PYTHONPATH")
+        else f"{repo_root}{os.pathsep}{env['PYTHONPATH']}"
+    )
+    scripts = [
+        (
+            "knowledgebase",
+            """
+from veadk.knowledgebase.backends.openviking_backend import OpenVikingKnowledgeBackend
+
+
+class FakeKnowledgeBackend(OpenVikingKnowledgeBackend):
+    def _build_client(self):
+        return object()
+
+
+kb = FakeKnowledgeBackend(index="faq")
+assert kb.url == "http://config-yaml.example"
+assert kb.api_key == "config-key"
+assert kb.openviking_user_id == "config-owner"
+assert kb.target_uri == "viking://user/config-owner/resources/faq/"
+""",
+        ),
+        (
+            "long_term_memory",
+            """
+from veadk.memory.long_term_memory_backends.openviking_backend import OpenVikingLTMBackend
+
+ltm = OpenVikingLTMBackend(index="support")
+assert ltm.url == "http://config-yaml.example"
+assert ltm.api_key == "config-key"
+assert ltm.openviking_user_id == "config-owner"
+""",
+        ),
+    ]
+
+    for name, script in scripts:
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, f"{name} failed: {result.stderr}"
 
 
 def test_add_from_files_imports_each_file_under_target_uri():
@@ -129,7 +342,7 @@ def test_add_from_files_imports_each_file_under_target_uri():
 
     assert [call["path"] for call in client.add_resource_calls] == ["a.md", "b.md"]
     assert all(
-        call["parent"] == "viking://resources/demo/"
+        call["parent"] == "viking://user/owner/resources/demo/"
         for call in client.add_resource_calls
     )
     assert all(call["wait"] is True for call in client.add_resource_calls)
@@ -145,7 +358,7 @@ def test_add_from_directory_imports_to_target_uri_with_structure():
     assert client.add_resource_calls == [
         {
             "path": "./docs",
-            "to": "viking://resources/demo/",
+            "to": "viking://user/owner/resources/demo/",
             "wait": True,
             "timeout": 300,
             "strict": False,
@@ -208,7 +421,7 @@ def test_search_converts_resources_to_entries_without_memories_or_skills():
         "context_type": "resource",
         "is_leaf": True,
     }
-    assert client.find_calls[0]["target_uri"] == "viking://resources/demo/"
+    assert client.find_calls[0]["target_uri"] == "viking://user/owner/resources/demo/"
     assert client.find_calls[0]["limit"] == 3
 
 

--- a/tests/test_openviking_long_term_memory.py
+++ b/tests/test_openviking_long_term_memory.py
@@ -213,6 +213,7 @@ def test_openviking_backend_writes_peer_messages_and_commits(monkeypatch):
         index="support_app",
         url="http://openviking.test",
         api_key="owner-key",
+        openviking_user_id="agent_scene",
     )
 
     assert backend.save_memory(
@@ -236,6 +237,7 @@ def test_openviking_backend_writes_peer_messages_and_commits(monkeypatch):
     assert openviking_session_id != "session_001"
     assert openviking_session_id.startswith("veadk__")
     assert "support_app" in openviking_session_id
+    assert "agent_scene" in openviking_session_id
     assert "alice" in openviking_session_id
     assert calls[0] == {
         "method": "create_session",
@@ -272,6 +274,7 @@ def test_openviking_backend_sdk_create_payload(monkeypatch):
         index="support_app",
         url="http://openviking.test",
         api_key="owner-key",
+        openviking_user_id="agent_scene",
     )
     client = backend._new_client()
 
@@ -293,12 +296,58 @@ def test_openviking_backend_sdk_create_payload(monkeypatch):
     ]
 
 
+def test_openviking_backend_uses_configured_memory_policy(monkeypatch):
+    calls = _install_fake_openviking_sdk(monkeypatch)
+    memory_policy = {
+        "self": {"enabled": True},
+        "peer": {"enabled": False},
+        "memory_types": ["events"],
+    }
+    backend = OpenVikingLTMBackend(
+        index="support_app",
+        url="http://openviking.test",
+        api_key="owner-key",
+        openviking_user_id="agent_scene",
+        memory_policy=memory_policy,
+    )
+    client = backend._new_client()
+
+    backend._create_session(client=client, session_id="sa1")
+
+    assert calls[0]["payload"]["memory_policy"] == memory_policy
+
+
+def test_openviking_backend_reads_memory_policy_from_env(monkeypatch):
+    calls = _install_fake_openviking_sdk(monkeypatch)
+    memory_policy = {
+        "self": {"enabled": False},
+        "peer": {"enabled": True},
+        "memory_types": ["entities"],
+    }
+    monkeypatch.setenv(
+        "DATABASE_OPENVIKING_MEMORY_POLICY",
+        json.dumps(memory_policy),
+    )
+    backend = OpenVikingLTMBackend(
+        index="support_app",
+        url="http://openviking.test",
+        api_key="owner-key",
+        openviking_user_id="agent_scene",
+    )
+    client = backend._new_client()
+
+    backend._create_session(client=client, session_id="sa1")
+
+    assert calls[0]["payload"]["memory_policy"] == memory_policy
+
+
 def test_openviking_backend_sdk_message_payload(monkeypatch):
     calls = _install_fake_openviking_sdk(monkeypatch)
     backend = OpenVikingLTMBackend(
         index="support_app",
         url="http://openviking.test",
         api_key="owner-key",
+        openviking_user_id="agent_scene",
     )
     client = backend._new_client()
 
@@ -333,6 +382,7 @@ def test_openviking_backend_search_uses_find_with_actor_peer(monkeypatch):
         index="support_app",
         url="http://openviking.test",
         api_key="owner-key",
+        openviking_user_id="agent_scene",
     )
 
     memories = backend.search_memory(
@@ -354,7 +404,7 @@ def test_openviking_backend_search_uses_find_with_actor_peer(monkeypatch):
         "actor_peer_id": "alice",
         "payload": {
             "query": "用户偏好",
-            "target_uri": "viking://user/peers/alice/memories",
+            "target_uri": "viking://user/agent_scene/peers/alice/memories",
             "context_type": "memory",
             "limit": 3,
         },
@@ -370,6 +420,7 @@ def test_openviking_backend_search_falls_back_to_find_without_session(monkeypatc
         index="support_app",
         url="http://openviking.test",
         api_key="owner-key",
+        openviking_user_id="default",
     )
 
     assert (
@@ -388,12 +439,64 @@ def test_openviking_backend_search_falls_back_to_find_without_session(monkeypatc
             "actor_peer_id": "alice",
             "payload": {
                 "query": "用户偏好",
-                "target_uri": "viking://user/peers/alice/memories",
+                "target_uri": "viking://user/default/peers/alice/memories",
                 "context_type": "memory",
                 "limit": 3,
             },
         }
     ]
+
+
+def test_openviking_backend_reads_openviking_user_id_from_env(monkeypatch):
+    calls = _install_fake_openviking_sdk(
+        monkeypatch,
+        responses={"find": {"memories": []}},
+    )
+    monkeypatch.setenv("DATABASE_OPENVIKING_USER_ID", "env_scene")
+    backend = OpenVikingLTMBackend(
+        index="support_app",
+        url="http://openviking.test",
+        api_key="owner-key",
+    )
+
+    backend.search_memory(
+        user_id="alice",
+        query="用户偏好",
+        top_k=3,
+        app_name="support_app",
+    )
+
+    assert backend.openviking_user_id == "env_scene"
+    assert calls[0]["payload"]["target_uri"] == (
+        "viking://user/env_scene/peers/alice/memories"
+    )
+
+
+def test_openviking_backend_defaults_openviking_user_id_with_warning(monkeypatch):
+    monkeypatch.delenv("DATABASE_OPENVIKING_USER_ID", raising=False)
+    warnings = []
+    monkeypatch.setattr(
+        "veadk.memory.long_term_memory_backends.openviking_backend.logger.warning",
+        warnings.append,
+    )
+
+    backend = OpenVikingLTMBackend(
+        index="support_app",
+        url="http://openviking.test",
+        api_key="owner-key",
+    )
+
+    assert backend.openviking_user_id == "default"
+    expected_warning = (
+        "OpenViking long-term memory `openviking_user_id` is not configured. "
+        "VeADK `user_id` identifies the current requester and is used as "
+        "OpenViking `peer_id`. OpenViking `openviking_user_id` identifies "
+        "the memory owner/context in `viking://user/<openviking_user_id>/...`. "
+        "Falling back to OpenViking user_id='default'. Set "
+        "backend_config['openviking_user_id'] or DATABASE_OPENVIKING_USER_ID "
+        "to isolate memories by agent/context."
+    )
+    assert warnings == [expected_warning]
 
 
 def test_openviking_backend_sdk_find_payload(monkeypatch):
@@ -405,6 +508,7 @@ def test_openviking_backend_sdk_find_payload(monkeypatch):
         index="support_app",
         url="http://openviking.test",
         api_key="owner-key",
+        openviking_user_id="default",
     )
 
     backend._search_with_actor_client(
@@ -419,7 +523,7 @@ def test_openviking_backend_sdk_find_payload(monkeypatch):
             "actor_peer_id": "a1",
             "payload": {
                 "query": "我的专属暗号和回答风格偏好是什么？",
-                "target_uri": "viking://user/peers/a1/memories",
+                "target_uri": "viking://user/default/peers/a1/memories",
                 "context_type": "memory",
                 "limit": 10,
             },
@@ -549,6 +653,20 @@ def test_openviking_backend_rejects_unsafe_peer_id(peer_id):
         )
 
 
+@pytest.mark.parametrize(
+    "openviking_user_id",
+    ["app/scene", "app:scene", "scene+1", ".", "..", "scene owner"],
+)
+def test_openviking_backend_rejects_unsafe_openviking_user_id(openviking_user_id):
+    with pytest.raises(ValueError, match="safe single path segment|must not be empty"):
+        OpenVikingLTMBackend(
+            index="support_app",
+            url="http://openviking.test",
+            api_key="owner-key",
+            openviking_user_id=openviking_user_id,
+        )
+
+
 def test_openviking_backend_namespaces_same_session_by_peer(monkeypatch):
     calls = _install_fake_openviking_sdk(monkeypatch)
     backend = OpenVikingLTMBackend(
@@ -594,7 +712,7 @@ async def test_long_term_memory_openviking_search_runs_sdk_off_event_loop_thread
             "find": {
                 "memories": [
                     {
-                        "uri": "viking://user/peers/alice/memories/preferences/a.md",
+                        "uri": "viking://user/agent_scene/peers/alice/memories/preferences/a.md",
                         "abstract": "用户喜欢简短直接的回答",
                     }
                 ]
@@ -607,6 +725,7 @@ async def test_long_term_memory_openviking_search_runs_sdk_off_event_loop_thread
             "index": "support_app",
             "url": "http://openviking.test",
             "api_key": "owner-key",
+            "openviking_user_id": "agent_scene",
         },
         top_k=2,
     )
@@ -623,7 +742,7 @@ async def test_long_term_memory_openviking_search_runs_sdk_off_event_loop_thread
     assert calls[1]["actor_peer_id"] == "alice"
     assert calls[1]["payload"] == {
         "query": "用户偏好",
-        "target_uri": "viking://user/peers/alice/memories",
+        "target_uri": "viking://user/agent_scene/peers/alice/memories",
         "context_type": "memory",
         "limit": 2,
     }

--- a/veadk/configs/database_configs.py
+++ b/veadk/configs/database_configs.py
@@ -14,6 +14,7 @@
 
 import os
 from functools import cached_property
+from typing import Any
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -138,6 +139,12 @@ class OpenVikingConfig(BaseSettings):
     api_key: str = ""
     """OpenViking service owner user key"""
 
+    user_id: str = ""
+    """OpenViking memory owner/context user id used in viking://user/<user_id>/..."""
+
+    memory_policy: dict[str, Any] | None = None
+    """OpenViking memory policy JSON used by LongTermMemory(backend="openviking")"""
+
 
 class VikingKnowledgebaseConfig(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="DATABASE_VIKING_")
@@ -155,7 +162,7 @@ class TOSConfig(BaseSettings):
 
     region: str = "cn-beijing"
 
-    def model_post_init(self, __context) -> None:
+    def model_post_init(self, __context, /) -> None:
         cloud_provider = os.getenv("CLOUD_PROVIDER", "volces").lower()
 
         if cloud_provider == "byteplus":

--- a/veadk/knowledgebase/backends/openviking_backend.py
+++ b/veadk/knowledgebase/backends/openviking_backend.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import os
+import re
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -22,11 +23,13 @@ from typing import Any
 from pydantic import Field, PrivateAttr
 from typing_extensions import override
 
+import veadk.config  # noqa: F401  # Load .env and config.yaml before reading env vars.
 from veadk.knowledgebase.backends.base_backend import BaseKnowledgebaseBackend
 from veadk.knowledgebase.entry import KnowledgebaseEntry
 from veadk.utils.logger import get_logger
 
 logger = get_logger(__name__)
+_SAFE_PATH_SEGMENT_PATTERN = re.compile(r"^[A-Za-z0-9_.@-]+$")
 
 
 def _getenv(*names: str) -> str | None:
@@ -55,18 +58,35 @@ def _parse_float(value: str | None, default: float | None) -> float | None:
     return float(value)
 
 
-def _default_target_uri(index: str) -> str:
-    return f"viking://resources/{index.strip('/')}/"
+def _default_target_uri(openviking_user_id: str, index: str) -> str:
+    openviking_user_id = _validate_safe_path_segment(
+        openviking_user_id,
+        name="openviking_user_id",
+    )
+    index = _validate_safe_path_segment(index, name="index")
+    return f"viking://user/{openviking_user_id}/resources/{index}/"
+
+
+def _validate_safe_path_segment(value: str, *, name: str) -> str:
+    value = str(value or "").strip()
+    if not value:
+        raise ValueError(f"OpenViking knowledgebase {name} must not be empty")
+    if value in {".", ".."} or not _SAFE_PATH_SEGMENT_PATTERN.match(value):
+        raise ValueError(
+            f"OpenViking knowledgebase {name} must be a safe single path segment. "
+            "Allowed characters: letters, digits, '.', '_', '@', '-'."
+        )
+    return value
 
 
 class OpenVikingKnowledgeBackend(BaseKnowledgebaseBackend):
     """OpenViking SDK backend for VeADK knowledge base operations.
 
     Each VeADK knowledgebase index maps to an OpenViking resources directory,
-    e.g. ``viking://resources/{index}/``. Imported resources are written under
-    that directory and searches are scoped with ``target_uri``. OpenViking
-    performs resource parsing and indexing, so this backend does not require
-    local embedding configuration.
+    e.g. ``viking://user/{openviking_user_id}/resources/{index}/``. Imported
+    resources are written under that directory and searches are scoped with
+    ``target_uri``. OpenViking performs resource parsing and indexing, so this
+    backend does not require local embedding configuration.
     """
 
     url: str | None = Field(
@@ -85,6 +105,8 @@ class OpenVikingKnowledgeBackend(BaseKnowledgebaseBackend):
     user: str | None = Field(
         default_factory=lambda: _getenv("DATABASE_OPENVIKING_USER", "OPENVIKING_USER")
     )
+    openviking_user_id: str | None = None
+    user_id: str | None = None
     actor_peer_id: str | None = Field(
         default_factory=lambda: _getenv(
             "DATABASE_OPENVIKING_ACTOR_PEER_ID", "OPENVIKING_ACTOR_PEER_ID"
@@ -128,12 +150,23 @@ class OpenVikingKnowledgeBackend(BaseKnowledgebaseBackend):
 
     _client: Any = PrivateAttr(default=None)
 
-    def model_post_init(self, __context: Any) -> None:
+    def model_post_init(self, __context: Any, /) -> None:
         self.precheck_index_naming()
-        self.target_uri = self._normalize_target_uri(
-            self.target_uri or _default_target_uri(self.index)
+        configured_openviking_user_id = (
+            self.openviking_user_id
+            or self.user_id
+            or _getenv("DATABASE_OPENVIKING_USER_ID", "OPENVIKING_USER_ID")
+            or "default"
         )
-        self._client = self._build_client()
+        self.openviking_user_id = configured_openviking_user_id.strip() or "default"
+        self.user_id = self.openviking_user_id
+        if self.target_uri:
+            self.target_uri = self._normalize_target_uri(self.target_uri)
+        else:
+            self.target_uri = self._normalize_target_uri(
+                _default_target_uri(self.openviking_user_id, self.index)
+            )
+        self._ensure_client()
 
     @override
     def precheck_index_naming(self) -> None:
@@ -163,18 +196,44 @@ class OpenVikingKnowledgeBackend(BaseKnowledgebaseBackend):
             actor_peer_id=self.actor_peer_id,
         )
 
+    def _initialize_client(self, client: Any) -> None:
+        initialize = getattr(client, "initialize", None)
+        if callable(initialize):
+            initialize()
+
+    def _ensure_client(self) -> Any:
+        if self._client is None:
+            client = self._build_client()
+            self._initialize_client(client)
+            self._client = client
+        return self._client
+
+    def close(self) -> None:
+        client = self._client
+        if client is None:
+            return
+
+        try:
+            close = getattr(client, "close", None)
+            if callable(close):
+                close()
+        finally:
+            self._client = None
+
     def _normalize_target_uri(self, target_uri: str) -> str:
         if not target_uri:
-            return _default_target_uri(self.index)
-        if target_uri.startswith("viking://resources/") and not target_uri.endswith(
-            "/"
-        ):
+            return _default_target_uri(
+                self.openviking_user_id or "default",
+                self.index,
+            )
+        if target_uri.startswith("viking://") and not target_uri.endswith("/"):
             return f"{target_uri}/"
         return target_uri
 
     @override
     def add_from_directory(self, directory: str, **kwargs) -> bool:
-        self._client.add_resource(
+        client = self._ensure_client()
+        client.add_resource(
             path=directory,
             to=kwargs.get("target_uri", self.target_uri),
             wait=kwargs.get("wait", self.wait),
@@ -193,8 +252,9 @@ class OpenVikingKnowledgeBackend(BaseKnowledgebaseBackend):
 
     @override
     def add_from_files(self, files: list[str], **kwargs) -> bool:
+        client = self._ensure_client()
         for file in files:
-            self._client.add_resource(
+            client.add_resource(
                 path=file,
                 parent=kwargs.get("target_uri", self.target_uri),
                 wait=kwargs.get("wait", self.wait),
@@ -223,7 +283,8 @@ class OpenVikingKnowledgeBackend(BaseKnowledgebaseBackend):
         target_uri = kwargs.get("target_uri", self.target_uri)
         score_threshold = kwargs.get("score_threshold", self.score_threshold)
         use_context_search = kwargs.get("use_context_search", self.use_context_search)
-        method = self._client.search if use_context_search else self._client.find
+        client = self._ensure_client()
+        method = client.search if use_context_search else client.find
 
         call_kwargs = {
             "query": query,
@@ -287,9 +348,10 @@ class OpenVikingKnowledgeBackend(BaseKnowledgebaseBackend):
             return str(item.get("abstract") or "")
 
         try:
+            client = self._ensure_client()
             if item.get("is_leaf"):
-                return self._client.read(uri, offset=0, limit=self.read_limit)
-            return self._client.overview(uri)
-        except Exception as e:
+                return client.read(uri, offset=0, limit=self.read_limit)
+            return client.overview(uri)
+        except Exception as e:  # noqa: BLE001 - SDK hydration failures fall back to abstracts.
             logger.debug(f"Failed to hydrate OpenViking resource {uri}: {e}")
             return str(item.get("abstract") or "")

--- a/veadk/knowledgebase/knowledgebase.py
+++ b/veadk/knowledgebase/knowledgebase.py
@@ -14,7 +14,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Literal, Union
+from collections.abc import Callable
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -85,7 +86,7 @@ def _get_backend_cls(backend: str) -> type[BaseKnowledgebaseBackend]:
                 "KnowledgeBase functionality requires 'veadk-python[extensions]'. "
                 "Please install it via `pip install veadk-python[extensions]`."
             ) from e
-        raise e
+        raise
 
 
 class KnowledgeBase(BaseModel):
@@ -126,7 +127,7 @@ class KnowledgeBase(BaseModel):
 
     description: str = "This knowledgebase stores some user-related information."
 
-    backend: Union[
+    backend: (
         Literal[
             "local",
             "opensearch",
@@ -136,9 +137,9 @@ class KnowledgeBase(BaseModel):
             "tos_vector",
             "context_search",
             "openviking",
-        ],
-        BaseKnowledgebaseBackend,
-    ] = "local"
+        ]
+        | BaseKnowledgebaseBackend
+    ) = "local"
 
     backend_config: dict = Field(default_factory=dict)
 
@@ -152,7 +153,7 @@ class KnowledgeBase(BaseModel):
 
     query_with_user_profile: bool = False
 
-    def model_post_init(self, __context: Any) -> None:
+    def model_post_init(self, __context: Any, /) -> None:
         if isinstance(self.backend, BaseKnowledgebaseBackend):
             self._backend = self.backend
             self.index = self._backend.index
@@ -279,6 +280,12 @@ class KnowledgeBase(BaseModel):
                 )
 
         return entries
+
+    def close(self) -> None:
+        """Release backend resources when the backend exposes a close hook."""
+        close = getattr(self._backend, "close", None)
+        if callable(close):
+            close()
 
     def __getattr__(self, name) -> Callable:
         """In case of knowledgebase have no backends' methods (`delete`, `list_chunks`, etc)

--- a/veadk/memory/long_term_memory_backends/openviking_backend.py
+++ b/veadk/memory/long_term_memory_backends/openviking_backend.py
@@ -25,6 +25,7 @@ from openviking_sdk import SyncHTTPClient
 from pydantic import Field
 from typing_extensions import override
 
+import veadk.config  # noqa: F401  # Load .env and config.yaml before settings.
 from veadk.configs.database_configs import OpenVikingConfig
 from veadk.memory.long_term_memory_backends.base_backend import (
     BaseLongTermMemoryBackend,
@@ -48,19 +49,29 @@ class OpenVikingLTMBackend(BaseLongTermMemoryBackend):
     openviking_config: OpenVikingConfig = Field(default_factory=OpenVikingConfig)
     url: str = ""
     api_key: str = ""
+    openviking_user_id: str = ""
+    memory_policy: dict[str, Any] | None = None
     peer_id_resolver: Callable[[str, str], str] | None = None
     timeout: float = 30
 
     _PEER_MEMORY_TYPES: ClassVar[list[str]] = ["entities", "events", "preferences"]
-    _MEMORY_POLICY: ClassVar[dict[str, Any]] = {
+    _DEFAULT_MEMORY_POLICY: ClassVar[dict[str, Any]] = {
         "self": {"enabled": False},
         "peer": {"enabled": True},
         "memory_types": _PEER_MEMORY_TYPES,
     }
 
-    def model_post_init(self, __context: Any) -> None:
+    def model_post_init(self, __context: Any, /) -> None:
         self.url = (self.url or self.openviking_config.url).rstrip("/")
         self.api_key = self.api_key or self.openviking_config.api_key
+        configured_openviking_user_id = (
+            self.openviking_user_id or self.openviking_config.user_id
+        ).strip()
+        using_default_openviking_user_id = not configured_openviking_user_id
+        self.openviking_user_id = self._validate_safe_path_segment(
+            configured_openviking_user_id or "default",
+            name="openviking_user_id",
+        )
         if not self.url:
             raise ValueError(
                 "OpenViking URL is required. Set DATABASE_OPENVIKING_URL or pass url."
@@ -69,6 +80,23 @@ class OpenVikingLTMBackend(BaseLongTermMemoryBackend):
             raise ValueError(
                 "OpenViking API key is required. Set DATABASE_OPENVIKING_API_KEY or pass api_key."
             )
+        if using_default_openviking_user_id:
+            logger.warning(
+                "OpenViking long-term memory `openviking_user_id` is not configured. "
+                "VeADK `user_id` identifies the current requester and is used as "
+                "OpenViking `peer_id`. OpenViking `openviking_user_id` identifies "
+                "the memory owner/context in `viking://user/<openviking_user_id>/...`. "
+                "Falling back to OpenViking user_id='default'. Set "
+                "backend_config['openviking_user_id'] or DATABASE_OPENVIKING_USER_ID "
+                "to isolate memories by agent/context."
+            )
+        self.memory_policy = (
+            self.memory_policy
+            if self.memory_policy is not None
+            else self.openviking_config.memory_policy
+        )
+        if self.memory_policy is None:
+            self.memory_policy = json.loads(json.dumps(self._DEFAULT_MEMORY_POLICY))
         if not self.peer_id_resolver:
             self.peer_id_resolver = default_peer_id_resolver
 
@@ -91,6 +119,7 @@ class OpenVikingLTMBackend(BaseLongTermMemoryBackend):
         peer_id = self._resolve_peer_id(app_name=app_name, user_id=user_id)
         openviking_session_id = self._openviking_session_id(
             app_name=app_name,
+            openviking_user_id=self.openviking_user_id,
             peer_id=peer_id,
             session_id=session_id,
         )
@@ -134,22 +163,27 @@ class OpenVikingLTMBackend(BaseLongTermMemoryBackend):
     def _resolve_peer_id(self, *, app_name: str, user_id: str) -> str:
         assert self.peer_id_resolver is not None
         peer_id = str(self.peer_id_resolver(app_name, user_id) or "").strip()
-        if not peer_id:
-            raise ValueError("OpenViking peer_id must not be empty")
-        if peer_id in {".", ".."} or not _SAFE_ID_PATTERN.match(peer_id):
+        return self._validate_safe_path_segment(peer_id, name="peer_id")
+
+    def _validate_safe_path_segment(self, value: str, *, name: str) -> str:
+        value = str(value or "").strip()
+        if not value:
+            raise ValueError(f"OpenViking {name} must not be empty")
+        if value in {".", ".."} or not _SAFE_ID_PATTERN.match(value):
             raise ValueError(
-                "OpenViking peer_id must be a safe single path segment. "
+                f"OpenViking {name} must be a safe single path segment. "
                 "Allowed characters: letters, digits, '.', '_', '@', '-'."
             )
-        return peer_id
+        return value
 
     def _peer_memory_target_uri(self, *, peer_id: str) -> str:
-        return f"viking://user/peers/{peer_id}/memories"
+        return f"viking://user/{self.openviking_user_id}/peers/{peer_id}/memories"
 
     def _openviking_session_id(
         self,
         *,
         app_name: str,
+        openviking_user_id: str,
         peer_id: str,
         session_id: str,
     ) -> str:
@@ -157,6 +191,7 @@ class OpenVikingLTMBackend(BaseLongTermMemoryBackend):
             [
                 "veadk",
                 self._safe_identifier_part(app_name, fallback="app"),
+                self._safe_identifier_part(openviking_user_id, fallback="user"),
                 self._safe_identifier_part(peer_id, fallback="peer"),
                 self._safe_identifier_part(session_id, fallback="session"),
             ]
@@ -182,7 +217,7 @@ class OpenVikingLTMBackend(BaseLongTermMemoryBackend):
         try:
             client.create_session(
                 session_id=session_id,
-                memory_policy=self._MEMORY_POLICY,
+                memory_policy=self.memory_policy,
             )
         except Exception as e:
             if self._is_existing_session_error(e):


### PR DESCRIPTION
## Summary
- Add `openviking_user_id` support for OpenViking KnowledgeBase and LongTermMemory backends.
- Add default OpenViking URI generation based on `openviking_user_id` and KnowledgeBase `index`.
- Add configurable OpenViking `memory_policy` for LongTermMemory.
- Add OpenViking client lifecycle release support through `KnowledgeBase.close()`.
- Add a standalone `examples/13_openviking` example and expand related docs / `.env.example` guidance.

## Details
- KnowledgeBase `target_uri` priority:
  - method-level `target_uri`
  - `backend_config["target_uri"]`
  - `DATABASE_OPENVIKING_TARGET_URI`
  - generated default URI
- `openviking_user_id` priority:
  - `backend_config["openviking_user_id"]`
  - `backend_config["user_id"]`
  - `DATABASE_OPENVIKING_USER_ID`
  - `default`
- Default KnowledgeBase URI:
  - `viking://user/{openviking_user_id}/resources/{index}/`
- LongTermMemory now supports configurable `memory_policy` through backend config or environment config.
- Explicit `target_uri` is treated as a full OpenViking URI and is not joined with `openviking_user_id` or `index`.

## Validation
- `uv run pre-commit run --all-files`
- `uv run pytest tests/test_openviking_knowledgebase.py tests/test_openviking_long_term_memory.py`