### PR TITLE
fix(studio): isolate release server publisher

### DIFF
--- a/frontend/service/studio_release_server/builder.py
+++ b/frontend/service/studio_release_server/builder.py
@@ -534,8 +534,7 @@ class StudioReleaseBuilder:
         credentials = resolve_credentials()
         command = [
             sys.executable,
-            "-m",
-            "veadk.cli.studio_release",
+            str(Path(__file__).with_name("publisher.py")),
             "--source-root",
             str(source_root),
             "--output-dir",
@@ -555,8 +554,9 @@ class StudioReleaseBuilder:
             command.extend(("--changelog", item))
         if frontend_assets is not None:
             command.extend(("--frontend-assets", str(frontend_assets)))
-        if dependency_wheels is not None:
-            command.extend(("--dependency-wheels", str(dependency_wheels)))
+        if dependency_wheels is None:
+            raise RuntimeError("Prepared Studio dependency wheels are missing.")
+        command.extend(("--dependency-wheels", str(dependency_wheels)))
         env = os.environ.copy()
         path_entries = [str(uv.parent)]
         if node_bin is not None:
@@ -565,9 +565,6 @@ class StudioReleaseBuilder:
         env.update(
             {
                 "PATH": os.pathsep.join(path_entries),
-                "PYTHONPATH": os.pathsep.join(
-                    (str(source_root), env.get("PYTHONPATH", ""))
-                ),
                 "VOLCENGINE_ACCESS_KEY": credentials.access_key,
                 "VOLCENGINE_SECRET_KEY": credentials.secret_key,
                 "VOLCENGINE_SESSION_TOKEN": credentials.session_token,

--- a/frontend/service/studio_release_server/publisher.py
+++ b/frontend/service/studio_release_server/publisher.py
@@ -1,0 +1,516 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build and publish a Studio bundle without importing the VeADK package."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import zipfile
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+_VERSION_PATTERN = re.compile(r"^\d{14}$")
+_GIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_MAX_STUDIO_BUNDLE_BYTES = 300 * 1024 * 1024
+_MAX_STUDIO_RELEASES = 50
+_RELEASE_ENVIRONMENT_FILENAME = ".studio-release-environment.json"
+_APMPLUS_AID_ENV = "VEADK_STUDIO_APMPLUS_AID"
+_APMPLUS_TOKEN_ENV = "VEADK_STUDIO_APMPLUS_TOKEN"
+
+
+class StudioPublisherError(ValueError):
+    """Raised when a Studio release cannot be built or published."""
+
+
+@dataclass(frozen=True)
+class StudioReleaseManifest:
+    """Public metadata for one immutable Studio release bundle."""
+
+    version: str
+    git_sha: str
+    sha256: str
+    size: int
+    created_at: str
+    changelog: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        try:
+            parsed_version = datetime.strptime(self.version, "%Y%m%d%H%M%S").replace(
+                tzinfo=ZoneInfo("Asia/Shanghai")
+            )
+        except ValueError as error:
+            raise StudioPublisherError(
+                "Studio release version must use Beijing time YYYYMMDDHHMMSS."
+            ) from error
+        if not _VERSION_PATTERN.fullmatch(self.version) or parsed_version.year < 2025:
+            raise StudioPublisherError(
+                "Studio release version must use Beijing time YYYYMMDDHHMMSS."
+            )
+        if not _GIT_SHA_PATTERN.fullmatch(self.git_sha):
+            raise StudioPublisherError("Studio release gitSha must be a 40-digit SHA.")
+        if not _SHA256_PATTERN.fullmatch(self.sha256):
+            raise StudioPublisherError("Studio release sha256 is invalid.")
+        if self.size <= 0 or self.size > _MAX_STUDIO_BUNDLE_BYTES:
+            raise StudioPublisherError("Studio release bundle size is invalid.")
+        try:
+            datetime.fromisoformat(self.created_at)
+        except ValueError as error:
+            raise StudioPublisherError(
+                "Studio release createdAt is invalid."
+            ) from error
+        if len(self.changelog) > 50 or any(
+            not item.strip() or len(item) > 240 for item in self.changelog
+        ):
+            raise StudioPublisherError("Studio release changelog is invalid.")
+
+    @classmethod
+    def from_json(cls, payload: bytes | str) -> StudioReleaseManifest:
+        try:
+            raw = json.loads(payload)
+            return cls(
+                version=str(raw["version"]),
+                git_sha=str(raw["gitSha"]),
+                sha256=str(raw["sha256"]),
+                size=int(raw["size"]),
+                created_at=str(raw["createdAt"]),
+                changelog=tuple(str(item) for item in raw.get("changelog", [])),
+            )
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+            raise StudioPublisherError("Studio release manifest is invalid.") from error
+
+    def to_json(self) -> bytes:
+        data = asdict(self)
+        payload = {
+            "version": data["version"],
+            "gitSha": data["git_sha"],
+            "sha256": data["sha256"],
+            "size": data["size"],
+            "createdAt": data["created_at"],
+            "changelog": list(data["changelog"]),
+        }
+        return (json.dumps(payload, ensure_ascii=False, indent=2) + "\n").encode()
+
+
+def _normalize_prefix(prefix: str) -> str:
+    normalized = prefix.strip().strip("/")
+    if not normalized or any(part in {"", ".", ".."} for part in normalized.split("/")):
+        raise StudioPublisherError("Studio release prefix is invalid.")
+    return normalized
+
+
+def _bundle_key(prefix: str, version: str) -> str:
+    return f"{prefix}/releases/{version}/studio-bundle.zip"
+
+
+def _manifest_key(prefix: str, version: str) -> str:
+    return f"{prefix}/releases/{version}/manifest.json"
+
+
+def _latest_key(prefix: str) -> str:
+    return f"{prefix}/latest.json"
+
+
+def _catalog_key(prefix: str) -> str:
+    return f"{prefix}/releases.json"
+
+
+def _read_object(response: Any, max_bytes: int) -> bytes:
+    content = bytearray()
+    for chunk in response:
+        if len(content) + len(chunk) > max_bytes:
+            raise StudioPublisherError("Studio release manifest is too large.")
+        content.extend(chunk)
+    return bytes(content)
+
+
+def _is_not_found(error: Exception) -> bool:
+    return isinstance(error, KeyError) or getattr(error, "status_code", None) == 404
+
+
+class StudioReleaseStore:
+    """Publish immutable release objects and move the latest pointer last."""
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        region: str,
+        access_key: str,
+        secret_key: str,
+        session_token: str,
+        prefix: str,
+    ) -> None:
+        import tos
+
+        self._bucket = bucket
+        self._prefix = _normalize_prefix(prefix)
+        self._client = tos.TosClientV2(
+            access_key,
+            secret_key,
+            security_token=session_token or None,
+            endpoint=f"tos-{region}.volces.com",
+            region=region,
+        )
+
+    def publish(self, bundle: Path, manifest: StudioReleaseManifest) -> None:
+        content = bundle.read_bytes()
+        if (
+            len(content) != manifest.size
+            or hashlib.sha256(content).hexdigest() != manifest.sha256
+        ):
+            raise StudioPublisherError(
+                "Studio release bundle does not match its manifest."
+            )
+        releases = self._existing_releases()
+        if any(item.version > manifest.version for item in releases):
+            raise StudioPublisherError(
+                "Studio release version must be newer than the published releases."
+            )
+        manifest_bytes = manifest.to_json()
+        self._client.put_object(
+            bucket=self._bucket,
+            key=_bundle_key(self._prefix, manifest.version),
+            content=content,
+            content_type="application/zip",
+            forbid_overwrite=True,
+        )
+        self._client.put_object(
+            bucket=self._bucket,
+            key=_manifest_key(self._prefix, manifest.version),
+            content=manifest_bytes,
+            content_type="application/json",
+            forbid_overwrite=True,
+        )
+        releases = [item for item in releases if item.version != manifest.version]
+        releases.append(manifest)
+        releases.sort(key=lambda item: item.version, reverse=True)
+        catalog = (
+            json.dumps(
+                {
+                    "releases": [
+                        json.loads(item.to_json())
+                        for item in releases[:_MAX_STUDIO_RELEASES]
+                    ]
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n"
+        ).encode()
+        self._client.put_object(
+            bucket=self._bucket,
+            key=_catalog_key(self._prefix),
+            content=catalog,
+            content_type="application/json",
+        )
+        self._client.put_object(
+            bucket=self._bucket,
+            key=_latest_key(self._prefix),
+            content=manifest_bytes,
+            content_type="application/json",
+        )
+
+    def _existing_releases(self) -> list[StudioReleaseManifest]:
+        try:
+            response = self._client.get_object(
+                bucket=self._bucket,
+                key=_catalog_key(self._prefix),
+            )
+            raw_releases = json.loads(_read_object(response, 512 * 1024))["releases"]
+            if (
+                not isinstance(raw_releases, list)
+                or len(raw_releases) > _MAX_STUDIO_RELEASES
+            ):
+                raise StudioPublisherError("Studio release catalog is invalid.")
+            releases = [
+                StudioReleaseManifest.from_json(json.dumps(item))
+                for item in raw_releases
+            ]
+            return sorted(releases, key=lambda item: item.version, reverse=True)
+        except Exception as error:
+            if not _is_not_found(error):
+                raise
+        try:
+            response = self._client.get_object(
+                bucket=self._bucket,
+                key=_latest_key(self._prefix),
+            )
+            return [StudioReleaseManifest.from_json(_read_object(response, 64 * 1024))]
+        except Exception as error:
+            if _is_not_found(error):
+                return []
+            raise
+
+
+def _validate_source_checkout(source_root: Path) -> None:
+    required = (
+        source_root / "pyproject.toml",
+        source_root / "README.md",
+        source_root / "LICENSE",
+        source_root / "frontend" / "package.json",
+        source_root / "frontend" / "package-lock.json",
+        source_root / "veadk",
+    )
+    if not all(path.exists() for path in required):
+        raise StudioPublisherError("Release source is not a VeADK checkout.")
+
+
+def _build_frontend_assets(
+    source_root: Path,
+    output_dir: Path,
+    env: Mapping[str, str],
+) -> None:
+    npm = shutil.which("npm", path=env.get("PATH"))
+    if npm is None:
+        raise StudioPublisherError("npm is required to build the Studio frontend.")
+    try:
+        subprocess.run([npm, "ci"], cwd=source_root / "frontend", env=env, check=True)
+        subprocess.run(
+            [npm, "run", "build", "--", "--outDir", str(output_dir)],
+            cwd=source_root / "frontend",
+            env=env,
+            check=True,
+        )
+    except subprocess.CalledProcessError as error:
+        raise StudioPublisherError(
+            f"Studio frontend build failed with exit code {error.returncode}."
+        ) from error
+    if not (output_dir / "index.html").is_file():
+        raise StudioPublisherError("Studio frontend build produced no index.html.")
+
+
+def _stage_wheel_source(
+    source_root: Path,
+    frontend_assets: Path,
+    wheel_source: Path,
+) -> None:
+    wheel_source.mkdir(parents=True)
+    for filename in ("pyproject.toml", "README.md", "LICENSE"):
+        shutil.copy2(source_root / filename, wheel_source / filename)
+    git_metadata = source_root / ".git"
+    if git_metadata.is_file():
+        shutil.copy2(git_metadata, wheel_source / ".git")
+    elif git_metadata.is_dir():
+        (wheel_source / ".git").write_text(
+            f"gitdir: {git_metadata.resolve()}\n", encoding="utf-8"
+        )
+    shutil.copytree(
+        source_root / "veadk",
+        wheel_source / "veadk",
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "webui"),
+    )
+    frontend_package = wheel_source / "frontend"
+    frontend_package.mkdir()
+    shutil.copy2(source_root / "frontend" / "__init__.py", frontend_package)
+    shutil.copytree(
+        source_root / "frontend" / "server",
+        frontend_package / "server",
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+    )
+    shutil.copytree(frontend_assets, wheel_source / "veadk" / "webui")
+
+
+def _build_local_requirements(
+    source_root: Path,
+    package_dir: Path,
+    frontend_assets: Path,
+    dependency_wheels: Path,
+    env: Mapping[str, str],
+) -> str:
+    wheel_source = package_dir / "wheel-source"
+    _stage_wheel_source(source_root, frontend_assets, wheel_source)
+    uv = shutil.which("uv", path=env.get("PATH"))
+    if uv is None:
+        raise StudioPublisherError("uv is required to build the VeADK wheel.")
+    try:
+        subprocess.run(
+            [uv, "build", "--wheel", str(wheel_source), "-o", str(package_dir)],
+            env=env,
+            check=True,
+        )
+    except subprocess.CalledProcessError as error:
+        raise StudioPublisherError(
+            f"Local VeADK wheel build failed with exit code {error.returncode}."
+        ) from error
+    built_wheels = sorted(package_dir.glob("veadk*.whl"))
+    if len(built_wheels) != 1:
+        raise StudioPublisherError(
+            "Local source build did not produce one VeADK wheel."
+        )
+    dependencies: list[Path] = []
+    for source in sorted(dependency_wheels.glob("*.whl")):
+        target = package_dir / source.name
+        shutil.copy2(source, target)
+        dependencies.append(target)
+    if not dependencies:
+        raise StudioPublisherError("Prepared Studio dependency wheels are missing.")
+    shutil.rmtree(wheel_source)
+    return "".join(f"./{path.name}\n" for path in (*dependencies, built_wheels[0]))
+
+
+def _studio_run_script() -> str:
+    return (
+        "#!/bin/bash\n"
+        "set -ex\n"
+        'ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"\n'
+        'cd "$ROOT_DIR"\n'
+        'if [ -d "output" ]; then cd ./output/; fi\n'
+        "HOST=0.0.0.0\n"
+        "PORT=${_FAAS_RUNTIME_PORT:-8000}\n"
+        "export PYTHONPATH=$PYTHONPATH:./site-packages\n"
+        "exec python3 -m veadk.cli.cli studio --auth-mode frontend "
+        '--host "$HOST" --port "$PORT"\n'
+    )
+
+
+def _release_environment(environ: Mapping[str, str]) -> dict[str, str]:
+    aid = str(environ.get(_APMPLUS_AID_ENV, "") or "").strip()
+    token = str(environ.get(_APMPLUS_TOKEN_ENV, "") or "").strip()
+    if bool(aid) != bool(token):
+        raise StudioPublisherError(
+            "Studio APMPlus release environment requires both aid and token."
+        )
+    if not aid:
+        return {}
+    return {_APMPLUS_AID_ENV: aid, _APMPLUS_TOKEN_ENV: token}
+
+
+def _zip_directory(source: Path, destination: Path) -> None:
+    with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in sorted(source.rglob("*")):
+            if path.is_file():
+                archive.write(path, path.relative_to(source))
+
+
+def build_studio_release(
+    *,
+    source_root: Path,
+    output_dir: Path,
+    version: str,
+    git_sha: str,
+    changelog: tuple[str, ...],
+    frontend_assets: Path | None,
+    dependency_wheels: Path,
+    env: Mapping[str, str],
+) -> tuple[Path, StudioReleaseManifest]:
+    """Build a release while treating VeADK only as source input."""
+    _validate_source_checkout(source_root)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="studio_release_publisher_") as tmp:
+        workspace = Path(tmp)
+        resolved_frontend = frontend_assets
+        if resolved_frontend is None:
+            resolved_frontend = workspace / "frontend"
+            _build_frontend_assets(source_root, resolved_frontend, env)
+        elif not (resolved_frontend / "index.html").is_file():
+            raise StudioPublisherError(
+                "Prepared Studio frontend assets contain no index.html."
+            )
+        package_dir = workspace / "package"
+        package_dir.mkdir()
+        requirements = _build_local_requirements(
+            source_root,
+            package_dir,
+            resolved_frontend,
+            dependency_wheels,
+            env,
+        )
+        (package_dir / "run.sh").write_text(_studio_run_script(), encoding="utf-8")
+        (package_dir / "requirements.txt").write_text(requirements, encoding="utf-8")
+        release_environment = _release_environment(env)
+        if release_environment:
+            (package_dir / _RELEASE_ENVIRONMENT_FILENAME).write_text(
+                json.dumps(release_environment, ensure_ascii=True, sort_keys=True),
+                encoding="utf-8",
+            )
+        bundle = output_dir / f"studio-bundle-{version}.zip"
+        _zip_directory(package_dir, bundle)
+    content = bundle.read_bytes()
+    manifest = StudioReleaseManifest(
+        version=version,
+        git_sha=git_sha,
+        sha256=hashlib.sha256(content).hexdigest(),
+        size=len(content),
+        created_at=datetime.now(ZoneInfo("Asia/Shanghai")).isoformat(
+            timespec="seconds"
+        ),
+        changelog=changelog,
+    )
+    (output_dir / f"manifest-{version}.json").write_bytes(manifest.to_json())
+    return bundle, manifest
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-root", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--git-sha", required=True)
+    parser.add_argument("--bucket", required=True)
+    parser.add_argument("--region", required=True)
+    parser.add_argument("--prefix", required=True)
+    parser.add_argument("--changelog", action="append", default=[])
+    parser.add_argument("--frontend-assets", type=Path)
+    parser.add_argument("--dependency-wheels", type=Path, required=True)
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    bundle, manifest = build_studio_release(
+        source_root=args.source_root.resolve(),
+        output_dir=args.output_dir.resolve(),
+        version=args.version,
+        git_sha=args.git_sha,
+        changelog=tuple(args.changelog),
+        frontend_assets=args.frontend_assets,
+        dependency_wheels=args.dependency_wheels,
+        env=os.environ,
+    )
+    store = StudioReleaseStore(
+        bucket=args.bucket,
+        region=args.region,
+        access_key=os.getenv("VOLCENGINE_ACCESS_KEY", ""),
+        secret_key=os.getenv("VOLCENGINE_SECRET_KEY", ""),
+        session_token=os.getenv("VOLCENGINE_SESSION_TOKEN", ""),
+        prefix=args.prefix,
+    )
+    store.publish(bundle, manifest)
+    print(
+        json.dumps(
+            {
+                "version": manifest.version,
+                "gitSha": manifest.git_sha,
+                "sha256": manifest.sha256,
+                "size": manifest.size,
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_studio_release_server.py
+++ b/tests/test_studio_release_server.py
@@ -20,9 +20,12 @@ import hashlib
 import importlib.machinery
 import io
 import json
+import os
 import shutil
 import subprocess
+import sys
 import tarfile
+import zipfile
 from collections.abc import Callable
 from concurrent.futures import Executor, Future
 from contextlib import nullcontext
@@ -43,9 +46,10 @@ from frontend.service.studio_release_server import (
     StudioReleaseBuilder,
     create_app,
 )
+from frontend.service.studio_release_server import app as release_app
 from frontend.service.studio_release_server import builder as release_builder
 from frontend.service.studio_release_server import deploy as release_deploy
-from frontend.service.studio_release_server import app as release_app
+from frontend.service.studio_release_server import publisher as release_publisher
 from frontend.service.studio_release_server.tos_store import TosDependencyStore
 
 
@@ -458,7 +462,7 @@ def test_builder_passes_studio_apmplus_to_publisher_environment(
         changelog=("发布 Studio 更新",),
         studioApmplus={"aid": "12345", "token": "client-token"},
     )
-    captured: dict[str, dict[str, str]] = {}
+    captured: dict[str, Any] = {}
 
     monkeypatch.setattr(
         release_builder,
@@ -471,6 +475,7 @@ def test_builder_passes_studio_apmplus_to_publisher_environment(
     )
 
     def _run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        captured["command"] = command
         captured["env"] = kwargs["env"]
         return subprocess.CompletedProcess(command, 0)
 
@@ -485,12 +490,72 @@ def test_builder_passes_studio_apmplus_to_publisher_environment(
         node_bin=None,
         uv=Path("/bin/uv"),
         frontend_assets=None,
-        dependency_wheels=None,
+        dependency_wheels=tmp_path,
     )
 
     assert captured["env"]["VEADK_STUDIO_APMPLUS_AID"] == "12345"
     assert captured["env"]["VEADK_STUDIO_APMPLUS_TOKEN"] == "client-token"
     assert captured["env"]["VOLCENGINE_ACCESS_KEY"] == "release-ak"
+    assert captured["command"][1].endswith("studio_release_server/publisher.py")
+    assert "veadk.cli.studio_release" not in captured["command"]
+    assert str(tmp_path) not in captured["env"].get("PYTHONPATH", "").split(os.pathsep)
+
+
+def test_standalone_publisher_starts_without_importing_veadk() -> None:
+    publisher = Path(release_builder.__file__).with_name("publisher.py")
+
+    completed = subprocess.run(
+        [sys.executable, "-I", str(publisher), "--help"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_standalone_publisher_builds_bundle_from_source_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    frontend_assets = tmp_path / "frontend-assets"
+    frontend_assets.mkdir()
+    (frontend_assets / "index.html").write_text("studio", encoding="utf-8")
+    dependency_wheels = tmp_path / "dependencies"
+    dependency_wheels.mkdir()
+    (dependency_wheels / "dependency-1.0-py3-none-any.whl").write_bytes(b"wheel")
+
+    def _run(command: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        output_dir = Path(command[command.index("-o") + 1])
+        (output_dir / "veadk_python-1.0.0-py3-none-any.whl").write_bytes(b"veadk")
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(release_publisher.subprocess, "run", _run)
+    output_dir = tmp_path / "output"
+    bundle, manifest = release_publisher.build_studio_release(
+        source_root=Path(__file__).parents[1],
+        output_dir=output_dir,
+        version="20260805190000",
+        git_sha="a" * 40,
+        changelog=("发布 Studio 更新",),
+        frontend_assets=frontend_assets,
+        dependency_wheels=dependency_wheels,
+        env={
+            "PATH": os.environ["PATH"],
+            "VEADK_STUDIO_APMPLUS_AID": "12345",
+            "VEADK_STUDIO_APMPLUS_TOKEN": "client-token",
+        },
+    )
+
+    with zipfile.ZipFile(bundle) as archive:
+        assert archive.read("requirements.txt").decode() == (
+            "./dependency-1.0-py3-none-any.whl\n./veadk_python-1.0.0-py3-none-any.whl\n"
+        )
+        assert json.loads(archive.read(".studio-release-environment.json")) == {
+            "VEADK_STUDIO_APMPLUS_AID": "12345",
+            "VEADK_STUDIO_APMPLUS_TOKEN": "client-token",
+        }
+    assert manifest.git_sha == "a" * 40
+    assert manifest.sha256 == hashlib.sha256(bundle.read_bytes()).hexdigest()
 
 
 def test_builder_shallow_clones_only_main_build_files(
@@ -762,6 +827,7 @@ def test_stage_deployment_uses_frontend_service_package(
     assert (destination / "frontend" / "__init__.py").is_file()
     assert (destination / "frontend" / "service" / "__init__.py").is_file()
     assert (package_root / "app.py").is_file()
+    assert (package_root / "publisher.py").is_file()
     assert not (package_root / "deploy.py").exists()
     assert not (package_root / "deploy.sh").exists()
     assert not (destination / "veadk").exists()


### PR DESCRIPTION
## Summary
- add a release-server-owned standalone Studio publisher under `frontend/service/studio_release_server`
- build VeADK as source input without importing the checked-out `veadk` package into the release service runtime
- preserve offline dependency wheels, telemetry release metadata, immutable release objects, and latest catalog updates

## Validation
- `pre-commit run --all-files`
- `pytest -q` (1180 passed, 5 skipped, 6 subtests passed)
- deployed to `veadk-studio-release-server-fn` (`59uogd8d`)
- completed a real release for `f31a9bdad467763573caa0befe2d5af6ed1c0176` and verified TOS `latest.json`