### PR TITLE
fix(studio): use Beijing source for cross-region updates

### DIFF
--- a/docs/content/docs/framework/frontend.en.mdx
+++ b/docs/content/docs/framework/frontend.en.mdx
@@ -329,16 +329,15 @@ keeps that Tool ID from the deployed Function instead of clearing it.
 
 ### One-click Studio updates
 
-Configure a release channel during deployment:
+Studio reads new releases from the centrally maintained `veadk-studio` TOS
+source in `cn-beijing`; no release-region configuration is required for customer
+deployments. Administrators can update Studio directly from the navbar:
 
 ```bash
 veadk studio deploy \
   --user-pool-id <pool-id> \
   --allowed-client-id <client-id> \
-  --vefaas-app-name <app-name> \
-  --studio-update-bucket <tos-bucket> \
-  --studio-update-region cn-beijing \
-  --studio-update-prefix veadk/studio/main
+  --vefaas-app-name <app-name>
 ```
 
 Studio reads `latest.json` every three minutes. Administrators can inspect each

--- a/docs/content/docs/framework/frontend.mdx
+++ b/docs/content/docs/framework/frontend.mdx
@@ -268,16 +268,14 @@ Application。未指定 `--region` 和 `--project` 时，会在北京、上海�
 
 ### Studio 一键更新
 
-部署时配置 TOS 发布通道后，管理员可以在导航栏更新 Studio：
+Studio 固定从维护在北京地域的 `veadk-studio` TOS 发布源读取新版本，客户部署
+地域无需额外配置。管理员可以直接在导航栏更新 Studio：
 
 ```bash
 veadk studio deploy \
   --user-pool-id <pool-id> \
   --allowed-client-id <client-id> \
-  --vefaas-app-name <app-name> \
-  --studio-update-bucket <tos-bucket> \
-  --studio-update-region cn-beijing \
-  --studio-update-prefix veadk/studio/main
+  --vefaas-app-name <app-name>
 ```
 
 Studio 每 3 分钟读取一次 `latest.json`，展示新版本的 changelog 和 Git SHA。

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -215,9 +215,10 @@ local image or a downloaded network image into the VeFaaS deployment package.
 
 ## In-app Studio updates
 
-Studio deployments use the `veadk-studio` TOS bucket in the deployment region
-as their immutable release channel by default, so administrators can update the
-frontend and Python backend together from the navbar without extra options:
+Studio deployments use the centrally maintained `veadk-studio` TOS bucket in
+`cn-beijing` as their immutable release channel, regardless of the deployment
+region. Administrators can update the frontend and Python backend together from
+the navbar without extra options:
 
 ```bash
 veadk studio deploy \
@@ -225,10 +226,6 @@ veadk studio deploy \
   --allowed-client-id <client-id> \
   --vefaas-app-name <app-name>
 ```
-
-Use `--studio-update-bucket`, `--studio-update-region`, and
-`--studio-update-prefix` (or their `VEADK_STUDIO_UPDATE_*` environment
-variables) to override the default release channel.
 
 Studio checks `latest.json` every three minutes and lists newer releases with
 their changelog and Git SHA. An accepted update verifies the selected complete

--- a/frontend/service/studio_release_server/deploy.py
+++ b/frontend/service/studio_release_server/deploy.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Any
 
 import veadk.config
+from veadk.cli.studio_release import STUDIO_RELEASE_REGION
 from veadk.cloud.cloud_agent_engine import CloudAgentEngine
 
 _APPLICATION_NAME = "veadk-studio-release-server"
@@ -42,7 +43,7 @@ _GATEWAY_UPSTREAM_NAME = "veadk-studio-release-server"
 _GATEWAY_ROUTE_NAME = "veadk-studio-release-server"
 _GATEWAY_TIMEOUT_MILLISECONDS = 30 * 60 * 1000
 _BUCKET = "veadk-studio"
-_REGION = "cn-beijing"
+_REGION = STUDIO_RELEASE_REGION
 _RELEASE_PREFIX = "veadk/studio/main"
 _JOB_PREFIX = "veadk/studio/release-server/jobs"
 _REPOSITORY = "volcengine/veadk-python"

--- a/tests/cli/test_studio_deploy_target.py
+++ b/tests/cli/test_studio_deploy_target.py
@@ -360,9 +360,10 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
     assert veadk_environments["SANDBOX_SKILL_CREATOR"] == "skill-code-env-id"
     assert veadk_environments["AGENTKIT_SANDBOX_REGION"] == expected_region
     assert veadk_environments["VEADK_STUDIO_UPDATE_BUCKET"] == expected_update_bucket
-    assert veadk_environments["VEADK_STUDIO_UPDATE_REGION"] == expected_region
     assert veadk_environments["VEADK_STUDIO_UPDATE_PREFIX"] == "veadk/studio/main"
+    assert veadk_environments["VEADK_STUDIO_DEPLOY_REGION"] == expected_region
     assert veadk_environments["VEADK_STUDIO_PROJECT"] == expected_project
+    assert "VEADK_STUDIO_UPDATE_REGION" not in veadk_environments
     assert sorted(credential_tool_ids) == [
         "chat-code-env-id",
         "skill-code-env-id",

--- a/tests/cli/test_studio_self_update.py
+++ b/tests/cli/test_studio_self_update.py
@@ -27,7 +27,11 @@ from fastapi.testclient import TestClient
 
 from veadk.cli.frontend_branding import SiteLogo
 from veadk.cli.studio_package import STUDIO_RELEASE_ENVIRONMENT_FILENAME
-from veadk.cli.studio_release import StudioReleaseError, StudioReleaseManifest
+from veadk.cli.studio_release import (
+    STUDIO_RELEASE_REGION,
+    StudioReleaseError,
+    StudioReleaseManifest,
+)
 from veadk.cli.studio_self_update import (
     StudioSelfUpdater,
     StudioUpdateSettings,
@@ -81,15 +85,39 @@ def _manifest() -> StudioReleaseManifest:
     )
 
 
-def _settings() -> StudioUpdateSettings:
+def _settings(*, deployment_region: str = "cn-beijing") -> StudioUpdateSettings:
     return StudioUpdateSettings(
         bucket="studio-releases",
-        region="cn-beijing",
+        deployment_region=deployment_region,
         prefix="veadk/studio/main",
         application_id="application-id",
         function_id="function-id",
         project="default",
     )
+
+
+def test_shanghai_studio_uses_beijing_release_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class _Store:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setenv("VEADK_STUDIO_DEPLOY_REGION", "cn-shanghai")
+    monkeypatch.setenv("VEADK_STUDIO_UPDATE_REGION", "cn-shanghai")
+    monkeypatch.setattr("veadk.cli.studio_self_update.StudioReleaseStore", _Store)
+    updater = StudioSelfUpdater(
+        settings=StudioUpdateSettings.from_env(),
+        credential_resolver=lambda: ("ak", "sk", "token"),
+        branding_logo=None,
+    )
+
+    updater._store("ak", "sk", "token")
+
+    assert updater._settings.deployment_region == "cn-shanghai"
+    assert captured["region"] == STUDIO_RELEASE_REGION
 
 
 def _bundle(
@@ -186,7 +214,7 @@ def test_submit_latest_uses_fixed_deployment_ids_and_sts(
             captured["update"] = kwargs
 
     updater = StudioSelfUpdater(
-        settings=_settings(),
+        settings=_settings(deployment_region="cn-shanghai"),
         credential_resolver=lambda: ("sts-ak", "sts-sk", "sts-token"),
         branding_logo=None,
     )
@@ -200,7 +228,7 @@ def test_submit_latest_uses_fixed_deployment_ids_and_sts(
         "access_key": "sts-ak",
         "secret_key": "sts-sk",
         "session_token": "sts-token",
-        "region": "cn-beijing",
+        "region": "cn-shanghai",
         "project_name": "default",
     }
     update = captured["update"]

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -6564,12 +6564,6 @@ def _resolve_studio_cloud_credentials(
     help="TOS bucket containing immutable Studio release bundles.",
 )
 @click.option(
-    "--studio-update-region",
-    default=None,
-    envvar="VEADK_STUDIO_UPDATE_REGION",
-    help="TOS region for Studio release bundles. Defaults to --region.",
-)
-@click.option(
     "--studio-update-prefix",
     default="veadk/studio/main",
     show_default=True,
@@ -6625,7 +6619,6 @@ def frontend_deploy(
     sandbox_chat_hermes_tool_id: str | None,
     sandbox_skill_creator_tool_id: str | None,
     studio_update_bucket: str,
-    studio_update_region: str | None,
     studio_update_prefix: str,
     apmplus_aid: str,
     apmplus_token: str,
@@ -6869,7 +6862,6 @@ def frontend_deploy(
     veadk_environments["SANDBOX_CHAT_HERMES"] = hermes_tool_id
     veadk_environments["AGENTKIT_SANDBOX_REGION"] = region
     veadk_environments["VEADK_STUDIO_UPDATE_BUCKET"] = studio_update_bucket
-    veadk_environments["VEADK_STUDIO_UPDATE_REGION"] = studio_update_region or region
     veadk_environments["VEADK_STUDIO_UPDATE_PREFIX"] = studio_update_prefix
     veadk_environments["VEADK_STUDIO_PROJECT"] = project
     studio_deploy_id = _new_studio_deploy_id()

--- a/veadk/cli/studio_release.py
+++ b/veadk/cli/studio_release.py
@@ -32,6 +32,7 @@ from zoneinfo import ZoneInfo
 _VERSION_PATTERN = re.compile(r"^\d{14}$")
 _GIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 _SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+STUDIO_RELEASE_REGION = "cn-beijing"
 DEFAULT_RELEASE_PREFIX = "veadk/studio/main"
 MAX_STUDIO_BUNDLE_BYTES = 300 * 1024 * 1024
 MAX_STUDIO_RELEASES = 50
@@ -444,7 +445,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--version", required=True)
     parser.add_argument("--git-sha", required=True)
     parser.add_argument("--bucket", required=True)
-    parser.add_argument("--region", default="cn-beijing")
+    parser.add_argument("--region", default=STUDIO_RELEASE_REGION)
     parser.add_argument("--prefix", default=DEFAULT_RELEASE_PREFIX)
     parser.add_argument("--changelog", action="append", default=[])
     parser.add_argument("--frontend-assets", type=Path)

--- a/veadk/cli/studio_self_update.py
+++ b/veadk/cli/studio_self_update.py
@@ -42,6 +42,7 @@ from veadk.cli.studio_package import (
 )
 from veadk.cli.studio_release import (
     DEFAULT_RELEASE_PREFIX,
+    STUDIO_RELEASE_REGION,
     StudioReleaseError,
     StudioReleaseManifest,
     StudioReleaseStore,
@@ -85,7 +86,7 @@ class StudioUpdateSettings:
     """Immutable identifiers required to update the current Studio."""
 
     bucket: str
-    region: str
+    deployment_region: str
     prefix: str
     application_id: str
     function_id: str
@@ -96,7 +97,11 @@ class StudioUpdateSettings:
         """Load self-update settings injected during Studio deployment."""
         return cls(
             bucket=os.getenv("VEADK_STUDIO_UPDATE_BUCKET", "").strip(),
-            region=os.getenv("VEADK_STUDIO_UPDATE_REGION", "cn-beijing").strip(),
+            deployment_region=(
+                os.getenv("VEADK_STUDIO_DEPLOY_REGION")
+                or os.getenv("AGENTKIT_SANDBOX_REGION")
+                or "cn-beijing"
+            ).strip(),
             prefix=os.getenv(
                 "VEADK_STUDIO_UPDATE_PREFIX", DEFAULT_RELEASE_PREFIX
             ).strip(),
@@ -110,7 +115,7 @@ class StudioUpdateSettings:
         """Whether this deployment has all required immutable identifiers."""
         return bool(
             self.bucket
-            and self.region
+            and self.deployment_region
             and self.prefix
             and self.application_id
             and self.function_id
@@ -362,7 +367,7 @@ class StudioSelfUpdater:
                     access_key=access_key,
                     secret_key=secret_key,
                     session_token=session_token or "",
-                    region=self._settings.region,
+                    region=self._settings.deployment_region,
                     project_name=self._settings.project,
                 )
                 self._set_progress("submitting", "正在提交 VeFaaS Function 更新")
@@ -443,7 +448,7 @@ class StudioSelfUpdater:
             (
                 f"errorId={self._error_id}",
                 f"stage={failure_stage}",
-                f"region={self._settings.region}",
+                f"region={self._settings.deployment_region}",
                 f"project={self._settings.project}",
                 f"applicationId={self._settings.application_id}",
                 f"functionId={self._settings.function_id}",
@@ -485,7 +490,7 @@ class StudioSelfUpdater:
             *self._diagnostic_lines,
             f"errorId={error_id}",
             f"stage={stage}",
-            f"region={self._settings.region}",
+            f"region={self._settings.deployment_region}",
             f"project={self._settings.project}",
             f"applicationId={self._settings.application_id}",
             f"functionId={self._settings.function_id}",
@@ -537,7 +542,7 @@ class StudioSelfUpdater:
                 access_key=access_key,
                 secret_key=secret_key,
                 session_token=session_token or "",
-                region=self._settings.region,
+                region=self._settings.deployment_region,
                 project_name=self._settings.project,
             )
             raw_lines = service._get_application_logs(
@@ -561,11 +566,11 @@ class StudioSelfUpdater:
 
     def _console_url(self) -> str:
         """Return the fixed VeFaaS Function console URL for this Studio."""
-        if not self._settings.region or not self._settings.function_id:
+        if not self._settings.deployment_region or not self._settings.function_id:
             return ""
         return (
             "https://console.volcengine.com/vefaas/"
-            f"region:vefaas+{self._settings.region}/function/detail/"
+            f"region:vefaas+{self._settings.deployment_region}/function/detail/"
             f"{self._settings.function_id}"
         )
 
@@ -578,7 +583,7 @@ class StudioSelfUpdater:
             access_key=access_key,
             secret_key=secret_key,
             session_token=session_token or "",
-            region=self._settings.region,
+            region=self._settings.deployment_region,
             project_name=self._settings.project,
         )
         status, response = service._get_application_status(
@@ -662,7 +667,7 @@ class StudioSelfUpdater:
     ) -> StudioReleaseStore:
         return StudioReleaseStore(
             bucket=self._settings.bucket,
-            region=self._settings.region,
+            region=STUDIO_RELEASE_REGION,
             prefix=self._settings.prefix,
             access_key=access_key,
             secret_key=secret_key,


### PR DESCRIPTION
## Summary

- read Studio release artifacts from the centrally maintained cn-beijing TOS source
- keep VeFaaS status, logs, publishing, and console links bound to the Studio deployment region
- remove the customer-facing Studio update region option and update the deployment documentation
- cover a Shanghai Studio reading releases from Beijing while updating its Shanghai Function

## Validation

- pre-commit hooks passed
- 1178 tests passed, 6 skipped, and 6 subtests passed
- targeted Pyright checks passed