### PR TITLE
feat(studio): report provisioned cloud resources

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -249,6 +249,12 @@ When `--user-pool-id` and `--allowed-client-id` are omitted, deployment creates
 or reuses them in the selected `--region` and prints the resolved IDs. Pass both
 options to keep using existing Identity resources.
 
+After automatic provisioning, the success summary lists every Sandbox type and
+Tool ID, the private Studio TOS address, and the resolved Identity user pool and
+client IDs. It also links to the matching Volcengine or BytePlus Identity
+console. Password sign-in remains disabled by default for security; configure
+an SSO identity provider before inviting users to the deployed Studio.
+
 Studio checks `latest.json` every three minutes and lists newer releases with
 their changelog and Git SHA. An accepted update verifies the selected complete
 Bundle, replaces the current Function code, and releases the existing

--- a/tests/cli/test_studio_deploy_target.py
+++ b/tests/cli/test_studio_deploy_target.py
@@ -429,6 +429,25 @@ def test_studio_deploy_auto_identity_is_injected_and_printed(
     assert "client id: client-created" in result.output
     assert captured["configured_user_pool"] == "pool-created"
     assert "Configured the user pool for IdP-only sign-in." in result.output
+    tos_domain = "bytepluses.com" if expected_provider == "byteplus" else "volces.com"
+    identity_console = (
+        "https://console.byteplus.com/identity"
+        if expected_provider == "byteplus"
+        else "https://console.volcengine.com/identity"
+    )
+    assert "Cloud resources configured for this Studio:" in result.output
+    assert "[Codex]: codex-tool" in result.output
+    assert "[OpenClaw]: openclaw-tool" in result.output
+    assert "[Hermes]: hermes-tool" in result.output
+    assert "[Dev Sandbox]: dev-tool" in result.output
+    assert (
+        "TOS (private): "
+        f"https://veadk-studio-2100123456.tos-{expected_region}.{tos_domain}"
+        in result.output
+    )
+    assert f"Identity console: {identity_console}" in result.output
+    assert "Password sign-in is disabled by default for security." in result.output
+    assert "Configure an SSO identity provider before inviting users." in result.output
 
 
 def test_studio_credentials_fall_back_to_volc_default_profile(
@@ -648,6 +667,11 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
 ) -> None:
     captured: dict[str, object] = {}
     credential_tool_ids: list[str] = []
+    monkeypatch.setitem(
+        veadk_environments,
+        "VEADK_STUDIO_TOS_BUCKET",
+        "existing-studio-storage",
+    )
 
     if update_bucket_env is None:
         monkeypatch.delenv("VEADK_STUDIO_UPDATE_BUCKET", raising=False)
@@ -777,6 +801,7 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
     assert ("Warning:" in result.output) == (
         expected_identity_region != expected_region
     )
+    assert "Cloud resources configured for this Studio:" not in result.output
     callback = captured["callback"]
     assert isinstance(callback, dict)
     assert callback["dismiss_login_page_enabled"] is False
@@ -1521,6 +1546,10 @@ def test_studio_deploy_creates_distinct_sandbox_tools_when_ids_are_omitted(
         assert f"AgentKit {label} Tool is ready." in result.output
         assert f"Creating AgentKit {label} model credential" in result.output
         assert f"AgentKit {label} model credential is ready." in result.output
+    assert "[Codex]: chat-tool" in result.output
+    assert "[OpenClaw]: openclaw-tool" in result.output
+    assert "[Hermes]: hermes-tool" in result.output
+    assert "[Dev Sandbox]: dev-tool" in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/frontend/server/storage/test_provisioning.py
+++ b/tests/frontend/server/storage/test_provisioning.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import pytest
 
+from frontend.server.storage import StudioProvider
 from frontend.server.storage import provisioning
 
 
@@ -63,23 +64,41 @@ def _patch_cloud(
     )
 
 
+@pytest.mark.parametrize(
+    ("provider", "region", "expected_host"),
+    [
+        (
+            "volcengine",
+            "cn-beijing",
+            "veadk-studio-2100123456.tos-cn-beijing.volces.com",
+        ),
+        (
+            "byteplus",
+            "ap-southeast-1",
+            "veadk-studio-2100123456.tos-ap-southeast-1.bytepluses.com",
+        ),
+    ],
+)
 def test_auto_storage_uses_stable_account_bucket_and_creates_it_private(
     monkeypatch: pytest.MonkeyPatch,
+    provider: StudioProvider,
+    region: str,
+    expected_host: str,
 ) -> None:
     client = _FakeTosClient()
     _patch_cloud(monkeypatch, client)
 
     config = provisioning.resolve_studio_storage_for_deploy(
-        provider="volcengine",
-        region="cn-beijing",
+        provider=provider,
+        region=region,
         access_key="ak",
         secret_key="sk",
         source={},
     )
 
     assert config.bucket == "veadk-studio-2100123456"
-    assert config.region == "cn-beijing"
-    assert config.object_host == ("veadk-studio-2100123456.tos-cn-beijing.volces.com")
+    assert config.region == region
+    assert config.object_host == expected_host
     assert client.created == [{"bucket": "veadk-studio-2100123456"}]
 
 

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -7762,6 +7762,7 @@ def frontend_deploy(
         if session_token:
             os.environ["BYTEPLUS_SESSION_TOKEN"] = session_token
 
+    auto_identity_resources = not (user_pool_id and allowed_client_id)
     user_pool_domain = ""
     if user_pool_id and allowed_client_id:
         identity_region = _resolve_studio_identity_region(
@@ -7833,6 +7834,9 @@ def frontend_deploy(
         resolve_studio_storage_for_deploy,
     )
 
+    auto_storage = not str(
+        veadk_environments.get("VEADK_STUDIO_TOS_BUCKET") or ""
+    ).strip()
     click.echo("Ensuring Studio persistent storage…")
     try:
         storage_config = resolve_studio_storage_for_deploy(
@@ -8275,6 +8279,22 @@ def frontend_deploy(
         if user_pool_domain:
             click.echo(f"   user pool domain: {user_pool_domain}")
         click.echo(f"   client id: {allowed_client_id}")
+        if auto_identity_resources or auto_storage or missing_sandbox_tools:
+            identity_console = (
+                "https://console.byteplus.com/identity"
+                if provider_id == "byteplus"
+                else "https://console.volcengine.com/identity"
+            )
+            click.echo("")
+            click.echo("   Cloud resources configured for this Studio:")
+            for kind, tool_id in resolved_sandbox_tool_ids.items():
+                click.echo(f"   [{sandbox_tool_labels[kind]}]: {tool_id}")
+            click.echo(f"   TOS (private): https://{storage_config.object_host}")
+            click.echo(f"   user pool id: {user_pool_id}")
+            click.echo(f"   client id: {allowed_client_id}")
+            click.echo(f"   Identity console: {identity_console}")
+            click.echo("   Password sign-in is disabled by default for security.")
+            click.echo("   Configure an SSO identity provider before inviting users.")
         click.echo("   (open the URL — you'll be redirected through SSO login)")
     finally:
         shutil.rmtree(tmp, ignore_errors=True)


### PR DESCRIPTION
## Summary
- print resolved Sandbox Tool IDs, the private TOS address, and Identity user pool/client IDs after automatic Studio provisioning
- link to the provider-specific Volcengine or BytePlus Identity console and explain that password sign-in is disabled by default
- cover both providers, explicit-resource deployments, and private bucket creation in tests and documentation

## Validation
- pre-commit hooks passed: Ruff check, Ruff format, and gitleaks
- full Python suite: 1372 passed, 5 skipped
- full frontend suite: 462 passed
- frontend production build passed

## Known baseline
- targeted Pyright still reports the same 27 existing errors in the broad Studio CLI and test modules; the new lines introduce no additional errors