### PR TITLE
fix: support STS credentials in studio deploy

### DIFF
--- a/tests/cli/test_frontend_branding.py
+++ b/tests/cli/test_frontend_branding.py
@@ -144,7 +144,7 @@ def test_studio_deploy_bundles_logo_and_optional_title(
     )
     monkeypatch.setattr(
         "veadk.cli.studio_deploy_serverless_iam.ensure_serverless_application_role",
-        lambda *_: False,
+        lambda *_, **__: False,
     )
     monkeypatch.setattr(
         "veadk.cli.studio_sandbox_tools.ensure_studio_code_env_tool",

--- a/tests/cli/test_frontend_deploy_iam.py
+++ b/tests/cli/test_frontend_deploy_iam.py
@@ -58,6 +58,7 @@ def test_existing_frontend_role_gets_missing_system_policies(
     trn = ensure_frontend_role("ak", "sk")
 
     assert trn == "trn:iam::123:role/VeADKFrontendServiceRole"
+    service.set_session_token.assert_not_called()
     service.create_role.assert_not_called()
     service.update_policy.assert_called_once()
     service.create_policy.assert_not_called()
@@ -80,6 +81,31 @@ def test_existing_frontend_role_gets_missing_system_policies(
             for policy_name in FRONTEND_DEPLOY_SYSTEM_POLICIES[1:]
         ],
     ]
+
+
+def test_frontend_role_uses_session_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = MagicMock()
+    service.get_role.return_value = {
+        "Result": {"Role": {"Trn": "trn:iam::123:role/VeADKFrontendServiceRole"}}
+    }
+    service.list_attached_role_policies.return_value = {
+        "Result": {
+            "AttachedPolicyMetadata": [
+                {"PolicyName": "VeADKFrontendPolicy"},
+                *[
+                    {"PolicyName": policy_name}
+                    for policy_name in FRONTEND_DEPLOY_SYSTEM_POLICIES
+                ],
+            ]
+        }
+    }
+    service.update_policy.return_value = {"Result": {}}
+    service.get_policy.return_value = _policy_response()
+    _install_iam_service(monkeypatch, service)
+
+    ensure_frontend_role("ak", "sk", session_token="sts-token")
+
+    service.set_session_token.assert_called_once_with("sts-token")
 
 
 def test_new_frontend_role_gets_custom_and_system_policies(

--- a/tests/cli/test_studio_deploy_serverless_iam.py
+++ b/tests/cli/test_studio_deploy_serverless_iam.py
@@ -48,10 +48,23 @@ def test_existing_role_is_reused(monkeypatch: pytest.MonkeyPatch) -> None:
     created = ensure_serverless_application_role("ak", "sk")
 
     assert created is False
+    service.set_session_token.assert_not_called()
     service.get_policy.assert_not_called()
     service.create_policy.assert_not_called()
     service.create_role.assert_not_called()
     service.attach_role_policy.assert_not_called()
+
+
+def test_serverless_role_uses_session_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = MagicMock()
+    service.get_role.return_value = {"Result": {"Role": {"RoleName": ROLE_NAME}}}
+    _install_iam_service(monkeypatch, service)
+
+    ensure_serverless_application_role("ak", "sk", session_token="sts-token")
+
+    service.set_session_token.assert_called_once_with("sts-token")
 
 
 def test_missing_role_is_created_with_all_policies(
@@ -131,7 +144,7 @@ def test_role_lookup_permission_error_fails_fast(
 def test_studio_deploy_checks_serverless_role_with_custom_function_role(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    checked_credentials: list[tuple[str, str]] = []
+    checked_credentials: list[tuple[str, str, str]] = []
 
     class _FakeCloudAgentEngine:
         def __init__(self, **_: object) -> None:
@@ -146,8 +159,8 @@ def test_studio_deploy_checks_serverless_role_with_custom_function_role(
 
     monkeypatch.setattr(
         "veadk.cli.studio_deploy_serverless_iam.ensure_serverless_application_role",
-        lambda access_key, secret_key: checked_credentials.append(
-            (access_key, secret_key)
+        lambda access_key, secret_key, session_token="": checked_credentials.append(
+            (access_key, secret_key, session_token)
         ),
     )
     monkeypatch.setattr(
@@ -196,4 +209,4 @@ def test_studio_deploy_checks_serverless_role_with_custom_function_role(
     )
 
     assert result.exit_code == 0, result.output
-    assert checked_credentials == [("ak", "sk")]
+    assert checked_credentials == [("ak", "sk", "")]

--- a/tests/cli/test_studio_deploy_target.py
+++ b/tests/cli/test_studio_deploy_target.py
@@ -36,13 +36,15 @@ from veadk.integrations.ve_identity.identity_client import IdentityClient
 
 @pytest.fixture(autouse=True)
 def _skip_serverless_role_setup(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VOLCENGINE_SESSION_TOKEN", raising=False)
+    monkeypatch.delenv("VOLC_SESSIONTOKEN", raising=False)
     monkeypatch.delenv("SANDBOX_CHAT_CODEX", raising=False)
     monkeypatch.delenv("SANDBOX_CHAT_OPENCLAW", raising=False)
     monkeypatch.delenv("SANDBOX_CHAT_HERMES", raising=False)
     monkeypatch.delenv("SANDBOX_SKILL_CREATOR", raising=False)
     monkeypatch.setattr(
         "veadk.cli.studio_deploy_serverless_iam.ensure_serverless_application_role",
-        lambda *_: None,
+        lambda *_, **__: None,
     )
     monkeypatch.setattr(
         "veadk.cli.studio_sandbox_tools.ensure_studio_code_env_tool",
@@ -73,6 +75,7 @@ def test_studio_credentials_prefer_inline_environment(
     )
     monkeypatch.setenv("VOLCENGINE_ACCESS_KEY", "env-ak")
     monkeypatch.setenv("VOLCENGINE_SECRET_KEY", "env-sk")
+    monkeypatch.setenv("VOLCENGINE_SESSION_TOKEN", "env-token")
 
     credentials = _resolve_studio_cloud_credentials(
         None,
@@ -80,7 +83,7 @@ def test_studio_credentials_prefer_inline_environment(
         credentials_path,
     )
 
-    assert credentials == ("env-ak", "env-sk")
+    assert credentials == ("env-ak", "env-sk", "env-token")
 
 
 def test_studio_credentials_fall_back_to_volc_default_profile(
@@ -89,7 +92,8 @@ def test_studio_credentials_fall_back_to_volc_default_profile(
 ) -> None:
     credentials_path = tmp_path / "credentials"
     credentials_path.write_text(
-        "[default]\naccess_key_id=file-ak\nsecret_access_key=file-sk\n",
+        "[default]\naccess_key_id=file-ak\nsecret_access_key=file-sk\n"
+        "session_token=file-token\n",
         encoding="utf-8",
     )
     monkeypatch.delenv("VOLCENGINE_ACCESS_KEY", raising=False)
@@ -101,7 +105,23 @@ def test_studio_credentials_fall_back_to_volc_default_profile(
         credentials_path,
     )
 
-    assert credentials == ("file-ak", "file-sk")
+    assert credentials == ("file-ak", "file-sk", "file-token")
+
+
+def test_studio_credentials_support_long_term_keys_without_session_token(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("VOLCENGINE_ACCESS_KEY", "env-ak")
+    monkeypatch.setenv("VOLCENGINE_SECRET_KEY", "env-sk")
+
+    credentials = _resolve_studio_cloud_credentials(
+        None,
+        None,
+        tmp_path / "missing-credentials",
+    )
+
+    assert credentials == ("env-ak", "env-sk", "")
 
 
 @pytest.mark.parametrize(
@@ -259,8 +279,8 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
             )
 
     class _FakeIdentityClient:
-        def __init__(self, **_: object) -> None:
-            pass
+        def __init__(self, **kwargs: object) -> None:
+            captured["identity_client"] = kwargs
 
         def register_callback_for_user_pool_client(self, **kwargs: object) -> None:
             captured["callback"] = kwargs
@@ -307,6 +327,8 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
             "ak",
             "--volcengine-secret-key",
             "sk",
+            "--volcengine-session-token",
+            "sts-token",
             *target_args,
         ],
     )
@@ -314,6 +336,13 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
     assert result.exit_code == 0, result.output
     assert captured["region"] == expected_region
     assert captured["project"] == expected_project
+    assert captured["volcengine_session_token"] == "sts-token"
+    assert captured["identity_client"] == {
+        "access_key": "ak",
+        "secret_key": "sk",
+        "session_token": "sts-token",
+        "region": expected_identity_region,
+    }
     assert veadk_environments["VEIDENTITY_REGION"] == expected_identity_region
     assert "VEADK_STUDIO_ADMINS" not in veadk_environments
     assert "VEADK_STUDIO_DEVELOPERS" not in veadk_environments
@@ -530,10 +559,12 @@ def test_studio_identity_region_searches_deployment_region_first(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     checked_regions: list[str] = []
+    checked_tokens: list[str] = []
 
     class _FakeIdentityClient:
         def __init__(self, **kwargs: str) -> None:
             self.region = kwargs["region"]
+            checked_tokens.append(kwargs["session_token"])
 
         def user_pool_client_exists(self, **_: str) -> bool:
             checked_regions.append(self.region)
@@ -550,10 +581,44 @@ def test_studio_identity_region_searches_deployment_region_first(
         user_pool_id="pool-id",
         client_id="client-id",
         deployment_region="cn-shanghai",
+        session_token="sts-token",
     )
 
     assert resolved == "cn-beijing"
     assert checked_regions == ["cn-shanghai", "cn-beijing"]
+    assert checked_tokens == ["sts-token", "sts-token"]
+
+
+def test_identity_client_preserves_external_sts_token() -> None:
+    identity_client = IdentityClient(
+        access_key="test_access_key",
+        secret_key="test_secret_key",
+        session_token="sts-token",
+    )
+    identity_client._api_client.get_user_pool_client = Mock(return_value=object())
+
+    assert identity_client.user_pool_client_exists("pool-id", "client-id")
+    assert not identity_client._is_sts_credential_expired()
+    assert (
+        identity_client._api_client.api_client.configuration.session_token
+        == "sts-token"
+    )
+
+
+def test_identity_client_refreshes_known_sts_expiration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity_client = IdentityClient(
+        access_key="test_access_key",
+        secret_key="test_secret_key",
+    )
+    monkeypatch.setattr("time.time", lambda: 1_000)
+
+    identity_client._sts_credential_expires_at = 1_301
+    assert not identity_client._is_sts_credential_expired()
+
+    identity_client._sts_credential_expires_at = 1_300
+    assert identity_client._is_sts_credential_expired()
 
 
 def test_identity_region_probe_only_swallows_not_found() -> None:

--- a/tests/cli/test_studio_update.py
+++ b/tests/cli/test_studio_update.py
@@ -180,7 +180,7 @@ def test_application_template_matches_deployment_region(
     )
     monkeypatch.setattr(
         "veadk.integrations.ve_faas.ve_faas.APIGateway",
-        lambda *_: object(),
+        lambda *_, **__: object(),
     )
 
     service = VeFaaS("ak", "sk", region="cn-shanghai")

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -22,6 +22,7 @@ os.environ["VOLCENGINE_ACCESS_KEY"] = "test_access_key"
 os.environ["VOLCENGINE_SECRET_KEY"] = "test_secret_key"
 
 from veadk.cloud.cloud_agent_engine import CloudAgentEngine
+from veadk.integrations.ve_apig.ve_apig import APIGateway
 from veadk.integrations.ve_faas.ve_faas import VeFaaS
 
 
@@ -41,6 +42,34 @@ def test_vefaas_create_function_uses_configured_project() -> None:
 
     request = service.client.create_function.call_args.args[0]
     assert request.project_name == "studio-project"
+
+
+def test_apig_uses_session_token() -> None:
+    gateway = APIGateway(
+        access_key="test_access_key",
+        secret_key="test_secret_key",
+        session_token="test_session_token",
+    )
+
+    assert gateway.session_token == "test_session_token"
+    assert gateway.api_client.configuration.session_token == "test_session_token"
+
+
+def test_vefaas_passes_session_token_to_apig() -> None:
+    with patch("veadk.integrations.ve_faas.ve_faas.APIGateway") as apig:
+        VeFaaS(
+            access_key="test_access_key",
+            secret_key="test_secret_key",
+            session_token="test_session_token",
+            region="cn-shanghai",
+        )
+
+    apig.assert_called_once_with(
+        "test_access_key",
+        "test_secret_key",
+        "cn-shanghai",
+        session_token="test_session_token",
+    )
 
 
 def test_vefaas_code_upload_callback_uses_configured_region() -> None:
@@ -129,10 +158,12 @@ async def test_cloud():
                     project="studio-project",
                     volcengine_access_key="test_access_key",
                     volcengine_secret_key="test_secret_key",
+                    volcengine_session_token="test_session_token",
                 )
                 mock_vefaas_class.assert_called_once_with(
                     access_key="test_access_key",
                     secret_key="test_secret_key",
+                    session_token="test_session_token",
                     region="cn-beijing",
                     project_name="studio-project",
                 )

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -5928,6 +5928,7 @@ def _resolve_studio_identity_region(
     user_pool_id: str,
     client_id: str,
     deployment_region: str,
+    session_token: str = "",
 ) -> str:
     """Locate a Studio user-pool client across supported Identity regions."""
     from veadk.integrations.ve_identity.identity_client import IdentityClient
@@ -5940,6 +5941,7 @@ def _resolve_studio_identity_region(
         identity_client = IdentityClient(
             access_key=access_key,
             secret_key=secret_key,
+            session_token=session_token,
             region=candidate_region,
         )
         if identity_client.user_pool_client_exists(
@@ -5956,14 +5958,20 @@ def _resolve_studio_cloud_credentials(
     access_key: str | None,
     secret_key: str | None,
     credentials_path: Path | None = None,
-) -> tuple[str, str]:
-    """Resolve Studio deploy credentials from CLI, environment, or ~/.volc."""
+    session_token: str | None = None,
+) -> tuple[str, str, str]:
+    """Resolve Studio deploy credentials as AK, SK, and token."""
     import configparser
 
     resolved_access_key = access_key or os.getenv("VOLCENGINE_ACCESS_KEY", "")
     resolved_secret_key = secret_key or os.getenv("VOLCENGINE_SECRET_KEY", "")
+    resolved_session_token = (
+        session_token
+        or os.getenv("VOLCENGINE_SESSION_TOKEN", "")
+        or os.getenv("VOLC_SESSIONTOKEN", "")
+    )
     if resolved_access_key and resolved_secret_key:
-        return resolved_access_key, resolved_secret_key
+        return resolved_access_key, resolved_secret_key, resolved_session_token
 
     path = credentials_path or Path.home() / ".volc" / "credentials"
     if path.is_file():
@@ -5983,9 +5991,13 @@ def _resolve_studio_cloud_credentials(
             resolved_secret_key
             or str(default_profile.get("secret_access_key", "")).strip()
         )
+        resolved_session_token = (
+            resolved_session_token
+            or str(default_profile.get("session_token", "")).strip()
+        )
 
     if resolved_access_key and resolved_secret_key:
-        return resolved_access_key, resolved_secret_key
+        return resolved_access_key, resolved_secret_key, resolved_session_token
     raise click.ClickException(
         "Volcengine credentials required: pass --volcengine-access-key/"
         "--volcengine-secret-key, set VOLCENGINE_ACCESS_KEY/"
@@ -6044,6 +6056,7 @@ def _resolve_studio_cloud_credentials(
 @click.option("--gateway-upstream-name", default="")
 @click.option("--volcengine-access-key", default=None)
 @click.option("--volcengine-secret-key", default=None)
+@click.option("--volcengine-session-token", default=None)
 @click.option(
     "--veadk-version",
     default="",
@@ -6150,6 +6163,7 @@ def frontend_deploy(
     gateway_upstream_name: str,
     volcengine_access_key: str | None,
     volcengine_secret_key: str | None,
+    volcengine_session_token: str | None,
     veadk_version: str,
     from_source: bool,
     site_logo: str | None,
@@ -6181,9 +6195,10 @@ def frontend_deploy(
     except ValueError as error:
         raise click.ClickException(str(error)) from error
 
-    ak, sk = _resolve_studio_cloud_credentials(
+    ak, sk, session_token = _resolve_studio_cloud_credentials(
         volcengine_access_key,
         volcengine_secret_key,
+        session_token=volcengine_session_token,
     )
 
     identity_region = _resolve_studio_identity_region(
@@ -6192,6 +6207,7 @@ def frontend_deploy(
         user_pool_id=user_pool_id,
         client_id=allowed_client_id,
         deployment_region=region,
+        session_token=session_token,
     )
     if identity_region != region:
         click.secho(
@@ -6206,7 +6222,7 @@ def frontend_deploy(
         ensure_serverless_application_role,
     )
 
-    ensure_serverless_application_role(ak, sk)
+    ensure_serverless_application_role(ak, sk, session_token=session_token)
 
     # 2) Ensure the IAM role the function runs as (auto-create unless provided).
     if iam_role:
@@ -6216,16 +6232,13 @@ def frontend_deploy(
         from veadk.cli.frontend_deploy_iam import ensure_frontend_role
 
         click.echo("Ensuring IAM role + policy…")
-        role_trn = ensure_frontend_role(ak, sk)
+        role_trn = ensure_frontend_role(ak, sk, session_token=session_token)
         click.echo(f"IAM role ready: {role_trn}")
     # Consumed by VeFaaS._create_function as the function's Role (STS creds are
     # then injected into the instance); read via getenv from os.environ, NOT
     # shipped as a plain env var.
     os.environ["IAM_ROLE"] = role_trn
 
-    session_token = os.getenv("VOLCENGINE_SESSION_TOKEN") or os.getenv(
-        "VOLC_SESSIONTOKEN"
-    )
     sandbox_tool_ids = {
         "codex": sandbox_chat_codex_tool_id,
         "skill_creator": sandbox_skill_creator_tool_id,
@@ -6411,7 +6424,7 @@ def frontend_deploy(
     from veadk.integrations.ve_apig.ve_apig import APIGateway
 
     if not gateway_name:
-        apig = APIGateway(ak, sk, region)
+        apig = APIGateway(ak, sk, region, session_token=session_token)
         gw = apig.find_serverless_gateway()
         if gw is not None:
             gateway_name = getattr(gw, "name")
@@ -6454,6 +6467,7 @@ def frontend_deploy(
         engine = CloudAgentEngine(
             volcengine_access_key=ak,
             volcengine_secret_key=sk,
+            volcengine_session_token=session_token,
             region=region,
             project=project,
         )
@@ -6484,7 +6498,10 @@ def frontend_deploy(
                 )
 
                 IdentityClient(
-                    access_key=ak, secret_key=sk, region=identity_region
+                    access_key=ak,
+                    secret_key=sk,
+                    session_token=session_token,
+                    region=identity_region,
                 ).register_callback_for_user_pool_client(
                     user_pool_uid=user_pool_id,
                     client_uid=allowed_client_id,

--- a/veadk/cli/frontend_deploy_iam.py
+++ b/veadk/cli/frontend_deploy_iam.py
@@ -146,6 +146,7 @@ def ensure_frontend_role(
     secret_key: str,
     role_name: str = DEFAULT_ROLE_NAME,
     policy_name: str = DEFAULT_POLICY_NAME,
+    session_token: str = "",
 ) -> str:
     """Get-or-create the frontend's IAM role and return its TRN.
 
@@ -158,6 +159,8 @@ def ensure_frontend_role(
     svc = IamService()
     svc.set_ak(access_key)
     svc.set_sk(secret_key)
+    if session_token:
+        svc.set_session_token(session_token)
     _ensure_custom_policy(svc, policy_name)
 
     # Reuse an existing role if present.

--- a/veadk/cli/studio_deploy_serverless_iam.py
+++ b/veadk/cli/studio_deploy_serverless_iam.py
@@ -118,6 +118,7 @@ def _attach_role_policies(service: Any) -> None:
 def ensure_serverless_application_role(
     access_key: str,
     secret_key: str,
+    session_token: str = "",
 ) -> bool:
     """Ensure Studio's VeFaaS deployment role has its required policies.
 
@@ -133,6 +134,8 @@ def ensure_serverless_application_role(
     service = IamService()
     service.set_ak(access_key)
     service.set_sk(secret_key)
+    if session_token:
+        service.set_session_token(session_token)
 
     if _get_role(service) is not None:
         logger.info(f"IAM role {ROLE_NAME} is ready.")

--- a/veadk/cloud/cloud_agent_engine.py
+++ b/veadk/cloud/cloud_agent_engine.py
@@ -70,6 +70,9 @@ class CloudAgentEngine(BaseModel):
     volcengine_secret_key: str = getenv(
         "VOLCENGINE_SECRET_KEY", "", allow_false_values=True
     )
+    volcengine_session_token: str = getenv(
+        "VOLCENGINE_SESSION_TOKEN", "", allow_false_values=True
+    ) or getenv("VOLC_SESSIONTOKEN", "", allow_false_values=True)
     region: str = "cn-beijing"
     project: str = "default"
 
@@ -91,6 +94,7 @@ class CloudAgentEngine(BaseModel):
         self._vefaas_service = VeFaaS(
             access_key=self.volcengine_access_key,
             secret_key=self.volcengine_secret_key,
+            session_token=self.volcengine_session_token,
             region=self.region,
             project_name=self.project,
         )
@@ -98,10 +102,12 @@ class CloudAgentEngine(BaseModel):
             access_key=self.volcengine_access_key,
             secret_key=self.volcengine_secret_key,
             region=self.region,
+            session_token=self.volcengine_session_token,
         )
         self._veidentity_service = IdentityClient(
             access_key=self.volcengine_access_key,
             secret_key=self.volcengine_secret_key,
+            session_token=self.volcengine_session_token,
             region=self.region,
         )
 

--- a/veadk/integrations/ve_apig/ve_apig.py
+++ b/veadk/integrations/ve_apig/ve_apig.py
@@ -22,13 +22,21 @@ from veadk.utils.volcengine_sign import ve_request
 
 
 class APIGateway:
-    def __init__(self, access_key: str, secret_key: str, region: str = "cn-beijing"):
+    def __init__(
+        self,
+        access_key: str,
+        secret_key: str,
+        region: str = "cn-beijing",
+        session_token: str = "",
+    ):
         self.ak = access_key
         self.sk = secret_key
+        self.session_token = session_token
         self.region = region
         configuration = volcenginesdkcore.Configuration()
         configuration.ak = self.ak
         configuration.sk = self.sk
+        configuration.session_token = self.session_token
         configuration.region = region
 
         self.api_client = volcenginesdkcore.ApiClient(configuration=configuration)
@@ -197,6 +205,7 @@ class APIGateway:
             version="2021-03-03",
             region=self.region,
             host="open.volcengineapi.com",
+            session_token=self.session_token,
         )
 
         try:
@@ -233,6 +242,7 @@ class APIGateway:
             version="2021-03-03",
             region=self.region,
             host="open.volcengineapi.com",
+            session_token=self.session_token,
         )
 
         try:

--- a/veadk/integrations/ve_faas/ve_faas.py
+++ b/veadk/integrations/ve_faas/ve_faas.py
@@ -77,7 +77,12 @@ class VeFaaS:
             volcenginesdkcore.ApiClient(configuration)
         )
 
-        self.apig_client = APIGateway(self.ak, self.sk, self.region)
+        self.apig_client = APIGateway(
+            self.ak,
+            self.sk,
+            self.region,
+            session_token=self.session_token,
+        )
 
         self.template_id = _APPLICATION_TEMPLATE_IDS.get(
             region, _APPLICATION_TEMPLATE_IDS["cn-beijing"]

--- a/veadk/integrations/ve_identity/identity_client.py
+++ b/veadk/integrations/ve_identity/identity_client.py
@@ -201,7 +201,7 @@ class IdentityClient:
             True if credential is expired or will expire within 5 minutes, False otherwise.
         """
         if self._sts_credential_expires_at is None:
-            return True
+            return False
 
         import time
 


### PR DESCRIPTION
## Summary

- preserve externally supplied STS credentials when no cached expiration is available
- propagate the session token through Identity, IAM, APIG, VeFaaS, and CloudAgentEngine during Studio deployment
- support session tokens from CLI, environment variables, and the default Volcengine credential profile
- retain the existing long-term AK/SK path when no session token is provided

## Validation

- `uv run pre-commit run --all-files`
- `uv run pytest -q` (1101 passed, 6 skipped, 6 subtests passed)
- completed a from-source Studio deployment and verified the endpoint returns HTTP 200