### PR TITLE
fix(ci): limit push secret scans to main

### DIFF
--- a/.github/workflows/secrets-scan.yaml
+++ b/.github/workflows/secrets-scan.yaml
@@ -17,6 +17,8 @@ name: Secret Scan
 on:
   pull_request:
   push:
+    branches:
+      - main
 
 jobs:
   gitleaks:


### PR DESCRIPTION
## Summary

- run push-triggered secret scans only on `main`
- keep secret scanning enabled for every pull request
- avoid full-history TruffleHog scans when a feature branch is created with an all-zero before SHA

## Validation

- `uv run pre-commit run --all-files`
- verified a feature-branch push does not start the Secret Scan workflow
- verify the pull-request Secret Scan completes successfully in CI