### PR TITLE
fix(studio): enforce IdP-only user pools after deploy

### DIFF
--- a/tests/cli/test_frontend_branding.py
+++ b/tests/cli/test_frontend_branding.py
@@ -144,6 +144,10 @@ def test_studio_deploy_bundles_logo_and_optional_title(
         lambda **kwargs: kwargs["deployment_region"],
     )
     monkeypatch.setattr(
+        "veadk.integrations.ve_identity.identity_client.IdentityClient.configure_user_pool_for_idp_only",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
         "veadk.cli.studio_deploy_serverless_iam.ensure_serverless_application_role",
         lambda *_, **__: False,
     )

--- a/tests/cli/test_studio_deploy_serverless_iam.py
+++ b/tests/cli/test_studio_deploy_serverless_iam.py
@@ -204,6 +204,10 @@ def test_studio_deploy_checks_serverless_role_with_custom_function_role(
         lambda **kwargs: kwargs["deployment_region"],
     )
     monkeypatch.setattr(
+        "veadk.integrations.ve_identity.identity_client.IdentityClient.configure_user_pool_for_idp_only",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
         "veadk.cli.studio_sandbox_tools.ensure_studio_code_env_tool",
         lambda **kwargs: f"auto-{kwargs['name']}",
     )

--- a/tests/cli/test_studio_deploy_target.py
+++ b/tests/cli/test_studio_deploy_target.py
@@ -347,6 +347,9 @@ def test_studio_deploy_auto_identity_is_injected_and_printed(
         def register_callback_for_user_pool_client(self, **kwargs: object) -> None:
             captured["callback"] = kwargs
 
+        def configure_user_pool_for_idp_only(self, user_pool_uid: str) -> None:
+            captured["configured_user_pool"] = user_pool_uid
+
     monkeypatch.setattr("veadk.config.veadk_environments", environments)
     monkeypatch.setattr(
         "veadk.cli.cli_frontend._resolve_or_create_studio_identity_resources",
@@ -395,6 +398,8 @@ def test_studio_deploy_auto_identity_is_injected_and_printed(
     assert "user pool id: pool-created" in result.output
     assert "user pool domain: identity.example.com" in result.output
     assert "client id: client-created" in result.output
+    assert captured["configured_user_pool"] == "pool-created"
+    assert "Configured the user pool for IdP-only sign-in." in result.output
 
 
 def test_studio_credentials_fall_back_to_volc_default_profile(
@@ -638,6 +643,9 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
         def register_callback_for_user_pool_client(self, **kwargs: object) -> None:
             captured["callback"] = kwargs
 
+        def configure_user_pool_for_idp_only(self, user_pool_uid: str) -> None:
+            captured["configured_user_pool"] = user_pool_uid
+
     monkeypatch.setattr(
         "veadk.cloud.cloud_agent_engine.CloudAgentEngine", _FakeCloudAgentEngine
     )
@@ -762,6 +770,10 @@ def test_studio_deploy_persists_telemetry_environment(
     )
     monkeypatch.setattr(
         "veadk.integrations.ve_identity.identity_client.IdentityClient.register_callback_for_user_pool_client",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "veadk.integrations.ve_identity.identity_client.IdentityClient.configure_user_pool_for_idp_only",
         lambda *_args, **_kwargs: None,
     )
     result = CliRunner().invoke(
@@ -914,6 +926,9 @@ def test_studio_deploy_byteplus_wires_provider_to_cloud_engine_and_package(
         def register_callback_for_user_pool_client(self, **kwargs: object) -> None:
             captured["callback"] = kwargs
 
+        def configure_user_pool_for_idp_only(self, user_pool_uid: str) -> None:
+            captured["configured_user_pool"] = user_pool_uid
+
     def _resolve_identity_region(**kwargs: object) -> str:
         captured["identity_probe"] = kwargs
         return "ap-southeast-1"
@@ -1037,6 +1052,9 @@ def test_studio_deploy_byteplus_auto_provisions_three_sandbox_tools(
 
         def register_callback_for_user_pool_client(self, **kwargs: object) -> None:
             captured["callback"] = kwargs
+
+        def configure_user_pool_for_idp_only(self, user_pool_uid: str) -> None:
+            captured["configured_user_pool"] = user_pool_uid
 
     def _ensure_code_tool(**kwargs: object) -> str:
         name = str(kwargs["name"])
@@ -1163,6 +1181,9 @@ def test_studio_deploy_byteplus_auto_creates_function_role(
 
         def register_callback_for_user_pool_client(self, **kwargs: object) -> None:
             captured["callback"] = kwargs
+
+        def configure_user_pool_for_idp_only(self, user_pool_uid: str) -> None:
+            captured["configured_user_pool"] = user_pool_uid
 
     def _ensure_frontend_role(
         access_key: str,
@@ -1304,6 +1325,10 @@ def test_studio_deploy_creates_distinct_sandbox_tools_when_ids_are_omitted(
         lambda **_: "cn-beijing",
     )
     monkeypatch.setattr(
+        "veadk.integrations.ve_identity.identity_client.IdentityClient.configure_user_pool_for_idp_only",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
         "veadk.cli.studio_sandbox_tools.ensure_studio_code_env_tool", _ensure_tool
     )
     monkeypatch.setattr(
@@ -1404,6 +1429,10 @@ def test_studio_deploy_enables_rbac_when_either_role_is_configured(
     )
     monkeypatch.setattr(
         "veadk.integrations.ve_identity.identity_client.IdentityClient.register_callback_for_user_pool_client",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "veadk.integrations.ve_identity.identity_client.IdentityClient.configure_user_pool_for_idp_only",
         lambda *_args, **_kwargs: None,
     )
 
@@ -1635,6 +1664,28 @@ def test_register_callback_only_sends_requested_login_switches(
     } == expected_switches
 
 
+def test_configure_user_pool_for_idp_only_disables_local_account_flows() -> None:
+    identity_client = IdentityClient(
+        access_key="test_access_key",
+        secret_key="test_secret_key",
+    )
+    identity_client._api_client = Mock()
+
+    identity_client.configure_user_pool_for_idp_only("pool-id")
+
+    update_request = identity_client._api_client.update_user_pool.call_args.args[0]
+    assert sanitize_for_serialization(update_request) == {
+        "EmailPasswordlessSignInEnabled": False,
+        "PasswordSignInEnabled": False,
+        "SelfAccountRecoveryEnabled": False,
+        "SelfSignUpEnabled": False,
+        "SignUpAutoVerificationEnabled": False,
+        "SmsPasswordlessSignInEnabled": False,
+        "UnconfirmedUserSignInEnabled": False,
+        "UserPoolUid": "pool-id",
+    }
+
+
 def test_studio_deploy_rejects_unsupported_region() -> None:
     result = CliRunner().invoke(
         studio,
@@ -1719,6 +1770,10 @@ def test_studio_deploy_from_source_bundles_unmirrored_dependencies(
     monkeypatch.setattr(
         "veadk.cli.cli_frontend._resolve_studio_identity_region",
         lambda **kwargs: kwargs["deployment_region"],
+    )
+    monkeypatch.setattr(
+        "veadk.integrations.ve_identity.identity_client.IdentityClient.configure_user_pool_for_idp_only",
+        lambda *_args, **_kwargs: None,
     )
     monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/uv")
     monkeypatch.setattr("subprocess.run", _fake_build)

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -7991,23 +7991,23 @@ def frontend_deploy(
         url = (app.vefaas_endpoint or "").rstrip("/")
         redirect_uri = f"{url}/oauth2/callback"
 
+        from veadk.integrations.ve_identity.identity_client import IdentityClient
+
+        identity_client = IdentityClient(
+            access_key=ak,
+            secret_key=sk,
+            session_token=session_token,
+            region=identity_region,
+            provider=provider_id,
+        )
+
         # 4) Register the SSO callback on the user-pool client HERE, with the
         #    deployer's full credentials — the function's IAM role is granted
         #    only read access to Identity (id:GetUserPoolClient), not
         #    id:UpdateUserPoolClient, so it can't register the callback itself.
         if url:
             try:
-                from veadk.integrations.ve_identity.identity_client import (
-                    IdentityClient,
-                )
-
-                IdentityClient(
-                    access_key=ak,
-                    secret_key=sk,
-                    session_token=session_token,
-                    region=identity_region,
-                    provider=provider_id,
-                ).register_callback_for_user_pool_client(
+                identity_client.register_callback_for_user_pool_client(
                     user_pool_uid=user_pool_id,
                     client_uid=allowed_client_id,
                     callback_url=redirect_uri,
@@ -8048,6 +8048,11 @@ def frontend_deploy(
                 function_id,
                 release_environment,
             )
+
+        # 6) Disable local account flows so Studio can only be entered through
+        #    the configured identity provider.
+        identity_client.configure_user_pool_for_idp_only(user_pool_id)
+        click.echo("Configured the user pool for IdP-only sign-in.")
 
         click.echo("")
         click.echo(f"✅ Frontend deployed: {url}")

--- a/veadk/integrations/ve_identity/identity_client.py
+++ b/veadk/integrations/ve_identity/identity_client.py
@@ -792,6 +792,23 @@ class IdentityClient:
         return response.uid, response.domain
 
     @refresh_credentials
+    def configure_user_pool_for_idp_only(self, user_pool_uid: str) -> None:
+        """Disable local sign-up, recovery, and sign-in for a user pool."""
+        from volcenginesdkid import UpdateUserPoolRequest
+
+        request = UpdateUserPoolRequest(
+            email_passwordless_sign_in_enabled=False,
+            password_sign_in_enabled=False,
+            self_account_recovery_enabled=False,
+            self_sign_up_enabled=False,
+            sign_up_auto_verification_enabled=False,
+            sms_passwordless_sign_in_enabled=False,
+            unconfirmed_user_sign_in_enabled=False,
+            user_pool_uid=user_pool_uid,
+        )
+        self._api_client.update_user_pool(request)
+
+    @refresh_credentials
     def list_user_pools(self, *, page_size: int = 100) -> list[dict[str, str]]:
         """List all user pools available to the current account."""
         from volcenginesdkid import ListUserPoolsRequest, ListUserPoolsResponse


### PR DESCRIPTION
## Summary

- disable local password, passwordless, recovery, sign-up, auto-verification, and unconfirmed-user sign-in on the resolved Studio user pool
- apply the IdP-only configuration at the end of deployment using the actual resolved user pool ID
- cover existing and automatically created user pools with deploy and SDK request tests

## Tests

- `pre-commit run --files veadk/integrations/ve_identity/identity_client.py veadk/cli/cli_frontend.py tests/cli/test_studio_deploy_target.py tests/cli/test_frontend_branding.py tests/cli/test_studio_deploy_serverless_iam.py`
- `pytest -q tests/cli/test_studio_deploy_target.py tests/cli/test_frontend_branding.py tests/cli/test_studio_deploy_serverless_iam.py` (59 passed)