### PR TITLE
fix(studio): harden release deployment pipeline

### DIFF
--- a/frontend/service/studio_release_server/builder.py
+++ b/frontend/service/studio_release_server/builder.py
@@ -215,7 +215,8 @@ class StudioReleaseBuilder:
         completed = subprocess.run(
             [
                 sys.executable,
-                str(script),
+                "-m",
+                "veadk.cli.studio_dependencies",
                 "--manifest-only",
                 "--manifest",
                 str(destination),

--- a/frontend/service/studio_release_server/deploy.py
+++ b/frontend/service/studio_release_server/deploy.py
@@ -274,10 +274,19 @@ def _find_named(items: list[Any], name: str) -> Any | None:
 def _find_function_id(service: Any) -> str:
     from volcenginesdkvefaas import ListFunctionsRequest
 
-    response = service.client.list_functions(
-        ListFunctionsRequest(page_number=1, page_size=100)
-    )
-    function = _find_named(list(getattr(response, "items", []) or []), _FUNCTION_NAME)
+    page_number = 1
+    page_size = 100
+    functions: list[Any] = []
+    while True:
+        response = service.client.list_functions(
+            ListFunctionsRequest(page_number=page_number, page_size=page_size)
+        )
+        functions.extend(list(getattr(response, "items", []) or []))
+        total = int(getattr(response, "total", 0) or 0)
+        if page_number * page_size >= total:
+            break
+        page_number += 1
+    function = _find_named(functions, _FUNCTION_NAME)
     return str(getattr(function, "id", "") or "")
 
 

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -144,7 +144,7 @@ def test_vefaas_code_upload_callback_uses_configured_region() -> None:
         url="https://example.com/upload",
         data=b"archive",
         headers={"Content-Type": "application/zip"},
-        timeout=(30, 300),
+        timeout=(300, 300),
     )
     callback.assert_called_once_with(
         ak="test_access_key",

--- a/tests/test_studio_release_server.py
+++ b/tests/test_studio_release_server.py
@@ -698,6 +698,7 @@ def test_builder_restores_manifest_dependencies_from_cache(tmp_path: Path) -> No
 
 def test_builder_generates_dependency_manifest_from_release_source(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     source_root = Path(__file__).parents[1]
     prepared_root = tmp_path / ".studio-release"
@@ -709,6 +710,14 @@ def test_builder_generates_dependency_manifest_from_release_source(
         _settings(),
         dependency_store=dependency_store,
     )
+    commands: list[list[str]] = []
+    original_run = subprocess.run
+
+    def capture_run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess:
+        commands.append(command)
+        return original_run(command, **kwargs)
+
+    monkeypatch.setattr(release_builder.subprocess, "run", capture_run)
 
     wheels = builder._prepare_dependency_wheels(
         source_root,
@@ -718,6 +727,11 @@ def test_builder_generates_dependency_manifest_from_release_source(
     )
 
     assert wheels == workspace / "dependency-wheels"
+    assert commands[0][:3] == [
+        sys.executable,
+        "-m",
+        "veadk.cli.studio_dependencies",
+    ]
     assert dependency_store.manifest == workspace / "dependencies.json"
     assert json.loads(dependency_store.manifest.read_text(encoding="utf-8"))["wheels"]
 
@@ -834,6 +848,33 @@ def test_stage_deployment_uses_frontend_service_package(
     assert "frontend.service.studio_release_server.app:app" in (
         destination / "run.sh"
     ).read_text(encoding="utf-8")
+
+
+def test_function_lookup_paginates() -> None:
+    requested_pages: list[int] = []
+
+    class _Client:
+        def list_functions(self, request: Any) -> Any:
+            requested_pages.append(request.page_number)
+            if request.page_number == 1:
+                return SimpleNamespace(
+                    total=101,
+                    items=[SimpleNamespace(name="another-function", id="other-id")],
+                )
+            return SimpleNamespace(
+                total=101,
+                items=[
+                    SimpleNamespace(
+                        name="veadk-studio-release-server-fn",
+                        id="release-function-id",
+                    )
+                ],
+            )
+
+    service = SimpleNamespace(client=_Client())
+
+    assert release_deploy._find_function_id(service) == "release-function-id"
+    assert requested_pages == [1, 2]
 
 
 def test_set_github_secret_reads_value_from_stdin(

--- a/veadk/integrations/ve_faas/ve_faas.py
+++ b/veadk/integrations/ve_faas/ve_faas.py
@@ -177,7 +177,7 @@ class VeFaaS:
                 url=upload_url,
                 data=code_zip_data,
                 headers=headers,
-                timeout=(30, 300),
+                timeout=(300, 300),
             )
         except requests.RequestException:
             raise ValueError("Function code upload request failed.") from None


### PR DESCRIPTION
## Summary

- run the Studio dependency manifest generator as a module so cloned source imports resolve correctly
- paginate VeFaaS Function discovery before updating an existing release service
- allow enough time for large Function bundles to upload on slower connections
- add regression coverage for manifest invocation, pagination, and upload timeout behavior

## Testing

- `uv run --group dev pre-commit run --files frontend/service/studio_release_server/builder.py frontend/service/studio_release_server/deploy.py veadk/integrations/ve_faas/ve_faas.py tests/test_cloud.py tests/test_studio_release_server.py`
- `uv run --group dev pytest tests/test_studio_release_server.py tests/test_cloud.py -q` (40 passed)