### PR TITLE
fix(studio): provision Dev Sandbox for BytePlus

### DIFF
--- a/docs/content/docs/framework/frontend.en.mdx
+++ b/docs/content/docs/framework/frontend.en.mdx
@@ -206,7 +206,7 @@ Each task has a one-hour DevEnv session. Leaving a running task stops and
 releases that session; task state remains in Sandbox so polling can continue
 across frontend instances.
 
-A Volcengine cloud deployment creates the Dev Sandbox when no Tool ID is
+A cloud deployment creates the Dev Sandbox when no Tool ID is
 provided, or uses an existing Tool selected with `--sandbox-dev-tool-id`.
 
 ```bash

--- a/docs/content/docs/framework/frontend.mdx
+++ b/docs/content/docs/framework/frontend.mdx
@@ -177,7 +177,7 @@ veadk studio --agents-dir examples
 每个任务的 DevEnv Session 最长保留 1 小时。离开仍在运行的任务时，Studio 会停止并
 释放对应 Session；任务状态保存在 Sandbox 中，因此前端实例切换后仍可继续轮询。
 
-Volcengine 云上部署未指定 Tool ID 时会自动创建 Dev Sandbox，也可通过
+云上部署未指定 Tool ID 时会自动创建 Dev Sandbox，也可通过
 `--sandbox-dev-tool-id` 使用已有 Tool：
 
 ```bash

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -400,7 +400,7 @@ streams its public activity, validates the generated files, and can then be
 previewed, downloaded, or published to AgentKit. Model credentials remain on
 the Tool and are never returned to the browser.
 
-Local Studio reads the DevEnv Tool ID from `SANDBOX_DEV`. A Volcengine cloud
+Local Studio reads the DevEnv Tool ID from `SANDBOX_DEV`. A cloud
 deployment creates the Dev Sandbox automatically when the ID is omitted, or
 uses the Tool supplied through `--sandbox-dev-tool-id`:
 

--- a/tests/cli/test_studio_deploy_target.py
+++ b/tests/cli/test_studio_deploy_target.py
@@ -311,7 +311,7 @@ def test_studio_identity_resources_reject_client_without_pool() -> None:
             ],
             "ap-southeast-1",
             "byteplus",
-            [],
+            ["--sandbox-dev-tool-id", "dev-tool"],
         ),
     ],
 )
@@ -978,6 +978,8 @@ def test_studio_deploy_byteplus_wires_provider_to_cloud_engine_and_package(
             "openclaw-tool-id",
             "--sandbox-chat-hermes-tool-id",
             "hermes-tool-id",
+            "--sandbox-dev-tool-id",
+            "dev-env-id",
             "--iam-role",
             "trn:iam::role/test",
             "--gateway-name",
@@ -1023,14 +1025,17 @@ def test_studio_deploy_byteplus_wires_provider_to_cloud_engine_and_package(
     assert veadk_environments["AGENTKIT_SANDBOX_REGION"] == "ap-southeast-1"
     assert sorted(credential_tool_ids) == [
         "chat-code-env-id",
+        "dev-env-id",
     ]
+    assert veadk_environments["SANDBOX_DEV"] == "dev-env-id"
 
 
-def test_studio_deploy_byteplus_auto_provisions_three_sandbox_tools(
+def test_studio_deploy_byteplus_auto_provisions_four_sandbox_tools(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, object] = {}
     code_tools: list[str] = []
+    dev_tools: list[str] = []
     agent_tools: list[dict[str, object]] = []
     code_credentials: list[dict[str, object]] = []
     agent_credentials: list[dict[str, object]] = []
@@ -1065,6 +1070,10 @@ def test_studio_deploy_byteplus_auto_provisions_three_sandbox_tools(
         agent_tools.append(kwargs)
         return f"{kwargs['kind']}-tool"
 
+    def _ensure_dev_tool(**kwargs: object) -> str:
+        dev_tools.append(str(kwargs["name"]))
+        return "dev-tool"
+
     monkeypatch.setattr(
         "veadk.cloud.cloud_agent_engine.CloudAgentEngine", _FakeCloudAgentEngine
     )
@@ -1083,6 +1092,10 @@ def test_studio_deploy_byteplus_auto_provisions_three_sandbox_tools(
     monkeypatch.setattr(
         "veadk.cli.studio_sandbox_tools.ensure_studio_agent_tool",
         _ensure_agent_tool,
+    )
+    monkeypatch.setattr(
+        "veadk.cli.studio_sandbox_tools.ensure_studio_dev_env_tool",
+        _ensure_dev_tool,
     )
     monkeypatch.setattr(
         "veadk.cli.frontend_skill_creator.ensure_skill_creator_model_credential",
@@ -1120,6 +1133,7 @@ def test_studio_deploy_byteplus_auto_provisions_three_sandbox_tools(
 
     assert result.exit_code == 0, result.output
     assert len(code_tools) == 1
+    assert len(dev_tools) == 1
     assert {str(call["kind"]) for call in agent_tools} == {"openclaw", "hermes"}
     assert {str(call["model_name"]) for call in agent_tools} == {"seed-2-0-lite-260228"}
     assert {str(call["provider"]) for call in code_credentials} == {"byteplus"}
@@ -1127,6 +1141,7 @@ def test_studio_deploy_byteplus_auto_provisions_three_sandbox_tools(
     assert code_credentials_by_tool["chat-tool"]["model_name"] == (
         "seed-2-0-lite-260228"
     )
+    assert code_credentials_by_tool["dev-tool"]["model_name"] is None
     assert {str(call["provider"]) for call in agent_credentials} == {"byteplus"}
     assert {str(call["model_base_url"]) for call in agent_credentials} == {
         "https://ark.ap-southeast.bytepluses.com/api/v3"
@@ -1135,7 +1150,7 @@ def test_studio_deploy_byteplus_auto_provisions_three_sandbox_tools(
     assert "SANDBOX_SKILL_CREATOR" not in veadk_environments
     assert veadk_environments["SANDBOX_CHAT_OPENCLAW"] == "openclaw-tool"
     assert veadk_environments["SANDBOX_CHAT_HERMES"] == "hermes-tool"
-    assert "SANDBOX_DEV" not in veadk_environments
+    assert veadk_environments["SANDBOX_DEV"] == "dev-tool"
 
 
 def test_studio_deploy_byteplus_rejects_invalid_application_name() -> None:

--- a/tests/cli/test_studio_update.py
+++ b/tests/cli/test_studio_update.py
@@ -669,13 +669,16 @@ def test_studio_update_only_overrides_explicit_sandbox_tool_id(
     }
 
 
+@pytest.mark.parametrize("dev_tool_id", [None, "replacement-dev-tool"])
 def test_byteplus_studio_update_repairs_missing_sandbox_tools(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    dev_tool_id: str | None,
 ) -> None:
     target = _target(region="ap-southeast-1")
     captured: dict[str, object] = {}
     code_tools: list[dict[str, object]] = []
+    dev_tools: list[dict[str, object]] = []
     agent_tools: list[dict[str, object]] = []
     code_credentials: list[dict[str, object]] = []
     agent_credentials: list[dict[str, object]] = []
@@ -702,6 +705,10 @@ def test_byteplus_studio_update_repairs_missing_sandbox_tools(
     monkeypatch.setattr(
         "veadk.cli.studio_sandbox_tools.ensure_studio_agent_tool",
         lambda **kwargs: agent_tools.append(kwargs) or f"{kwargs['kind']}-tool",
+    )
+    monkeypatch.setattr(
+        "veadk.cli.studio_sandbox_tools.ensure_studio_dev_env_tool",
+        lambda **kwargs: dev_tools.append(kwargs) or f"{kwargs['name']}-tool",
     )
     monkeypatch.setattr(
         "veadk.cli.frontend_skill_creator.ensure_skill_creator_model_credential",
@@ -731,25 +738,31 @@ def test_byteplus_studio_update_repairs_missing_sandbox_tools(
 
     monkeypatch.setattr("veadk.integrations.ve_faas.ve_faas.VeFaaS", _FakeVeFaaS)
 
-    result = CliRunner().invoke(
-        studio,
-        [
-            "update",
-            "--provider",
-            "byteplus",
-            "--vefaas-app-name",
-            "studio-app",
-            "--path",
-            str(tmp_path),
-            "--byteplus-access-key",
-            "ak",
-            "--byteplus-secret-key",
-            "sk",
-        ],
-    )
+    args = [
+        "update",
+        "--provider",
+        "byteplus",
+        "--vefaas-app-name",
+        "studio-app",
+        "--path",
+        str(tmp_path),
+        "--byteplus-access-key",
+        "ak",
+        "--byteplus-secret-key",
+        "sk",
+    ]
+    if dev_tool_id is not None:
+        args.extend(["--sandbox-dev-tool-id", dev_tool_id])
+    result = CliRunner().invoke(studio, args)
 
     assert result.exit_code == 0, result.output
     assert code_tools == []
+    if dev_tool_id is None:
+        assert len(dev_tools) == 1
+        expected_dev_tool_id = f"{dev_tools[0]['name']}-tool"
+    else:
+        assert dev_tools == []
+        expected_dev_tool_id = dev_tool_id
     assert {str(call["kind"]) for call in agent_tools} == {"openclaw", "hermes"}
     assert {str(call["provider"]) for call in code_credentials} == {"byteplus"}
     assert {str(call["provider"]) for call in agent_credentials} == {"byteplus"}
@@ -762,6 +775,7 @@ def test_byteplus_studio_update_repairs_missing_sandbox_tools(
     assert "SANDBOX_SKILL_CREATOR" not in overrides
     assert overrides["SANDBOX_CHAT_OPENCLAW"] == "openclaw-tool"
     assert overrides["SANDBOX_CHAT_HERMES"] == "hermes-tool"
+    assert overrides["SANDBOX_DEV"] == expected_dev_tool_id
     assert overrides["CLOUD_PROVIDER"] == "byteplus"
 
 

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -7439,7 +7439,7 @@ def _resolve_studio_cloud_credentials(
     default=None,
     envvar="SANDBOX_DEV",
     help="Dedicated ready AgentKit DevEnv Tool ID for Studio development. "
-    "Volcengine default: create one during deployment.",
+    "Default: create one during deployment.",
 )
 @click.option(
     "--sandbox-chat-codex-tool-id",
@@ -7671,13 +7671,8 @@ def frontend_deploy(
         "codex": sandbox_chat_codex_tool_id,
         "openclaw": sandbox_chat_openclaw_tool_id,
         "hermes": sandbox_chat_hermes_tool_id,
+        "dev": sandbox_dev_tool_id,
     }
-    if provider_id == "volcengine":
-        sandbox_tool_ids["dev"] = sandbox_dev_tool_id
-    elif sandbox_dev_tool_id:
-        raise click.ClickException(
-            "--sandbox-dev-tool-id is supported only for Volcengine Studio deployments."
-        )
     sandbox_tool_labels = {
         "codex": "Codex",
         "openclaw": "OpenClaw",
@@ -7877,8 +7872,7 @@ def frontend_deploy(
     veadk_environments["SANDBOX_CHAT_CODEX"] = chat_codex_tool_id
     veadk_environments["SANDBOX_CHAT_OPENCLAW"] = openclaw_tool_id
     veadk_environments["SANDBOX_CHAT_HERMES"] = hermes_tool_id
-    if provider_id == "volcengine":
-        veadk_environments["SANDBOX_DEV"] = dev_tool_id
+    veadk_environments["SANDBOX_DEV"] = dev_tool_id
     veadk_environments["AGENTKIT_SANDBOX_REGION"] = region
     veadk_environments["VEADK_STUDIO_UPDATE_BUCKET"] = studio_update_bucket
     veadk_environments["VEADK_STUDIO_UPDATE_PREFIX"] = studio_update_prefix
@@ -8112,7 +8106,7 @@ def frontend_deploy(
     "--sandbox-dev-tool-id",
     "sandbox_dev_tool_id",
     default=None,
-    help="Replace the Volcengine Studio DevEnv Tool ID.",
+    help="Replace the Studio DevEnv Tool ID.",
 )
 @click.option(
     "--sandbox-chat-codex-tool-id",
@@ -8173,10 +8167,6 @@ def frontend_update(
 
     provider_id = normalize_cloud_provider(provider)
     if provider_id == "byteplus":
-        if sandbox_dev_tool_id is not None:
-            raise click.ClickException(
-                "--sandbox-dev-tool-id is supported only for Volcengine Studio updates."
-            )
         if region is not None and region != DEFAULT_BYTEPLUS_REGION:
             raise click.ClickException(
                 "BytePlus Studio update currently supports only "
@@ -8288,6 +8278,7 @@ def frontend_update(
             has_explicit_sandbox_tool = any(
                 tool_id is not None
                 for tool_id in (
+                    sandbox_dev_tool_id,
                     sandbox_chat_codex_tool_id,
                     sandbox_chat_openclaw_tool_id,
                     sandbox_chat_hermes_tool_id,
@@ -8308,6 +8299,9 @@ def frontend_update(
                 }
                 repair_sandbox_tools = True
             byteplus_sandbox_tool_ids = {
+                "dev": sandbox_dev_tool_id
+                if sandbox_dev_tool_id is not None
+                else current_env.get("SANDBOX_DEV", ""),
                 "codex": sandbox_chat_codex_tool_id
                 if sandbox_chat_codex_tool_id is not None
                 else current_env.get("SANDBOX_CHAT_CODEX", ""),
@@ -8319,11 +8313,13 @@ def frontend_update(
                 else current_env.get("SANDBOX_CHAT_HERMES", ""),
             }
             byteplus_sandbox_labels = {
+                "dev": "Dev Sandbox",
                 "codex": "Codex",
                 "openclaw": "OpenClaw",
                 "hermes": "Hermes",
             }
             byteplus_sandbox_purposes = {
+                "dev": "dev",
                 "codex": "chat",
                 "openclaw": "openclaw",
                 "hermes": "hermes",
@@ -8336,6 +8332,7 @@ def frontend_update(
                     ensure_studio_agent_model_credential,
                     ensure_studio_agent_tool,
                     ensure_studio_code_env_tool,
+                    ensure_studio_dev_env_tool,
                     studio_sandbox_agent_model_name,
                     studio_sandbox_model_base_url,
                     studio_sandbox_tool_name,
@@ -8365,6 +8362,15 @@ def frontend_update(
                             if kind == "codex":
                                 future = ex.submit(
                                     ensure_studio_code_env_tool,
+                                    name=tool_name,
+                                    region=target.region,
+                                    access_key=ak,
+                                    secret_key=sk,
+                                    session_token=session_token or "",
+                                )
+                            elif kind == "dev":
+                                future = ex.submit(
+                                    ensure_studio_dev_env_tool,
                                     name=tool_name,
                                     region=target.region,
                                     access_key=ak,
@@ -8408,7 +8414,10 @@ def frontend_update(
                             continue
                         label = byteplus_sandbox_labels[kind]
                         click.echo(f"Creating AgentKit {label} model credential…")
-                        if kind == "codex":
+                        if kind in {"codex", "dev"}:
+                            code_model_name = (
+                                sandbox_agent_model_name if kind == "codex" else None
+                            )
                             future = ex.submit(
                                 ensure_skill_creator_model_credential,
                                 tool_id=tool_id,
@@ -8417,7 +8426,7 @@ def frontend_update(
                                 secret_key=sk,
                                 session_token=session_token,
                                 provider=provider_id,
-                                model_name=sandbox_agent_model_name,
+                                model_name=code_model_name,
                             )
                         else:
                             future = ex.submit(
@@ -8456,6 +8465,9 @@ def frontend_update(
                 )
                 environment_overrides["SANDBOX_CHAT_HERMES"] = str(
                     byteplus_sandbox_tool_ids["hermes"] or ""
+                )
+                environment_overrides["SANDBOX_DEV"] = str(
+                    byteplus_sandbox_tool_ids["dev"] or ""
                 )
         if branding_title is not None:
             environment_overrides["VEADK_SITE_TITLE"] = branding_title


### PR DESCRIPTION
## Summary

- provision or reuse a DevEnv Tool for BytePlus Studio deployments and inject SANDBOX_DEV
- align BytePlus Studio updates with Volcengine by preserving, replacing, or repairing the Dev Sandbox Tool ID
- document cloud-provider parity and cover default provisioning plus explicit Tool ID paths

## Testing

- pre-commit run --all-files
- pytest -q: 1324 passed, 5 skipped, 6 subtests passed
- focused Studio deploy/update/sandbox tests: 69 passed
- docs npm run types:check
- Pyright comparison against origin/main: no new diagnostics