### PR TITLE
fix(studio): display sandbox creator identity

### DIFF
--- a/tests/cli/test_frontend_sandbox.py
+++ b/tests/cli/test_frontend_sandbox.py
@@ -259,6 +259,7 @@ class _FakeGateway:
         self.tool_ids: list[str] = []
         self.display_names: list[str] = []
         self.usernames: list[str | None] = []
+        self.creator_names: list[str] = []
         self.deleted: list[SandboxCloudSession] = []
         self.thread_ids: list[str] = []
         self.connections: list[_FakeCodex] = []
@@ -297,11 +298,16 @@ class _FakeGateway:
         return session
 
     async def create_session(
-        self, tool_id: str, display_name: str = "", username: str = ""
+        self,
+        tool_id: str,
+        display_name: str = "",
+        username: str = "",
+        creator_name: str = "",
     ) -> SandboxCloudSession:
         self.created += 1
         self.tool_ids.append(tool_id)
         self.display_names.append(display_name)
+        self.creator_names.append(creator_name)
         session = SandboxCloudSession(
             tool_id=tool_id,
             instance_id=f"remote-{self.created}",
@@ -314,6 +320,7 @@ class _FakeGateway:
             tool_type="CodeEnv",
             display_name=display_name,
             created_by=username,
+            creator_name=creator_name,
         )
         self.sessions[session.instance_id] = session
         return session
@@ -345,7 +352,16 @@ def _app(gateway: _FakeGateway, tool_id: str | None = "tool-studio") -> FastAPI:
     def _admin(request: Request) -> bool:
         return request.headers.get("X-Test-Role") == "admin"
 
-    mount_sandbox_routes(app, service, _owner, admin_resolver=_admin)
+    def _creator(request: Request) -> str:
+        return request.headers.get("X-Test-Creator") or _owner(request)
+
+    mount_sandbox_routes(
+        app,
+        service,
+        _owner,
+        admin_resolver=_admin,
+        creator_resolver=_creator,
+    )
     return app
 
 
@@ -360,6 +376,9 @@ def _agent_app(gateway: _FakeGateway) -> FastAPI:
 
     def _admin(request: Request) -> bool:
         return request.headers.get("X-Test-Role") == "admin"
+
+    def _creator(request: Request) -> str:
+        return request.headers.get("X-Test-Creator") or _owner(request)
 
     mount_sandbox_agent_routes(
         app,
@@ -377,6 +396,7 @@ def _agent_app(gateway: _FakeGateway) -> FastAPI:
         },
         _owner,
         _admin,
+        _creator,
     )
     return app
 
@@ -497,6 +517,29 @@ def test_managed_agent_routes_enforce_username_scope() -> None:
     }
     assert all(item["createdBy"] for item in admin_list.json()["sessions"])
     assert denied.status_code == 404
+
+
+def test_managed_agent_routes_display_creator_separately_from_owner_id() -> None:
+    gateway = _FakeGateway()
+    owner_id = "255d476b-099c-4719-b0f5-22f0d57efe56"
+    headers = {
+        "X-Test-User": owner_id,
+        "X-Test-Creator": "alice@example.com",
+    }
+    with TestClient(_agent_app(gateway)) as client:
+        created = client.post("/web/openclaw/sessions", headers=headers)
+        owner_list = client.get("/web/openclaw/sessions", headers=headers)
+        other_list = client.get(
+            "/web/openclaw/sessions",
+            headers={"X-Test-User": "another-user-id"},
+        )
+
+    assert created.json()["createdBy"] == "alice@example.com"
+    assert owner_list.json()["sessions"][0]["createdBy"] == "alice@example.com"
+    assert other_list.json() == {"sessions": []}
+    session = gateway.sessions[created.json()["sessionId"]]
+    assert session.created_by == owner_id
+    assert session.creator_name == "alice@example.com"
 
 
 def test_sandbox_routes_list_create_connect_and_disconnect() -> None:
@@ -1099,7 +1142,12 @@ async def test_gateway_filters_sessions_by_username_metadata() -> None:
                         endpoint="https://sandbox.example/path?Authorization=secret",
                         status="Ready",
                         metadata=[
-                            {"Key": "Username", "Type": "String", "Value": "alice"}
+                            {"Key": "Username", "Type": "String", "Value": "alice"},
+                            {
+                                "Key": "veadk_creator_name",
+                                "Type": "String",
+                                "Value": "alice@example.com",
+                            },
                         ],
                     )
                 ],
@@ -1118,6 +1166,7 @@ async def test_gateway_filters_sessions_by_username_metadata() -> None:
         }
     ]
     assert [session.created_by for session in sessions] == ["alice"]
+    assert [session.creator_name for session in sessions] == ["alice@example.com"]
 
 
 @pytest.mark.asyncio
@@ -1137,13 +1186,20 @@ async def test_gateway_creates_session_with_username_metadata() -> None:
         "tool-sdk",
         "Alice Agent",
         "alice",
+        "alice@example.com",
     )
 
     assert requests[0]["Metadata"] == [
         {"Key": "veadk_display_name", "Type": "String", "Value": "Alice Agent"},
         {"Key": "Username", "Type": "String", "Value": "alice"},
+        {
+            "Key": "veadk_creator_name",
+            "Type": "String",
+            "Value": "alice@example.com",
+        },
     ]
     assert session.created_by == "alice"
+    assert session.creator_name == "alice@example.com"
 
 
 @pytest.mark.asyncio

--- a/veadk/cli/agentkit_session_metadata.py
+++ b/veadk/cli/agentkit_session_metadata.py
@@ -23,6 +23,7 @@ from pydantic import Field
 
 SESSION_DISPLAY_NAME_MAX_LENGTH = 40
 SESSION_DISPLAY_NAME_METADATA_KEY = "veadk_display_name"
+SESSION_CREATOR_NAME_METADATA_KEY = "veadk_creator_name"
 SESSION_USERNAME_METADATA_KEY = "Username"
 
 
@@ -76,6 +77,7 @@ def build_create_session_request(
     user_session_id: str,
     display_name: str,
     username: str = "",
+    creator_name: str = "",
 ) -> Any:
     """Build a native or compatibility CreateSession request."""
     metadata = []
@@ -93,6 +95,14 @@ def build_create_session_request(
                 Key=SESSION_USERNAME_METADATA_KEY,
                 Type="String",
                 Value=username,
+            )
+        )
+    if creator_name:
+        metadata.append(
+            _SessionMetadata(
+                Key=SESSION_CREATOR_NAME_METADATA_KEY,
+                Type="String",
+                Value=creator_name,
             )
         )
     request_type: Any = tools_types.CreateSessionRequest
@@ -198,4 +208,21 @@ def session_username(value: Any) -> str:
             username = getattr(item, "value", "")
         if key == SESSION_USERNAME_METADATA_KEY and isinstance(username, str):
             return username.strip()
+    return ""
+
+
+def session_creator_name(value: Any) -> str:
+    """Extract the human-readable creator name from one Session response."""
+    metadata = getattr(value, "metadata", None)
+    if not isinstance(metadata, (list, tuple)):
+        return ""
+    for item in metadata:
+        if isinstance(item, dict):
+            key = item.get("key") or item.get("Key")
+            creator_name = item.get("value") or item.get("Value")
+        else:
+            key = getattr(item, "key", "")
+            creator_name = getattr(item, "value", "")
+        if key == SESSION_CREATOR_NAME_METADATA_KEY and isinstance(creator_name, str):
+            return creator_name.strip()
     return ""

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -1191,6 +1191,12 @@ def _run_frontend_server(
             raise HTTPException(status_code=401, detail="Studio identity is required")
         return principal.owner_id
 
+    def _sandbox_creator(request: Request) -> str:
+        principal = _current_principal(request)
+        if principal is None:
+            raise HTTPException(status_code=401, detail="Studio identity is required")
+        return principal.display_name
+
     def _sandbox_is_admin(request: Request) -> bool:
         return _request_role(request) == StudioRole.ADMIN
 
@@ -1243,12 +1249,14 @@ def _run_frontend_server(
         _sandbox_owner,
         _sandbox_proxy_target,
         _sandbox_is_admin,
+        _sandbox_creator,
     )
     mount_sandbox_agent_routes(
         app,
         sandbox_agent_services,
         _sandbox_owner,
         _sandbox_is_admin,
+        _sandbox_creator,
     )
 
     # Prefixes (and a few exact keys) we copy from the server's environment

--- a/veadk/cli/frontend_sandbox.py
+++ b/veadk/cli/frontend_sandbox.py
@@ -36,6 +36,7 @@ from veadk.cli.agentkit_session_metadata import (
     build_create_session_request,
     build_list_sessions_request,
     call_session_client,
+    session_creator_name,
     session_display_name,
     session_username,
 )
@@ -225,6 +226,7 @@ class SandboxCloudSession:
     tool_type: str = ""
     display_name: str = ""
     created_by: str = ""
+    creator_name: str = ""
 
 
 @dataclass
@@ -382,7 +384,11 @@ class SandboxCloudGateway(Protocol):
         raise NotImplementedError
 
     async def create_session(
-        self, tool_id: str, display_name: str = "", username: str = ""
+        self,
+        tool_id: str,
+        display_name: str = "",
+        username: str = "",
+        creator_name: str = "",
     ) -> SandboxCloudSession:
         """Create a fresh remote Sandbox session."""
         raise NotImplementedError
@@ -496,6 +502,7 @@ class AgentkitSandboxGateway:
             tool_type=str(getattr(value, "tool_type", "") or "").strip(),
             display_name=session_display_name(value),
             created_by=session_username(value),
+            creator_name=session_creator_name(value),
         )
 
     async def list_sessions(
@@ -578,7 +585,11 @@ class AgentkitSandboxGateway:
         raise SandboxSessionNotFoundError("AgentKit Session 不存在或已过期。")
 
     async def create_session(
-        self, tool_id: str, display_name: str = "", username: str = ""
+        self,
+        tool_id: str,
+        display_name: str = "",
+        username: str = "",
+        creator_name: str = "",
     ) -> SandboxCloudSession:
         user_session_id = f"studio-{uuid.uuid4()}"
         regions = self._region_candidates or ("",)
@@ -589,6 +600,7 @@ class AgentkitSandboxGateway:
                 user_session_id=user_session_id,
                 display_name=display_name,
                 username=username,
+                creator_name=creator_name,
             )
             create_task = asyncio.create_task(
                 self._call("create_session", request, region=region)
@@ -634,6 +646,7 @@ class AgentkitSandboxGateway:
                 status="Ready" if endpoint else "Creating",
                 display_name=display_name,
                 created_by=username,
+                creator_name=creator_name,
             )
         raise SandboxProvisioningError("无法在支持的地域创建 AgentKit 沙箱会话。")
 
@@ -749,7 +762,10 @@ class SandboxConversationService:
         )
 
     async def create(
-        self, owner_id: str, display_name: object = ""
+        self,
+        owner_id: str,
+        display_name: object = "",
+        creator_name: str = "",
     ) -> SandboxCloudSession:
         """Create a cloud Session without opening a conversation connection."""
         if not isinstance(display_name, str):
@@ -768,7 +784,9 @@ class SandboxConversationService:
                 raise SandboxCapacityError("Sandbox 创建或连接数已达上限，请稍后重试。")
             self._sessions_starting += 1
         try:
-            return await self._gateway.create_session(tool_id, display_name, owner_id)
+            return await self._gateway.create_session(
+                tool_id, display_name, owner_id, creator_name
+            )
         finally:
             async with self._registry_lock:
                 self._sessions_starting -= 1
@@ -1288,6 +1306,7 @@ class SandboxAgentSessionService:
         self,
         owner_id: str,
         display_name: object = "",
+        creator_name: str = "",
     ) -> SandboxCloudSession:
         if not isinstance(display_name, str):
             raise SandboxValidationError("智能体名称必须是文本。")
@@ -1297,7 +1316,7 @@ class SandboxAgentSessionService:
                 f"智能体名称不能超过 {STUDIO_SANDBOX_DISPLAY_NAME_MAX_LENGTH} 个字符。"
             )
         return await self._gateway.create_session(
-            self._tool_id(), display_name, owner_id
+            self._tool_id(), display_name, owner_id, creator_name
         )
 
     async def open(
@@ -1408,6 +1427,7 @@ def mount_sandbox_agent_routes(
     services: dict[str, SandboxAgentSessionService],
     owner_resolver: Callable[[Any], str],
     admin_resolver: Callable[[Any], bool] | None = None,
+    creator_resolver: Callable[[Any], str] | None = None,
 ) -> None:
     """Mount list/create/open routes for managed agent Sessions."""
     from fastapi import HTTPException
@@ -1456,7 +1476,7 @@ def mount_sandbox_agent_routes(
             "createdAt": session.created_at,
             "expireAt": session.expire_at,
             "toolType": session.tool_type,
-            "createdBy": session.created_by,
+            "createdBy": session.creator_name or session.created_by,
             "displayName": session.display_name,
             "toolName": kind,
         }
@@ -1505,6 +1525,7 @@ def mount_sandbox_agent_routes(
             session = await _service(kind).create(
                 owner_id,
                 data.get("displayName", ""),
+                creator_resolver(request) if creator_resolver else owner_id,
             )
         except SandboxError as error:
             raise _http_error(error) from error
@@ -1592,6 +1613,7 @@ def mount_sandbox_routes(
     owner_resolver: Callable[[Any], str],
     proxy_target_resolver: Callable[[str, str], SandboxProxyTarget] | None = None,
     admin_resolver: Callable[[Any], bool] | None = None,
+    creator_resolver: Callable[[Any], str] | None = None,
 ) -> None:
     """Mount Studio HTTP routes for reusable Sandbox Sessions."""
     from fastapi import HTTPException
@@ -1631,7 +1653,7 @@ def mount_sandbox_routes(
             "createdAt": session.created_at,
             "expireAt": session.expire_at,
             "toolType": session.tool_type,
-            "createdBy": session.created_by,
+            "createdBy": session.creator_name or session.created_by,
             "displayName": session.display_name,
         }
 
@@ -1704,7 +1726,11 @@ def mount_sandbox_routes(
                     raise SandboxValidationError("创建智能体的请求格式无效。")
             else:
                 data = {}
-            session = await service.create(owner_id, data.get("displayName", ""))
+            session = await service.create(
+                owner_id,
+                data.get("displayName", ""),
+                creator_resolver(request) if creator_resolver else owner_id,
+            )
         except SandboxError as error:
             raise _http_error(error) from error
         return {


### PR DESCRIPTION
## Summary

- keep the stable Session owner ID for authorization and user-scoped filtering
- persist the OAuth username or email as separate creator metadata
- display the creator metadata while retaining a fallback for existing Sessions
- cover UUID owner IDs and email display identities in route and gateway tests

## Validation

- `uvx pre-commit run --all-files`
- `uv run pytest -q` (`1065 passed, 6 skipped, 6 subtests passed`)
