### PR TITLE
Fix mem0 dependency for debug runtimes

### DIFF
--- a/tests/cli/test_cli_harness_open_source_defaults.py
+++ b/tests/cli/test_cli_harness_open_source_defaults.py
@@ -43,7 +43,7 @@ def test_harness_dockerfile_uses_accelerated_source_with_official_fallback() -> 
         in cli_harness._DOCKERFILE
     )
     assert "https://github.com/volcengine/veadk-python.git" in cli_harness._DOCKERFILE
-    assert '"./src[harness]"' in cli_harness._DOCKERFILE
+    assert '"./src[database,extensions,harness]"' in cli_harness._DOCKERFILE
     old_package_path = "packages/" + "agentkit" + "-harness-python"
     assert old_package_path not in cli_harness._DOCKERFILE
 

--- a/tests/cli/test_studio_deploy_target.py
+++ b/tests/cli/test_studio_deploy_target.py
@@ -996,6 +996,7 @@ def test_studio_deploy_byteplus_wires_provider_to_cloud_engine_and_package(
     assert str(captured["requirements"]).startswith(
         "./pydantic-2.12.5-py3-none-any.whl\n"
     )
+    assert "veadk-python[database]\n" in str(captured["requirements"])
     assert captured["serverless_role"] == {
         "args": ("byteplus-ak", "byteplus-sk"),
         "kwargs": {"session_token": "", "provider": "byteplus"},
@@ -1769,5 +1770,5 @@ def test_studio_deploy_from_source_bundles_unmirrored_dependencies(
     )
     assert captured["requirements"] == (
         (expected_prefix or expected_common_requirements)
-        + "./veadk_python-test-py3-none-any.whl\n"
+        + "./veadk_python-test-py3-none-any.whl[database]\n"
     )

--- a/tests/memory/long_term_memory_backends/test_mem0_backend.py
+++ b/tests/memory/long_term_memory_backends/test_mem0_backend.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import builtins
+import importlib
+import sys
+
+import pytest
+
+
+def test_mem0_backend_missing_dependency_points_to_database_extra(monkeypatch):
+    module_name = "veadk.memory.long_term_memory_backends.mem0_backend"
+    sys.modules.pop(module_name, None)
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "mem0":
+            raise ImportError("No module named mem0")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    try:
+        with pytest.raises(ImportError) as exc_info:
+            importlib.import_module(module_name)
+        message = str(exc_info.value)
+        assert "veadk-python[database]" in message
+        assert "mem0ai>=1.0.0,<2" in message
+    finally:
+        sys.modules.pop(module_name, None)

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -7894,7 +7894,9 @@ def frontend_deploy(
     # 3) Build the function project (zip): run.sh launches the frontend server on
     #    the FaaS-assigned port; requirements.txt pulls veadk-python (ships the UI).
     requirements = (
-        f"veadk-python=={veadk_version}\n" if veadk_version else "veadk-python\n"
+        f"veadk-python[database]=={veadk_version}\n"
+        if veadk_version
+        else "veadk-python[database]\n"
     )
     # 3b) Resolve the serverless APIG gateway: use --gateway-name if given, else
     #     reuse an existing serverless gateway, creating one only if none exists.

--- a/veadk/cli/cli_harness.py
+++ b/veadk/cli/cli_harness.py
@@ -233,7 +233,7 @@ RUN set -eux; \\
     done; \\
     test -d src/veadk
 RUN uv pip install --system --index-url https://mirrors.aliyun.com/pypi/simple/ \\
-        "./src[harness]" fastapi "uvicorn[standard]"
+        "./src[database,extensions,harness]" fastapi "uvicorn[standard]"
 EXPOSE 8000
 CMD ["python", "-m", "uvicorn", "veadk.cloud.harness_app.app:app", "--host", "0.0.0.0", "--port", "8000"]
 """

--- a/veadk/cli/studio_package.py
+++ b/veadk/cli/studio_package.py
@@ -191,10 +191,9 @@ def build_local_studio_requirements(
     )
 
     shutil.rmtree(package_dir / "wheel-source", ignore_errors=True)
-    requirements = "".join(
-        f"./{name}\n"
-        for name in (*(path.name for path in dependencies), wheels[0].name)
-    )
+    requirement_lines = [f"./{path.name}" for path in dependencies]
+    requirement_lines.append(f"./{wheels[0].name}[database]")
+    requirements = "".join(f"{line}\n" for line in requirement_lines)
     return requirements
 
 

--- a/veadk/cloud/harness_app/Dockerfile
+++ b/veadk/cloud/harness_app/Dockerfile
@@ -18,9 +18,9 @@ WORKDIR /app
 
 # `[extensions]` pulls llama-index / redis / opensearch, required when the
 # KNOWLEDGEBASE_TYPE or LONG_TERM_MEMORY_TYPE env vars enable those components.
-# (Viking / MySQL / PostgreSQL backends are already in the base dependencies.)
+# `[database]` pulls optional database SDKs, including mem0ai for mem0 memory.
 RUN apt-get update && apt-get install -y --no-install-recommends git && \
-    pip3 install --no-cache-dir "veadk-python[extensions] @ git+https://github.com/volcengine/veadk-python.git" && \
+    pip3 install --no-cache-dir "veadk-python[database,extensions] @ git+https://github.com/volcengine/veadk-python.git" && \
     apt-get purge -y git && apt-get autoremove -y && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/veadk/memory/long_term_memory_backends/mem0_backend.py
+++ b/veadk/memory/long_term_memory_backends/mem0_backend.py
@@ -29,11 +29,16 @@ logger = get_logger(__name__)
 try:
     from mem0 import MemoryClient
 
-except ImportError:
+except ImportError as e:
     logger.error(
-        "Failed to import mem0 or dotenv. Please install them with 'pip install mem0 '"
+        "Failed to import mem0. Install mem0 support with "
+        '`pip install "veadk-python[database]"` or '
+        '`pip install "mem0ai>=1.0.0,<2"`.'
     )
-    raise ImportError("Required packages not installed: mem0")
+    raise ImportError(
+        "LongTermMemory backend 'mem0' requires veadk-python[database] "
+        "(mem0ai>=1.0.0,<2)."
+    ) from e
 
 
 class Mem0LTMBackend(BaseLongTermMemoryBackend):


### PR DESCRIPTION
## 背景

在 Studio 创建 Agent 并配置长期记忆后端为 mem0 时，本地/云端调试运行会在启动阶段失败：

```text
ModuleNotFoundError: No module named 'mem0'
ImportError: LongTermMemory backend 'mem0' requires veadk-python[database]
```

根因是生成 Agent 项目的 `requirements.txt` 已经会为 mem0 添加 `veadk-python[database]`，但 Studio 调试运行并不会安装临时项目里的 requirements，而是直接复用 Studio/WebUI 进程所在 Python 环境启动调试 runner。旧的 Studio 部署包只安装 `veadk-python`，harness 镜像也没有带 `database` extra，因此 mem0 SDK (`mem0ai`) 不会被安装。

## 修改内容

- Studio 部署包默认安装 `veadk-python[database]`，让调试 runner 所在环境包含 mem0 依赖。
- `--from-source` 构建本地 Studio wheel 时，为本地 wheel requirements 追加 `[database]` extra。
- harness Dockerfile 和 open-source harness 模板安装 `database,extensions,harness` extras，覆盖 `LONG_TERM_MEMORY_TYPE=mem0` 的运行场景。
- 修正 mem0 backend 缺依赖提示，从 `pip install mem0` 改为指向 `veadk-python[database]` / `mem0ai>=1.0.0,<2`。
- 增加测试覆盖 Studio/harness requirements 以及 mem0 缺依赖提示。

## 验证

- `.venv/bin/pre-commit run --files ...`
- `.venv/bin/python -m pytest tests/cli/test_cli_harness_open_source_defaults.py tests/cli/test_studio_deploy_target.py::test_studio_deploy_byteplus_wires_provider_to_cloud_engine_and_package tests/cli/test_studio_deploy_target.py::test_studio_deploy_from_source_bundles_unmirrored_dependencies tests/memory/long_term_memory_backends/test_mem0_backend.py tests/cli/test_studio_release.py tests/cli/test_studio_update.py::test_studio_update_preserves_branding_and_updates_existing_ids tests/cli/test_studio_update.py::test_studio_update_supports_byteplus_provider`
