### PR TITLE
feat: support provider-specific Studio sandboxes

### DIFF
--- a/tests/cli/test_agentkit_sandbox_region.py
+++ b/tests/cli/test_agentkit_sandbox_region.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provider routing tests for Studio Sandbox sessions."""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from agentkit.platform.context import (
+    reset_default_cloud_provider,
+    set_default_cloud_provider,
+)
+from agentkit.sdk.tools.client import AgentkitToolsClient
+
+from veadk.cli.agentkit_sandbox_region import sandbox_region_candidates
+from veadk.cli.frontend_sandbox import AgentkitSandboxGateway
+
+
+def test_byteplus_sandbox_regions_never_fall_back_to_volcengine() -> None:
+    assert sandbox_region_candidates(
+        "cn-beijing",
+        provider="byteplus",
+    ) == ("ap-southeast-1",)
+
+
+@pytest.mark.asyncio
+async def test_byteplus_create_session_uses_byteplus_agentkit_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[Any, str, Any]] = []
+
+    def _call(client: Any, method_name: str, request: Any) -> SimpleNamespace:
+        calls.append((client, method_name, request))
+        return SimpleNamespace(
+            session_id="session-id",
+            endpoint="https://sandbox.byteplus.example.com",
+            user_session_id=request.user_session_id,
+        )
+
+    monkeypatch.setattr("veadk.cli.frontend_sandbox.call_session_client", _call)
+    token = set_default_cloud_provider("byteplus")
+    try:
+        gateway = AgentkitSandboxGateway(
+            lambda region: AgentkitToolsClient(
+                access_key="byteplus-ak",
+                secret_key="byteplus-sk",
+                region=region,
+            ),
+            region_candidates=sandbox_region_candidates(
+                "ap-southeast-1",
+                provider="byteplus",
+            ),
+        )
+        session = await gateway.create_session("tool-id", display_name="Dev")
+    finally:
+        reset_default_cloud_provider(token)
+
+    assert session.region == "ap-southeast-1"
+    assert len(calls) == 1
+    client, method_name, request = calls[0]
+    assert method_name == "create_session"
+    assert client.host == "agentkit.ap-southeast-1.byteplusapi.com"
+    assert client.api_version == "2025-10-30"
+    assert request.tool_id == "tool-id"

--- a/tests/cli/test_frontend_branding.py
+++ b/tests/cli/test_frontend_branding.py
@@ -156,6 +156,10 @@ def test_studio_deploy_bundles_logo_and_optional_title(
         lambda **kwargs: f"auto-{kwargs['name']}",
     )
     monkeypatch.setattr(
+        "veadk.cli.studio_sandbox_tools.ensure_studio_dev_env_tool",
+        lambda **kwargs: f"auto-{kwargs['name']}",
+    )
+    monkeypatch.setattr(
         "veadk.cli.studio_sandbox_tools.ensure_studio_agent_model_credential",
         lambda **_: None,
     )

--- a/tests/cli/test_frontend_skill_creator.py
+++ b/tests/cli/test_frontend_skill_creator.py
@@ -329,38 +329,43 @@ def test_archive_metadata_rejects_symlink_entry() -> None:
         SkillCreatorService(tool_id="tool-id")._archive_metadata(output.getvalue())
 
 
-def test_model_credential_is_bound_directly_to_tool() -> None:
+@pytest.mark.parametrize(
+    ("provider", "expected_base_url", "expected_model_provider"),
+    [
+        ("volcengine", _MODEL_BASE_URL, "model_square"),
+        (
+            "byteplus",
+            "https://ark.ap-southeast.bytepluses.com/api/v3",
+            "byteplus_model_square",
+        ),
+    ],
+)
+def test_model_credential_is_bound_directly_to_tool(
+    provider: str,
+    expected_base_url: str,
+    expected_model_provider: str,
+) -> None:
     access_key = os.urandom(16).hex()
     model_api_key = os.urandom(24).hex()
     secret_key = os.urandom(24).hex()
-    calls: list[tuple[str, dict[str, object]]] = []
+    updates: list[object] = []
+    client = SimpleNamespace(
+        get_tool=lambda _: SimpleNamespace(
+            envs=[SimpleNamespace(key="EXISTING_ENV", value="preserved")]
+        ),
+        update_tool=updates.append,
+    )
 
-    class FakeApi:
-        def call(
-            self,
-            _service: str,
-            action: str,
-            _version: str,
-            body: dict[str, object],
-        ) -> dict[str, object]:
-            calls.append((action, body))
-            if action == "GetTool":
-                return {
-                    "Tool": {"Envs": [{"Key": "EXISTING_ENV", "Value": "preserved"}]}
-                }
-            return {}
-
-    with (
-        patch("agentkit.auth._openapi.OpenApiClient", return_value=FakeApi()),
-        patch(
-            "veadk.auth.veauth.ark_veauth.get_ark_token",
-            return_value=model_api_key,
-        ) as get_ark_token,
-    ):
+    with patch(
+        "veadk.auth.veauth.ark_veauth.get_ark_token",
+        return_value=model_api_key,
+    ) as get_ark_token:
         ensure_skill_creator_model_credential(
             tool_id="tool-id",
             access_key=access_key,
             secret_key=secret_key,
+            provider=provider,
+            client=client,
         )
 
     get_ark_token.assert_called_once_with(
@@ -369,15 +374,42 @@ def test_model_credential_is_bound_directly_to_tool() -> None:
         secret_key=secret_key,
         session_token=None,
     )
-    assert [action for action, _ in calls] == ["GetTool", "UpdateTool"]
-    update_body = calls[1][1]
+    assert len(updates) == 1
     envs = {
-        item["Key"]: item["Value"]
-        for item in cast(list[dict[str, str]], update_body["Envs"])
+        item.key: item.value for item in cast(list[Any], getattr(updates[0], "envs"))
     }
     assert envs["EXISTING_ENV"] == "preserved"
     assert envs["CODEX_API_KEY"] == model_api_key
-    assert envs["CODEX_BASE_URL"] == _MODEL_BASE_URL
+    assert envs["CODEX_BASE_URL"] == expected_base_url
+    assert envs["AGENTKIT_SANDBOX_MODEL_PROVIDER"] == expected_model_provider
+
+
+def test_code_env_credential_accepts_a_provider_specific_default_model() -> None:
+    updates: list[object] = []
+    client = SimpleNamespace(
+        get_tool=lambda _: SimpleNamespace(envs=[]),
+        update_tool=updates.append,
+    )
+
+    with patch(
+        "veadk.auth.veauth.ark_veauth.get_ark_token",
+        return_value=os.urandom(24).hex(),
+    ):
+        ensure_skill_creator_model_credential(
+            tool_id="codex-tool-id",
+            access_key=os.urandom(16).hex(),
+            secret_key=os.urandom(24).hex(),
+            provider="byteplus",
+            model_name="seed-2-0-lite-260228",
+            client=client,
+        )
+
+    envs = {
+        item.key: item.value for item in cast(list[Any], getattr(updates[0], "envs"))
+    }
+    assert envs["CODEX_MODEL"] == "seed-2-0-lite-260228"
+    assert envs["OPENCODE_MODEL"] == "seed-2-0-lite-260228"
+    assert envs["ANTHROPIC_MODEL"] == "seed-2-0-lite-260228"
 
 
 def test_candidate_session_never_overrides_tool_model_credential(monkeypatch) -> None:
@@ -468,6 +500,7 @@ def test_skill_creator_reads_only_dedicated_sandbox_tool_env(monkeypatch) -> Non
 
 
 def test_skill_creator_uses_configured_sandbox_region(monkeypatch) -> None:
+    monkeypatch.setenv("AGENTKIT_CLOUD_PROVIDER", "volcengine")
     monkeypatch.setenv("AGENTKIT_SANDBOX_REGION", "cn-shanghai")
     tool = SimpleNamespace(
         tool_type="CodeEnv",
@@ -485,7 +518,8 @@ def test_skill_creator_uses_configured_sandbox_region(monkeypatch) -> None:
     client_class.assert_called_once_with(region="cn-shanghai")
 
 
-def test_skill_creator_retries_tool_lookup_in_shanghai() -> None:
+def test_skill_creator_retries_tool_lookup_in_shanghai(monkeypatch) -> None:
+    monkeypatch.setenv("AGENTKIT_CLOUD_PROVIDER", "volcengine")
     regions: list[str] = []
     tool = SimpleNamespace(
         tool_type="CodeEnv",

--- a/tests/cli/test_studio_deploy_serverless_iam.py
+++ b/tests/cli/test_studio_deploy_serverless_iam.py
@@ -212,6 +212,10 @@ def test_studio_deploy_checks_serverless_role_with_custom_function_role(
         lambda **kwargs: f"auto-{kwargs['name']}",
     )
     monkeypatch.setattr(
+        "veadk.cli.studio_sandbox_tools.ensure_studio_dev_env_tool",
+        lambda **kwargs: f"auto-{kwargs['name']}",
+    )
+    monkeypatch.setattr(
         "veadk.cli.studio_sandbox_tools.ensure_studio_agent_model_credential",
         lambda **_: None,
     )

--- a/tests/cli/test_studio_deploy_target.py
+++ b/tests/cli/test_studio_deploy_target.py
@@ -50,6 +50,7 @@ def _skip_serverless_role_setup(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("SANDBOX_CHAT_OPENCLAW", raising=False)
     monkeypatch.delenv("SANDBOX_CHAT_HERMES", raising=False)
     monkeypatch.delenv("SANDBOX_SKILL_CREATOR", raising=False)
+    monkeypatch.delenv("SANDBOX_DEV", raising=False)
     monkeypatch.setattr(
         "veadk.cli.studio_deploy_serverless_iam.ensure_serverless_application_role",
         lambda *_, **__: None,
@@ -60,6 +61,10 @@ def _skip_serverless_role_setup(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(
         "veadk.cli.studio_sandbox_tools.ensure_studio_agent_tool",
+        lambda **kwargs: f"auto-{kwargs['name']}",
+    )
+    monkeypatch.setattr(
+        "veadk.cli.studio_sandbox_tools.ensure_studio_dev_env_tool",
         lambda **kwargs: f"auto-{kwargs['name']}",
     )
     monkeypatch.setattr(
@@ -370,6 +375,8 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
             "client-id",
             "--vefaas-app-name",
             "studio-app",
+            "--sandbox-dev-tool-id",
+            "dev-env-id",
             "--sandbox-chat-codex-tool-id",
             "chat-code-env-id",
             "--sandbox-chat-openclaw-tool-id",
@@ -413,6 +420,7 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
     assert veadk_environments["SANDBOX_CHAT_OPENCLAW"] == "openclaw-tool-id"
     assert veadk_environments["SANDBOX_CHAT_HERMES"] == "hermes-tool-id"
     assert veadk_environments["SANDBOX_SKILL_CREATOR"] == "skill-code-env-id"
+    assert veadk_environments["SANDBOX_DEV"] == "dev-env-id"
     assert veadk_environments["AGENTKIT_SANDBOX_REGION"] == expected_region
     assert veadk_environments["VEADK_STUDIO_UPDATE_BUCKET"] == expected_update_bucket
     assert veadk_environments["VEADK_STUDIO_UPDATE_PREFIX"] == "veadk/studio/main"
@@ -421,6 +429,7 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
     assert "VEADK_STUDIO_UPDATE_REGION" not in veadk_environments
     assert sorted(credential_tool_ids) == [
         "chat-code-env-id",
+        "dev-env-id",
         "skill-code-env-id",
     ]
     assert f"{expected_region}/{expected_project}" in result.output
@@ -721,10 +730,14 @@ def test_studio_deploy_byteplus_wires_provider_to_cloud_engine_and_package(
     ]
 
 
-def test_studio_deploy_byteplus_skips_sandbox_auto_provisioning(
+def test_studio_deploy_byteplus_auto_provisions_four_sandbox_tools(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, object] = {}
+    code_tools: list[str] = []
+    agent_tools: list[dict[str, object]] = []
+    code_credentials: list[dict[str, object]] = []
+    agent_credentials: list[dict[str, object]] = []
 
     class _FakeCloudAgentEngine:
         def __init__(self, **kwargs: object) -> None:
@@ -744,8 +757,14 @@ def test_studio_deploy_byteplus_skips_sandbox_auto_provisioning(
         def register_callback_for_user_pool_client(self, **kwargs: object) -> None:
             captured["callback"] = kwargs
 
-    def _fail_auto_provision(*_: object, **__: object) -> None:
-        raise AssertionError("BytePlus deploy must not auto-provision sandbox tools")
+    def _ensure_code_tool(**kwargs: object) -> str:
+        name = str(kwargs["name"])
+        code_tools.append(name)
+        return "chat-tool" if "-chat-" in name else "skill-tool"
+
+    def _ensure_agent_tool(**kwargs: object) -> str:
+        agent_tools.append(kwargs)
+        return f"{kwargs['kind']}-tool"
 
     monkeypatch.setattr(
         "veadk.cloud.cloud_agent_engine.CloudAgentEngine", _FakeCloudAgentEngine
@@ -760,19 +779,19 @@ def test_studio_deploy_byteplus_skips_sandbox_auto_provisioning(
     )
     monkeypatch.setattr(
         "veadk.cli.studio_sandbox_tools.ensure_studio_code_env_tool",
-        _fail_auto_provision,
+        _ensure_code_tool,
     )
     monkeypatch.setattr(
         "veadk.cli.studio_sandbox_tools.ensure_studio_agent_tool",
-        _fail_auto_provision,
+        _ensure_agent_tool,
     )
     monkeypatch.setattr(
         "veadk.cli.frontend_skill_creator.ensure_skill_creator_model_credential",
-        _fail_auto_provision,
+        lambda **kwargs: code_credentials.append(kwargs),
     )
     monkeypatch.setattr(
         "veadk.cli.studio_sandbox_tools.ensure_studio_agent_model_credential",
-        _fail_auto_provision,
+        lambda **kwargs: agent_credentials.append(kwargs),
     )
 
     result = CliRunner().invoke(
@@ -801,13 +820,24 @@ def test_studio_deploy_byteplus_skips_sandbox_auto_provisioning(
     )
 
     assert result.exit_code == 0, result.output
-    assert (
-        "Skipping AgentKit Codex Tool auto-provisioning for BytePlus" in result.output
+    assert len(code_tools) == 2
+    assert {str(call["kind"]) for call in agent_tools} == {"openclaw", "hermes"}
+    assert {str(call["model_name"]) for call in agent_tools} == {"seed-2-0-lite-260228"}
+    assert {str(call["provider"]) for call in code_credentials} == {"byteplus"}
+    code_credentials_by_tool = {str(call["tool_id"]): call for call in code_credentials}
+    assert code_credentials_by_tool["chat-tool"]["model_name"] == (
+        "seed-2-0-lite-260228"
     )
-    assert veadk_environments["SANDBOX_CHAT_CODEX"] == ""
-    assert veadk_environments["SANDBOX_SKILL_CREATOR"] == ""
-    assert veadk_environments["SANDBOX_CHAT_OPENCLAW"] == ""
-    assert veadk_environments["SANDBOX_CHAT_HERMES"] == ""
+    assert code_credentials_by_tool["skill-tool"]["model_name"] is None
+    assert {str(call["provider"]) for call in agent_credentials} == {"byteplus"}
+    assert {str(call["model_base_url"]) for call in agent_credentials} == {
+        "https://ark.ap-southeast.bytepluses.com/api/v3"
+    }
+    assert veadk_environments["SANDBOX_CHAT_CODEX"] == "chat-tool"
+    assert veadk_environments["SANDBOX_SKILL_CREATOR"] == "skill-tool"
+    assert veadk_environments["SANDBOX_CHAT_OPENCLAW"] == "openclaw-tool"
+    assert veadk_environments["SANDBOX_CHAT_HERMES"] == "hermes-tool"
+    assert "SANDBOX_DEV" not in veadk_environments
 
 
 def test_studio_deploy_byteplus_rejects_invalid_application_name() -> None:
@@ -945,7 +975,7 @@ def test_studio_deploy_creates_distinct_sandbox_tools_when_ids_are_omitted(
     credential_tool_ids: list[str] = []
     agent_tool_kinds: list[str] = []
     agent_credential_kinds: list[str] = []
-    creation_barrier = threading.Barrier(4)
+    creation_barrier = threading.Barrier(5)
     created_kinds_lock = threading.Lock()
 
     class _FakeCloudAgentEngine:
@@ -975,12 +1005,18 @@ def test_studio_deploy_creates_distinct_sandbox_tools_when_ids_are_omitted(
         agent_tool_kinds.append(kind)
         return f"{kind}-tool"
 
+    def _ensure_dev_tool(**_: object) -> str:
+        creation_barrier.wait(timeout=5)
+        with created_kinds_lock:
+            created_kinds.append("dev")
+        return "dev-tool"
+
     def _ensure_code_credential(**kwargs: object) -> None:
-        assert len(created_kinds) == 4
+        assert len(created_kinds) == 5
         credential_tool_ids.append(str(kwargs["tool_id"]))
 
     def _ensure_agent_credential(**kwargs: object) -> None:
-        assert len(created_kinds) == 4
+        assert len(created_kinds) == 5
         agent_credential_kinds.append(str(kwargs["kind"]))
 
     monkeypatch.setattr(
@@ -996,6 +1032,10 @@ def test_studio_deploy_creates_distinct_sandbox_tools_when_ids_are_omitted(
     monkeypatch.setattr(
         "veadk.cli.studio_sandbox_tools.ensure_studio_agent_tool",
         _ensure_agent_tool,
+    )
+    monkeypatch.setattr(
+        "veadk.cli.studio_sandbox_tools.ensure_studio_dev_env_tool",
+        _ensure_dev_tool,
     )
     monkeypatch.setattr(
         "veadk.cli.studio_sandbox_tools.ensure_studio_agent_model_credential",
@@ -1030,18 +1070,20 @@ def test_studio_deploy_creates_distinct_sandbox_tools_when_ids_are_omitted(
     assert result.exit_code == 0, result.output
     assert sorted(created_kinds) == [
         "codex",
+        "dev",
         "hermes",
         "openclaw",
         "skill_creator",
     ]
     assert veadk_environments["SANDBOX_CHAT_CODEX"] == "chat-tool"
     assert veadk_environments["SANDBOX_SKILL_CREATOR"] == "skill-tool"
-    assert sorted(credential_tool_ids) == ["chat-tool", "skill-tool"]
+    assert sorted(credential_tool_ids) == ["chat-tool", "dev-tool", "skill-tool"]
     assert sorted(agent_tool_kinds) == ["hermes", "openclaw"]
     assert sorted(agent_credential_kinds) == ["hermes", "openclaw"]
     assert veadk_environments["SANDBOX_CHAT_OPENCLAW"] == "openclaw-tool"
     assert veadk_environments["SANDBOX_CHAT_HERMES"] == "hermes-tool"
-    for label in ("Codex", "Skill Creator", "OpenClaw", "Hermes"):
+    assert veadk_environments["SANDBOX_DEV"] == "dev-tool"
+    for label in ("Codex", "Skill Creator", "OpenClaw", "Hermes", "Dev Sandbox"):
         assert f"Creating AgentKit {label} Tool" in result.output
         assert f"AgentKit {label} Tool is ready." in result.output
         assert f"Creating AgentKit {label} model credential" in result.output

--- a/tests/cli/test_studio_sandbox_tools.py
+++ b/tests/cli/test_studio_sandbox_tools.py
@@ -25,6 +25,9 @@ from veadk.cli.studio_sandbox_tools import (
     ensure_studio_agent_model_credential,
     ensure_studio_agent_tool,
     ensure_studio_code_env_tool,
+    ensure_studio_dev_env_tool,
+    studio_sandbox_agent_model_name,
+    studio_sandbox_model_base_url,
 )
 
 
@@ -87,6 +90,27 @@ def test_ensure_studio_code_env_tool_creates_ready_code_env() -> None:
     assert getattr(request, "envs") is None
 
 
+def test_ensure_studio_dev_env_tool_creates_ready_dev_env() -> None:
+    requests: list[object] = []
+    client = SimpleNamespace(
+        list_tools=lambda _: SimpleNamespace(tools=[], next_token=None),
+        get_tool=lambda _: SimpleNamespace(status="Ready"),
+        create_tool=lambda request: (
+            requests.append(request) or SimpleNamespace(tool_id="dev-tool")
+        ),
+    )
+
+    assert (
+        ensure_studio_dev_env_tool(
+            name="veadk-studio-demo-dev-12345678",
+            client=client,
+            timeout_seconds=0,
+        )
+        == "dev-tool"
+    )
+    assert getattr(requests[0], "tool_type") == "DevEnv"
+
+
 @pytest.mark.parametrize(
     ("kind", "tool_type"),
     [("openclaw", "ArkClawEnv"), ("hermes", "HermesEnv")],
@@ -124,27 +148,17 @@ def test_agent_model_credential_is_bound_to_tool_as_complete_env_set() -> None:
     access_key = os.urandom(16).hex()
     model_api_key = os.urandom(24).hex()
     secret_key = os.urandom(24).hex()
-    calls: list[tuple[str, dict[str, object]]] = []
-
-    class FakeApi:
-        def call(
-            self,
-            _service: str,
-            action: str,
-            _version: str,
-            body: dict[str, object],
-        ) -> dict[str, object]:
-            calls.append((action, body))
-            if action == "GetTool":
-                return {"Tool": {"Envs": [{"Key": "EXISTING_ENV", "Value": "kept"}]}}
-            return {}
-
-    with (
-        patch("agentkit.auth._openapi.OpenApiClient", return_value=FakeApi()),
-        patch(
-            "veadk.auth.veauth.ark_veauth.get_ark_token",
-            return_value=model_api_key,
+    updates: list[object] = []
+    client = SimpleNamespace(
+        get_tool=lambda _: SimpleNamespace(
+            envs=[SimpleNamespace(key="EXISTING_ENV", value="kept")]
         ),
+        update_tool=updates.append,
+    )
+
+    with patch(
+        "veadk.auth.veauth.ark_veauth.get_ark_token",
+        return_value=model_api_key,
     ):
         ensure_studio_agent_model_credential(
             tool_id="tool-openclaw",
@@ -152,11 +166,13 @@ def test_agent_model_credential_is_bound_to_tool_as_complete_env_set() -> None:
             model_name="doubao-seed-evolving",
             access_key=access_key,
             secret_key=secret_key,
+            client=client,
         )
 
-    assert [action for action, _ in calls] == ["GetTool", "UpdateTool"]
-    updated_envs = cast(list[dict[str, str]], calls[1][1]["Envs"])
-    envs = {item["Key"]: item["Value"] for item in updated_envs}
+    assert len(updates) == 1
+    assert getattr(updates[0], "model_agent_name") == "doubao-seed-evolving"
+    updated_envs = cast(list[object], getattr(updates[0], "envs"))
+    envs = {getattr(item, "key"): getattr(item, "value") for item in updated_envs}
     assert envs == {
         "EXISTING_ENV": "kept",
         "MODEL_AGENT_API_KEY": model_api_key,
@@ -164,3 +180,16 @@ def test_agent_model_credential_is_bound_to_tool_as_complete_env_set() -> None:
         "MODEL_AGENT_BASE_URL": "https://ark.cn-beijing.volces.com/api/v3",
         "ARK_BASE_URL": "https://ark.cn-beijing.volces.com/api/v3",
     }
+
+
+def test_byteplus_agent_model_configuration() -> None:
+    assert studio_sandbox_agent_model_name("byteplus") == "seed-2-0-lite-260228"
+    assert studio_sandbox_model_base_url("byteplus") == (
+        "https://ark.ap-southeast.bytepluses.com/api/v3"
+    )
+
+
+def test_volcengine_agent_model_configuration() -> None:
+    assert studio_sandbox_agent_model_name("volcengine") == (
+        "doubao-seed-2-1-pro-260628"
+    )

--- a/tests/cli/test_studio_update.py
+++ b/tests/cli/test_studio_update.py
@@ -652,6 +652,8 @@ def test_studio_update_only_overrides_explicit_sandbox_tool_id(
             str(tmp_path),
             "--sandbox-chat-codex-tool-id",
             "chat-tool-new",
+            "--sandbox-dev-tool-id",
+            "dev-tool-new",
             "--volcengine-access-key",
             "ak",
             "--volcengine-secret-key",
@@ -663,6 +665,7 @@ def test_studio_update_only_overrides_explicit_sandbox_tool_id(
     assert captured["environment_overrides"] == {
         "AGENTKIT_SANDBOX_REGION": "cn-beijing",
         "SANDBOX_CHAT_CODEX": "chat-tool-new",
+        "SANDBOX_DEV": "dev-tool-new",
     }
 
 

--- a/veadk/cli/agentkit_sandbox_region.py
+++ b/veadk/cli/agentkit_sandbox_region.py
@@ -14,13 +14,35 @@
 
 """Shared AgentKit Sandbox region selection."""
 
+import os
+
 _SANDBOX_REGIONS = ("cn-beijing", "cn-shanghai")
+_BYTEPLUS_SANDBOX_REGIONS = ("ap-southeast-1",)
 _RESOURCE_NOT_FOUND_CODE = "InvalidResource.NotFound"
 
 
-def sandbox_region_candidates(preferred: str | None = None) -> tuple[str, ...]:
-    first = (preferred or _SANDBOX_REGIONS[0]).strip() or _SANDBOX_REGIONS[0]
-    return (first, *tuple(region for region in _SANDBOX_REGIONS if region != first))
+def sandbox_region_candidates(
+    preferred: str | None = None,
+    *,
+    provider: str | None = None,
+) -> tuple[str, ...]:
+    provider_id = (
+        (
+            provider
+            or os.getenv("AGENTKIT_CLOUD_PROVIDER")
+            or os.getenv("CLOUD_PROVIDER")
+            or "volcengine"
+        )
+        .strip()
+        .lower()
+    )
+    regions = (
+        _BYTEPLUS_SANDBOX_REGIONS if provider_id == "byteplus" else _SANDBOX_REGIONS
+    )
+    first = (preferred or regions[0]).strip() or regions[0]
+    if provider_id == "byteplus" and first not in regions:
+        first = regions[0]
+    return (first, *tuple(region for region in regions if region != first))
 
 
 def is_agentkit_resource_not_found(error: object) -> bool:

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -1420,7 +1420,8 @@ def _run_frontend_server(
     sandbox_gateway = AgentkitSandboxGateway(
         _sandbox_client,
         region_candidates=sandbox_region_candidates(
-            os.getenv("AGENTKIT_SANDBOX_REGION")
+            os.getenv("AGENTKIT_SANDBOX_REGION"),
+            provider=provider,
         ),
     )
     sandbox_service = SandboxConversationService(
@@ -7187,6 +7188,14 @@ def _resolve_studio_cloud_credentials(
     help="Comma-separated Studio developer usernames or OAuth emails.",
 )
 @click.option(
+    "--sandbox-dev-tool-id",
+    "sandbox_dev_tool_id",
+    default=None,
+    envvar="SANDBOX_DEV",
+    help="Dedicated ready AgentKit DevEnv Tool ID for Studio development. "
+    "Volcengine default: create one during deployment.",
+)
+@click.option(
     "--sandbox-chat-codex-tool-id",
     "sandbox_chat_codex_tool_id",
     default=None,
@@ -7283,6 +7292,7 @@ def frontend_deploy(
     site_title: str | None,
     studio_admins: str | None,
     studio_developers: str | None,
+    sandbox_dev_tool_id: str | None,
     sandbox_chat_codex_tool_id: str | None,
     sandbox_chat_openclaw_tool_id: str | None,
     sandbox_chat_hermes_tool_id: str | None,
@@ -7411,43 +7421,44 @@ def frontend_deploy(
         "openclaw": sandbox_chat_openclaw_tool_id,
         "hermes": sandbox_chat_hermes_tool_id,
     }
+    if provider_id == "volcengine":
+        sandbox_tool_ids["dev"] = sandbox_dev_tool_id
+    elif sandbox_dev_tool_id:
+        raise click.ClickException(
+            "--sandbox-dev-tool-id is supported only for Volcengine Studio deployments."
+        )
     sandbox_tool_labels = {
         "codex": "Codex",
         "skill_creator": "Skill Creator",
         "openclaw": "OpenClaw",
         "hermes": "Hermes",
+        "dev": "Dev Sandbox",
     }
     sandbox_tool_purposes = {
         "codex": "chat",
         "skill_creator": "skill",
         "openclaw": "openclaw",
         "hermes": "hermes",
-    }
-    sandbox_tool_flags = {
-        "codex": "--sandbox-chat-codex-tool-id",
-        "skill_creator": "--sandbox-skill-creator-tool-id",
-        "openclaw": "--sandbox-chat-openclaw-tool-id",
-        "hermes": "--sandbox-chat-hermes-tool-id",
+        "dev": "dev",
     }
     from veadk.cli.studio_sandbox_tools import (
-        STUDIO_SANDBOX_AGENT_MODEL_NAME,
         ensure_studio_agent_model_credential,
         ensure_studio_agent_tool,
         ensure_studio_code_env_tool,
+        ensure_studio_dev_env_tool,
+        studio_sandbox_agent_model_name,
+        studio_sandbox_model_base_url,
         studio_sandbox_tool_name,
     )
+
+    sandbox_agent_model_name = studio_sandbox_agent_model_name(provider_id)
+    sandbox_model_base_url = studio_sandbox_model_base_url(provider_id)
 
     missing_sandbox_tools: dict[str, str] = {}
     for kind, tool_id in sandbox_tool_ids.items():
         label = sandbox_tool_labels[kind]
         if tool_id:
             click.echo(f"Using configured AgentKit {label} Tool '{tool_id}'.")
-            continue
-        if provider_id == "byteplus":
-            click.echo(
-                f"Skipping AgentKit {label} Tool auto-provisioning for BytePlus. "
-                f"Pass {sandbox_tool_flags[kind]} to enable it."
-            )
             continue
         tool_name = studio_sandbox_tool_name(
             vefaas_app_name,
@@ -7469,12 +7480,21 @@ def frontend_deploy(
                         secret_key=sk,
                         session_token=session_token or "",
                     )
+                elif kind == "dev":
+                    future = executor.submit(
+                        ensure_studio_dev_env_tool,
+                        name=tool_name,
+                        region=region,
+                        access_key=ak,
+                        secret_key=sk,
+                        session_token=session_token or "",
+                    )
                 else:
                     future = executor.submit(
                         ensure_studio_agent_tool,
                         name=tool_name,
                         kind=kind,
-                        model_name=STUDIO_SANDBOX_AGENT_MODEL_NAME,
+                        model_name=sandbox_agent_model_name,
                         region=region,
                         access_key=ak,
                         secret_key=sk,
@@ -7504,8 +7524,6 @@ def frontend_deploy(
     resolved_sandbox_tool_ids: dict[str, str] = {}
     for kind, tool_id in sandbox_tool_ids.items():
         if not tool_id:
-            if provider_id == "byteplus":
-                continue
             raise click.ClickException(
                 f"AgentKit {sandbox_tool_labels[kind]} Tool did not return a Tool ID."
             )
@@ -7519,7 +7537,8 @@ def frontend_deploy(
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         credential_futures = {}
         for kind, tool_id in resolved_sandbox_tool_ids.items():
-            if kind in {"codex", "skill_creator"}:
+            if kind in {"codex", "skill_creator", "dev"}:
+                code_model_name = sandbox_agent_model_name if kind == "codex" else None
                 future = executor.submit(
                     ensure_skill_creator_model_credential,
                     tool_id=tool_id,
@@ -7527,17 +7546,21 @@ def frontend_deploy(
                     access_key=ak,
                     secret_key=sk,
                     session_token=session_token,
+                    provider=provider_id,
+                    model_name=code_model_name,
                 )
             else:
                 future = executor.submit(
                     ensure_studio_agent_model_credential,
                     tool_id=tool_id,
                     kind=kind,
-                    model_name=STUDIO_SANDBOX_AGENT_MODEL_NAME,
+                    model_name=sandbox_agent_model_name,
+                    model_base_url=sandbox_model_base_url,
                     region=region,
                     access_key=ak,
                     secret_key=sk,
                     session_token=session_token,
+                    provider=provider_id,
                 )
             credential_futures[kind] = future
 
@@ -7560,6 +7583,7 @@ def frontend_deploy(
     skill_creator_tool_id = resolved_sandbox_tool_ids.get("skill_creator", "")
     openclaw_tool_id = resolved_sandbox_tool_ids.get("openclaw", "")
     hermes_tool_id = resolved_sandbox_tool_ids.get("hermes", "")
+    dev_tool_id = resolved_sandbox_tool_ids.get("dev", "")
 
     # SECURITY: VeFaaS._create_function uploads *everything* in veadk_environments
     # (i.e. the deployer's whole .env) as function env vars. The frontend must
@@ -7604,6 +7628,8 @@ def frontend_deploy(
     veadk_environments["SANDBOX_SKILL_CREATOR"] = skill_creator_tool_id
     veadk_environments["SANDBOX_CHAT_OPENCLAW"] = openclaw_tool_id
     veadk_environments["SANDBOX_CHAT_HERMES"] = hermes_tool_id
+    if provider_id == "volcengine":
+        veadk_environments["SANDBOX_DEV"] = dev_tool_id
     veadk_environments["AGENTKIT_SANDBOX_REGION"] = region
     veadk_environments["VEADK_STUDIO_UPDATE_BUCKET"] = studio_update_bucket
     veadk_environments["VEADK_STUDIO_UPDATE_PREFIX"] = studio_update_prefix
@@ -7824,6 +7850,12 @@ def frontend_deploy(
     help="Replace the deployed Studio title, at most 6 characters.",
 )
 @click.option(
+    "--sandbox-dev-tool-id",
+    "sandbox_dev_tool_id",
+    default=None,
+    help="Replace the Volcengine Studio DevEnv Tool ID.",
+)
+@click.option(
     "--sandbox-chat-codex-tool-id",
     "sandbox_chat_codex_tool_id",
     default=None,
@@ -7862,6 +7894,7 @@ def frontend_update(
     path: Path,
     site_logo: str | None,
     site_title: str | None,
+    sandbox_dev_tool_id: str | None,
     sandbox_chat_codex_tool_id: str | None,
     sandbox_chat_openclaw_tool_id: str | None,
     sandbox_chat_hermes_tool_id: str | None,
@@ -7889,6 +7922,10 @@ def frontend_update(
 
     provider_id = normalize_cloud_provider(provider)
     if provider_id == "byteplus":
+        if sandbox_dev_tool_id is not None:
+            raise click.ClickException(
+                "--sandbox-dev-tool-id is supported only for Volcengine Studio updates."
+            )
         if region is not None and region != DEFAULT_BYTEPLUS_REGION:
             raise click.ClickException(
                 "BytePlus Studio update currently supports only "
@@ -7996,6 +8033,8 @@ def frontend_update(
             environment_overrides["DATABASE_VIKING_REGION"] = DEFAULT_BYTEPLUS_REGION
         if branding_title is not None:
             environment_overrides["VEADK_SITE_TITLE"] = branding_title
+        if sandbox_dev_tool_id is not None:
+            environment_overrides["SANDBOX_DEV"] = sandbox_dev_tool_id
         if sandbox_chat_codex_tool_id is not None:
             environment_overrides["SANDBOX_CHAT_CODEX"] = sandbox_chat_codex_tool_id
         if sandbox_chat_openclaw_tool_id is not None:

--- a/veadk/cli/frontend_skill_creator.py
+++ b/veadk/cli/frontend_skill_creator.py
@@ -64,6 +64,8 @@ _MODELS = (
 )
 _MODEL_PROVIDER = "model_square"
 _MODEL_BASE_URL = "https://ark.cn-beijing.volces.com/api/v3"
+_BYTEPLUS_MODEL_PROVIDER = "byteplus_model_square"
+_BYTEPLUS_MODEL_BASE_URL = "https://ark.ap-southeast.bytepluses.com/api/v3"
 _REGION = "cn-beijing"
 _SESSION_TTL_SECONDS = 1800
 _SESSION_DISCOVERY_ATTEMPTS = 6
@@ -689,10 +691,29 @@ def _safe_json_response(
     return payload
 
 
+def _sandbox_provider() -> str:
+    return (
+        (
+            os.getenv("AGENTKIT_CLOUD_PROVIDER")
+            or os.getenv("CLOUD_PROVIDER")
+            or "volcengine"
+        )
+        .strip()
+        .lower()
+    )
+
+
+def _sandbox_model_config(provider: str | None = None) -> tuple[str, str]:
+    if (provider or _sandbox_provider()) == "byteplus":
+        return _BYTEPLUS_MODEL_PROVIDER, _BYTEPLUS_MODEL_BASE_URL
+    return _MODEL_PROVIDER, _MODEL_BASE_URL
+
+
 def _validate_model_base_url(value: str) -> str:
     """Require the Ark model endpoint configured by Studio deployment."""
     normalized = value.rstrip("/")
-    if normalized != _MODEL_BASE_URL:
+    _, expected_base_url = _sandbox_model_config()
+    if normalized != expected_base_url:
         raise SkillCreatorError("Sandbox 模型服务地址无效")
     return normalized
 
@@ -704,37 +725,33 @@ def ensure_skill_creator_model_credential(
     secret_key: str,
     session_token: str | None = None,
     region: str = _REGION,
+    provider: str = "volcengine",
+    model_name: str | None = None,
+    client: Any | None = None,
 ) -> None:
     """Resolve an Ark API key and bind it directly to the CodeEnv Tool."""
-    from agentkit.auth._openapi import OpenApiClient
     from veadk.auth.veauth.ark_veauth import get_ark_token
 
-    api = OpenApiClient(
+    tools_client = client or AgentkitToolsClient(
         access_key=access_key,
         secret_key=secret_key,
-        session_token=session_token,
+        session_token=session_token or "",
         region=region,
     )
-    response = api.call("agentkit", "GetTool", "2025-10-30", {"ToolId": tool_id})
-    tool = response.get("Tool") if isinstance(response.get("Tool"), dict) else response
-    if not isinstance(tool, dict):
-        raise SkillCreatorError("AgentKit Tool 响应格式错误")
-    envs = {
-        item.get("Key"): item.get("Value")
-        for item in tool.get("Envs", [])
-        if item.get("Key")
-    }
+    tool = tools_client.get_tool(tools_types.GetToolRequest(ToolId=tool_id))
+    envs = {item.key: item.value for item in tool.envs or [] if item.key}
     model_api_key = get_ark_token(
         region=region,
         access_key=access_key,
         secret_key=secret_key,
         session_token=session_token,
     )
+    model_provider, model_base_url = _sandbox_model_config(provider)
     session_envs = build_exec_session_envs(
-        model_name=_MODELS[0][1],
+        model_name=model_name or _MODELS[0][1],
         model_api_key=model_api_key,
-        model_provider=_MODEL_PROVIDER,
-        model_base_url=_MODEL_BASE_URL,
+        model_provider=model_provider,
+        model_base_url=model_base_url,
         model_provider_was_provided=True,
         model_base_url_was_provided=True,
         include_codex_config=True,
@@ -746,14 +763,9 @@ def ensure_skill_creator_model_credential(
     if all(envs.get(key) == value for key, value in updates.items()):
         return
     envs.update(updates)
-    api.call(
-        "agentkit",
-        "UpdateTool",
-        "2025-10-30",
-        {
-            "ToolId": tool_id,
-            "Envs": [{"Key": key, "Value": value} for key, value in envs.items()],
-        },
+    updated_envs = [{"Key": key, "Value": value} for key, value in envs.items()]
+    tools_client.update_tool(
+        tools_types.UpdateToolRequest(ToolId=tool_id, Envs=updated_envs)
     )
 
 
@@ -763,7 +775,8 @@ class SkillCreatorService:
     def __init__(self, tool_id: str | None = None, region: str | None = None) -> None:
         self._configured_tool_id = (tool_id or "").strip()
         self._region = sandbox_region_candidates(
-            region or os.getenv("AGENTKIT_SANDBOX_REGION")
+            region or os.getenv("AGENTKIT_SANDBOX_REGION"),
+            provider=_sandbox_provider(),
         )[0]
 
     def capabilities(self) -> dict[str, Any]:
@@ -1083,9 +1096,10 @@ class SkillCreatorService:
         del label
         client = AgentkitToolsClient(region=self._region)
         session_id = self._session_id(job_id, candidate_id)
+        model_provider, _ = _sandbox_model_config()
         session_envs = build_exec_session_envs(
             model_name=model,
-            model_provider=_MODEL_PROVIDER,
+            model_provider=model_provider,
             model_base_url=model_base_url,
             model_provider_was_provided=True,
             model_base_url_was_provided=True,
@@ -1213,7 +1227,7 @@ class SkillCreatorService:
             ],
         )
         response = None
-        regions = sandbox_region_candidates(self._region)
+        regions = sandbox_region_candidates(self._region, provider=_sandbox_provider())
         for index, region in enumerate(regions):
             try:
                 response = AgentkitToolsClient(region=region).list_sessions(request)
@@ -1267,7 +1281,7 @@ class SkillCreatorService:
 
     def _get_tool(self, tool_id: str) -> Any:
         request = tools_types.GetToolRequest(ToolId=tool_id)
-        regions = sandbox_region_candidates(self._region)
+        regions = sandbox_region_candidates(self._region, provider=_sandbox_provider())
         for index, region in enumerate(regions):
             try:
                 tool = AgentkitToolsClient(region=region).get_tool(request)

--- a/veadk/cli/studio_sandbox_tools.py
+++ b/veadk/cli/studio_sandbox_tools.py
@@ -25,13 +25,32 @@ from typing import Any
 
 _PROJECT_NAME = "default"
 _TOOL_TYPE = "CodeEnv"
-STUDIO_SANDBOX_AGENT_MODEL_NAME = "doubao-seed-evolving"
+_DEV_TOOL_TYPE = "DevEnv"
+STUDIO_SANDBOX_AGENT_MODEL_NAME = "doubao-seed-2-1-pro-260628"
+STUDIO_SANDBOX_BYTEPLUS_AGENT_MODEL_NAME = "seed-2-0-lite-260228"
+STUDIO_SANDBOX_MODEL_BASE_URLS = {
+    "volcengine": "https://ark.cn-beijing.volces.com/api/v3",
+    "byteplus": "https://ark.ap-southeast.bytepluses.com/api/v3",
+}
 _AGENT_TOOL_TYPES = {
     "openclaw": "ArkClawEnv",
     "hermes": "HermesEnv",
 }
 _READY_STATUS = "Ready"
 _FAILED_STATUSES = frozenset({"Error", "Failed", "CreateFailed", "Deleting", "Deleted"})
+
+
+def studio_sandbox_agent_model_name(provider: str) -> str:
+    if provider == "byteplus":
+        return STUDIO_SANDBOX_BYTEPLUS_AGENT_MODEL_NAME
+    return STUDIO_SANDBOX_AGENT_MODEL_NAME
+
+
+def studio_sandbox_model_base_url(provider: str) -> str:
+    try:
+        return STUDIO_SANDBOX_MODEL_BASE_URLS[provider]
+    except KeyError as error:
+        raise ValueError(f"Unsupported Studio cloud provider: {provider}") from error
 
 
 def studio_sandbox_tool_name(application_name: str, purpose: str) -> str:
@@ -107,9 +126,10 @@ def _find_exact_tool(
     return matches[0] if matches else None
 
 
-def ensure_studio_code_env_tool(
+def _ensure_studio_environment_tool(
     *,
     name: str,
+    tool_type: str,
     access_key: str = "",
     secret_key: str = "",
     region: str = "cn-beijing",
@@ -119,7 +139,7 @@ def ensure_studio_code_env_tool(
     poll_interval: float = 5.0,
     sleep: Callable[[float], None] = time.sleep,
 ) -> str:
-    """Reuse or create one Ready CodeEnv Tool and return its Tool ID."""
+    """Reuse or create one ready managed environment Tool."""
     from agentkit.sdk.tools import types as tools_types
     from agentkit.sdk.tools.client import AgentkitToolsClient
 
@@ -129,46 +149,21 @@ def ensure_studio_code_env_tool(
         region=region,
         session_token=session_token,
     )
-    matches = []
-    next_token: str | None = None
-    while True:
-        response = tools_client.list_tools(
-            tools_types.ListToolsRequest(
-                ProjectName=_PROJECT_NAME,
-                MaxResults=100,
-                NextToken=next_token,
-                Filters=[
-                    tools_types.FiltersItemForListTools(
-                        Name="Name",
-                        Values=[name],
-                    )
-                ],
-            )
-        )
-        matches.extend(
-            tool
-            for tool in (response.tools or [])
-            if tool.name == name
-            and tool.project_name == _PROJECT_NAME
-            and tool.tool_type == _TOOL_TYPE
-        )
-        next_token = response.next_token or None
-        if not next_token:
-            break
-
-    if len(matches) > 1:
-        raise RuntimeError(
-            f"Multiple AgentKit CodeEnv Tools named '{name}' were found."
-        )
-    if matches:
-        tool_id = (matches[0].tool_id or "").strip()
+    match = _find_exact_tool(
+        tools_client,
+        tools_types,
+        name=name,
+        tool_type=tool_type,
+    )
+    if match is not None:
+        tool_id = (match.tool_id or "").strip()
         if not tool_id:
             raise RuntimeError(f"AgentKit Tool '{name}' did not return a Tool ID.")
     else:
         response = tools_client.create_tool(
             tools_types.CreateToolRequest(
                 Name=name,
-                ToolType=_TOOL_TYPE,
+                ToolType=tool_type,
                 ProjectName=_PROJECT_NAME,
                 CpuMilli=4000,
                 MemoryMb=8192,
@@ -190,19 +185,25 @@ def ensure_studio_code_env_tool(
                 f"Creating AgentKit Tool '{name}' did not return a Tool ID."
             )
 
-    deadline = time.monotonic() + timeout_seconds
-    while True:
-        tool = tools_client.get_tool(tools_types.GetToolRequest(ToolId=tool_id))
-        status = (tool.status or "").strip()
-        if status == _READY_STATUS:
-            return tool_id
-        if status in _FAILED_STATUSES:
-            raise RuntimeError(
-                f"AgentKit Tool '{name}' failed to become ready: {status}."
-            )
-        if time.monotonic() >= deadline:
-            raise RuntimeError(f"Timed out waiting for AgentKit Tool '{name}'.")
-        sleep(poll_interval)
+    return _wait_for_ready_tool(
+        tools_client,
+        tools_types,
+        tool_id=tool_id,
+        name=name,
+        timeout_seconds=timeout_seconds,
+        poll_interval=poll_interval,
+        sleep=sleep,
+    )
+
+
+def ensure_studio_code_env_tool(**kwargs: Any) -> str:
+    """Reuse or create one Ready CodeEnv Tool and return its Tool ID."""
+    return _ensure_studio_environment_tool(tool_type=_TOOL_TYPE, **kwargs)
+
+
+def ensure_studio_dev_env_tool(**kwargs: Any) -> str:
+    """Reuse or create one Ready DevEnv Tool and return its Tool ID."""
+    return _ensure_studio_environment_tool(tool_type=_DEV_TOOL_TYPE, **kwargs)
 
 
 def ensure_studio_agent_tool(
@@ -293,7 +294,9 @@ def ensure_studio_agent_model_credential(
     secret_key: str,
     session_token: str | None = None,
     region: str = "cn-beijing",
-    model_base_url: str = "https://ark.cn-beijing.volces.com/api/v3",
+    model_base_url: str = STUDIO_SANDBOX_MODEL_BASE_URLS["volcengine"],
+    provider: str = "volcengine",
+    client: Any | None = None,
 ) -> None:
     """Bind the complete model environment required by Hermes/OpenClaw."""
     if kind not in _AGENT_TOOL_TYPES:
@@ -302,25 +305,19 @@ def ensure_studio_agent_model_credential(
     if not normalized_model_name:
         raise ValueError("model_name must not be empty")
 
-    from agentkit.auth._openapi import OpenApiClient
-
     from veadk.auth.veauth.ark_veauth import get_ark_token
 
-    api = OpenApiClient(
+    from agentkit.sdk.tools import types as tools_types
+    from agentkit.sdk.tools.client import AgentkitToolsClient
+
+    tools_client = client or AgentkitToolsClient(
         access_key=access_key,
         secret_key=secret_key,
-        session_token=session_token,
+        session_token=session_token or "",
         region=region,
     )
-    response = api.call("agentkit", "GetTool", "2025-10-30", {"ToolId": tool_id})
-    tool = response.get("Tool") if isinstance(response.get("Tool"), dict) else response
-    if not isinstance(tool, dict):
-        raise TypeError("AgentKit Tool response is invalid.")
-    envs = {
-        item.get("Key"): item.get("Value")
-        for item in tool.get("Envs", [])
-        if isinstance(item, dict) and item.get("Key")
-    }
+    tool = tools_client.get_tool(tools_types.GetToolRequest(ToolId=tool_id))
+    envs = {item.key: item.value for item in tool.envs or [] if item.key}
     model_api_key = get_ark_token(
         region=region,
         access_key=access_key,
@@ -336,15 +333,17 @@ def ensure_studio_agent_model_credential(
         "MODEL_AGENT_BASE_URL": normalized_base_url,
         "ARK_BASE_URL": normalized_base_url,
     }
-    if all(envs.get(key) == value for key, value in updates.items()):
+    current_model_name = str(getattr(tool, "model_agent_name", "") or "").strip()
+    if current_model_name == normalized_model_name and all(
+        envs.get(key) == value for key, value in updates.items()
+    ):
         return
     envs.update(updates)
-    api.call(
-        "agentkit",
-        "UpdateTool",
-        "2025-10-30",
-        {
-            "ToolId": tool_id,
-            "Envs": [{"Key": key, "Value": value} for key, value in envs.items()],
-        },
+    updated_envs = [{"Key": key, "Value": value} for key, value in envs.items()]
+    tools_client.update_tool(
+        tools_types.UpdateToolRequest(
+            ToolId=tool_id,
+            ModelAgentName=normalized_model_name,
+            Envs=updated_envs,
+        )
     )


### PR DESCRIPTION
## Summary

- add a Volcengine DevEnv sandbox input and automatic provisioning for Studio deploys
- automatically provision the four existing BytePlus sandbox tools when IDs are omitted
- route BytePlus Tool and Session APIs exclusively through `ap-southeast-1`
- configure provider-specific model endpoints and defaults for Codex, OpenClaw, and Hermes
- reconcile model configuration when reusing existing managed agent tools

## Validation

- `pre-commit run --all-files`
- `pytest -q` (`1237 passed, 5 skipped`)
- manually verified fresh BytePlus CodeEnv, OpenClaw, and Hermes session creation
- manually verified a fresh BytePlus Codex session uses `seed-2-0-lite-260228` and completes a model response
