### PR TITLE
Fix Studio release telemetry publisher imports

### DIFF
--- a/tests/cli/test_studio_telemetry.py
+++ b/tests/cli/test_studio_telemetry.py
@@ -15,13 +15,29 @@
 import pytest
 
 from veadk.cli.studio_telemetry import (
+    STUDIO_APMPLUS_DOMAIN,
+    STUDIO_APMPLUS_ENV,
     StudioTelemetryConfigurationError,
     normalize_studio_apmplus_release_environment,
     studio_apmplus_environment_from_options,
     studio_apmplus_release_environment_from_env,
     studio_telemetry_config,
 )
-from veadk.consts import STUDIO_APMPLUS_DOMAIN, STUDIO_APMPLUS_ENV
+
+
+def test_studio_telemetry_module_has_no_heavy_imports() -> None:
+    import subprocess
+    import sys
+
+    code = """
+import sys
+import veadk.cli.studio_telemetry
+assert "veadk.consts" not in sys.modules
+assert "veadk.utils.logger" not in sys.modules
+assert "veadk.utils.misc" not in sys.modules
+"""
+
+    subprocess.run([sys.executable, "-c", code], check=True)
 
 
 def test_studio_telemetry_config_builds_ui_payload_from_environment() -> None:

--- a/veadk/cli/studio_telemetry.py
+++ b/veadk/cli/studio_telemetry.py
@@ -21,24 +21,22 @@ shape here so CLI deploy, release publishing, and runtime config cannot drift.
 
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Mapping
 from typing import Any
 
-from veadk.consts import (
-    STUDIO_APMPLUS_AID,
-    STUDIO_APMPLUS_DOMAIN,
-    STUDIO_APMPLUS_ENV,
-    STUDIO_APMPLUS_TOKEN,
-)
-from veadk.utils.logger import get_logger
-
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 STUDIO_APMPLUS_AID_ENV = "VEADK_STUDIO_APMPLUS_AID"
 STUDIO_APMPLUS_TOKEN_ENV = "VEADK_STUDIO_APMPLUS_TOKEN"
 STUDIO_APMPLUS_DOMAIN_ENV = "VEADK_STUDIO_APMPLUS_DOMAIN"
 STUDIO_APMPLUS_ENV_ENV = "VEADK_STUDIO_APMPLUS_ENV"
+
+STUDIO_APMPLUS_AID = ""
+STUDIO_APMPLUS_TOKEN = ""
+STUDIO_APMPLUS_DOMAIN = "apmplus.volces.com"
+STUDIO_APMPLUS_ENV = "production"
 
 STUDIO_DEPLOY_ID_ENV = "VEADK_STUDIO_DEPLOY_ID"
 STUDIO_USER_POOL_ID_ENV = "VEADK_STUDIO_USER_POOL_ID"


### PR DESCRIPTION
## 背景

Studio release 发版时，publisher 在浅克隆源码后直接运行 `python -m veadk.cli.studio_release`。这一步还没有完整安装项目依赖。

之前 `veadk.cli.studio_package` 会 import `veadk.cli.studio_telemetry`，而 `studio_telemetry` 又 import 了 `veadk.consts` 和项目 logger，间接触发 `veadk.utils.misc -> yaml`，导致发版失败：

```text
ModuleNotFoundError: No module named yaml
```

## 修改

- 让 `veadk.cli.studio_telemetry` 保持轻量 import，不再依赖 `veadk.consts` 和 `veadk.utils.logger`。
- APMPlus 默认值直接保留在 telemetry 边界模块中。
- 新增回归测试，确保只 import `studio_telemetry` 时不会加载 `veadk.consts`、`veadk.utils.logger` 或 `veadk.utils.misc`。

## 验证

```bash
python - <<'PY'
import sys
import veadk.cli.studio_package
for name in ("yaml", "veadk.consts", "veadk.utils.misc", "veadk.utils.logger"):
    print(f"{name}={name in sys.modules}")
PY

python -m pytest tests/cli/test_studio_telemetry.py tests/cli/test_studio_release.py tests/cli/test_studio_self_update.py
pre-commit run --files veadk/cli/studio_telemetry.py tests/cli/test_studio_telemetry.py
```

结果：相关测试 43 passed，pre-commit passed。