### PR TITLE
feat(studio): persist evaluation optimization snapshots to TOS

### DIFF
--- a/frontend/server/evaluation_automation/__init__.py
+++ b/frontend/server/evaluation_automation/__init__.py
@@ -21,27 +21,59 @@ from typing import Any
 
 import httpx
 
+from frontend.server.storage import StudioProvider, StudioStorageConfig
+from veadk.utils.logger import get_logger
+
 from .datasets import ensure_feedback_sets
 from .model_gateway import StructuredEvaluationModels
 from .models import RunSseActivity
 from .repository import (
     AgentKitAutoEvaluationRepository,
     InMemoryOptimizationRepository,
+    TosOptimizationRepository,
 )
 from .routes import mount_routes
 from .service import EvaluationAutomationService
 from .sse import RunSseObservation, observed_sse_stream
 
 OpenApiPost = Callable[..., Awaitable[dict[str, Any]]]
+CredentialResolver = Callable[[], tuple[str, str, str | None]]
+logger = get_logger(__name__)
 
 
 def create_service(
     *,
     openapi_post: OpenApiPost,
+    provider: StudioProvider = "volcengine",
+    resolve_credentials: CredentialResolver | None = None,
     quiet_seconds: float = 300,
 ) -> EvaluationAutomationService:
     models = StructuredEvaluationModels()
-    optimizations = InMemoryOptimizationRepository()
+    storage = StudioStorageConfig.from_env(provider)
+    if storage.configured and resolve_credentials is not None:
+
+        def tos_client() -> Any:
+            import tos
+
+            access_key, secret_key, session_token = resolve_credentials()
+            return tos.TosClientV2(
+                ak=access_key,
+                sk=secret_key,
+                security_token=session_token,
+                endpoint=storage.endpoint,
+                region=storage.region,
+            )
+
+        optimizations = TosOptimizationRepository(
+            bucket=storage.bucket,
+            client_factory=tos_client,
+        )
+    else:
+        logger.warning(
+            "Studio optimization snapshots are using process-local storage because "
+            "VEADK_STUDIO_TOS_BUCKET/REGION or a credential resolver is unavailable."
+        )
+        optimizations = InMemoryOptimizationRepository()
 
     async def runtime_get(
         activity: RunSseActivity,

--- a/frontend/server/evaluation_automation/repository.py
+++ b/frontend/server/evaluation_automation/repository.py
@@ -19,8 +19,10 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Protocol
+from urllib.parse import quote
 
 from veadk.integrations.agentkit.evaluation import AgentKitOpenApiError
 
@@ -46,6 +48,8 @@ AUTO_FIELD_KEYS = (
 _MAX_DATASET_NAME_LENGTH = 50
 _DUPLICATE_DATASET_ERROR_CODE = "601104504"
 _LOOKUP_DELAYS = (0.25, 0.5, 1.0, 2.0, 4.0)
+_OPTIMIZATION_KEY_PREFIX = "veadk-studio/v1/evaluation-optimizations"
+_MAX_OPTIMIZATION_BYTES = 8 * 1024 * 1024
 
 
 class AgentKitPost(Protocol):
@@ -311,16 +315,81 @@ class AgentKitAutoEvaluationRepository:
 
 
 class InMemoryOptimizationRepository:
-    """POC snapshot store; replaceable without changing orchestration."""
+    """Process-local fallback used when Studio storage is not configured."""
 
     def __init__(self) -> None:
         self._items: dict[tuple[str, str], OptimizationSnapshot] = {}
 
-    def put(self, snapshot: OptimizationSnapshot) -> None:
+    async def put(self, snapshot: OptimizationSnapshot) -> None:
         self._items[(snapshot.runtime_id, snapshot.app_name)] = snapshot
 
-    def get(self, runtime_id: str, app_name: str) -> OptimizationSnapshot | None:
+    async def get(
+        self,
+        runtime_id: str,
+        app_name: str,
+    ) -> OptimizationSnapshot | None:
         return self._items.get((runtime_id, app_name))
+
+
+class TosOptimizationRepository:
+    """Persist the latest optimization snapshot for each Runtime application."""
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        client_factory: Callable[[], Any],
+    ) -> None:
+        if not bucket.strip():
+            raise ValueError("TOS optimization storage requires a bucket.")
+        self._bucket = bucket
+        self._client_factory = client_factory
+
+    async def put(self, snapshot: OptimizationSnapshot) -> None:
+        await asyncio.to_thread(self._put, snapshot)
+
+    def _put(self, snapshot: OptimizationSnapshot) -> None:
+        content = snapshot.model_dump_json(by_alias=True).encode("utf-8")
+        self._client_factory().put_object(
+            bucket=self._bucket,
+            key=self._key(snapshot.runtime_id, snapshot.app_name),
+            content=content,
+            content_type="application/json",
+        )
+
+    async def get(
+        self,
+        runtime_id: str,
+        app_name: str,
+    ) -> OptimizationSnapshot | None:
+        return await asyncio.to_thread(self._get, runtime_id, app_name)
+
+    def _get(
+        self,
+        runtime_id: str,
+        app_name: str,
+    ) -> OptimizationSnapshot | None:
+        import tos
+
+        try:
+            response = self._client_factory().get_object(
+                bucket=self._bucket,
+                key=self._key(runtime_id, app_name),
+            )
+        except tos.exceptions.TosServerError as error:
+            if error.status_code == 404:
+                return None
+            raise
+        content = b"".join(response)
+        if len(content) > _MAX_OPTIMIZATION_BYTES:
+            raise ValueError("Studio optimization snapshot is too large.")
+        return OptimizationSnapshot.model_validate_json(content)
+
+    @staticmethod
+    def _key(runtime_id: str, app_name: str) -> str:
+        runtime_segment = quote(runtime_id, safe="")
+        app_segment = quote(app_name, safe="")
+        return f"{_OPTIMIZATION_KEY_PREFIX}/{runtime_segment}/{app_segment}.json"
 
 
 def _extract_items(response: dict[str, Any]) -> list[dict[str, Any]]:

--- a/frontend/server/evaluation_automation/routes.py
+++ b/frontend/server/evaluation_automation/routes.py
@@ -60,7 +60,7 @@ def mount_routes(
         region: str = Query(default="cn-beijing", min_length=1),
     ) -> dict[str, Any]:
         authorize(request, runtimeId, region)
-        snapshot = service.get_optimizations(runtimeId, appName)
+        snapshot = await service.get_optimizations(runtimeId, appName)
         if snapshot is None:
             return {
                 "runtimeId": runtimeId,

--- a/frontend/server/evaluation_automation/service.py
+++ b/frontend/server/evaluation_automation/service.py
@@ -34,7 +34,7 @@ from .models import (
     OptimizationSnapshot,
     RunSseActivity,
 )
-from .repository import InMemoryOptimizationRepository, auto_item_key
+from .repository import auto_item_key
 from .scheduler import QuietSessionScheduler
 
 logger = get_logger(__name__)
@@ -62,6 +62,16 @@ class CaseRepository(Protocol):
     ) -> list[AutoEvaluationCase]: ...
 
 
+class OptimizationRepository(Protocol):
+    async def put(self, snapshot: OptimizationSnapshot) -> None: ...
+
+    async def get(
+        self,
+        runtime_id: str,
+        app_name: str,
+    ) -> OptimizationSnapshot | None: ...
+
+
 RuntimeGet = Callable[[RunSseActivity, str], Awaitable[dict[str, Any]]]
 CaseRepositoryFactory = Callable[[RunSseActivity], Awaitable[CaseRepository]]
 
@@ -72,7 +82,7 @@ class EvaluationAutomationService:
         *,
         evaluator: Evaluator,
         optimizer: Optimizer,
-        optimization_repository: InMemoryOptimizationRepository,
+        optimization_repository: OptimizationRepository,
         runtime_get: RuntimeGet,
         case_repository: CaseRepositoryFactory,
         quiet_seconds: float = 300,
@@ -180,7 +190,7 @@ class EvaluationAutomationService:
                     agent_info=agent_info,
                     cases=cases,
                 )
-                self._optimizations.put(
+                await self._optimizations.put(
                     OptimizationSnapshot(
                         runtimeId=activity.runtime_id,
                         appName=activity.app_name,
@@ -234,12 +244,12 @@ class EvaluationAutomationService:
         repository = await self._case_repository(activity)
         return await repository.list_cases(agent_name=agent_name, page_size=page_size)
 
-    def get_optimizations(
+    async def get_optimizations(
         self,
         runtime_id: str,
         app_name: str,
     ) -> OptimizationSnapshot | None:
-        return self._optimizations.get(runtime_id, app_name)
+        return await self._optimizations.get(runtime_id, app_name)
 
     async def close(self) -> None:
         await self.scheduler.close()

--- a/tests/cli/test_frontend_evaluation_feedback.py
+++ b/tests/cli/test_frontend_evaluation_feedback.py
@@ -502,7 +502,7 @@ def test_feedback_cases_list_agentkit_dataset_items(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     class _Automation:
-        def get_optimizations(self, runtime_id: str, app_name: str) -> None:
+        async def get_optimizations(self, runtime_id: str, app_name: str) -> None:
             del runtime_id, app_name
 
         async def close(self) -> None:

--- a/tests/cli/test_frontend_runtime_proxy.py
+++ b/tests/cli/test_frontend_runtime_proxy.py
@@ -1084,7 +1084,7 @@ def test_studio_runtime_proxy_only_schedules_successful_completed_sse(
         def session_completed(self, activity: Any) -> None:
             self.completed.append(activity)
 
-        def get_optimizations(self, runtime_id: str, app_name: str) -> None:
+        async def get_optimizations(self, runtime_id: str, app_name: str) -> None:
             del runtime_id, app_name
 
         async def close(self) -> None:

--- a/tests/frontend/server/evaluation_automation/test_repository.py
+++ b/tests/frontend/server/evaluation_automation/test_repository.py
@@ -14,14 +14,153 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
+import tos
 
-from frontend.server.evaluation_automation.models import AutoEvaluationCase
+from frontend.server.evaluation_automation import create_service
+from frontend.server.evaluation_automation.models import (
+    AutoEvaluationCase,
+    OptimizationGroup,
+    OptimizationSnapshot,
+    OptimizationSuggestion,
+)
 from frontend.server.evaluation_automation.repository import (
     AgentKitAutoEvaluationRepository,
+    TosOptimizationRepository,
 )
+
+
+class _FakeTosClient:
+    def __init__(self) -> None:
+        self.objects: dict[tuple[str, str], bytes] = {}
+
+    def put_object(
+        self,
+        *,
+        bucket: str,
+        key: str,
+        content: bytes,
+        content_type: str,
+    ) -> None:
+        assert content_type == "application/json"
+        self.objects[(bucket, key)] = content
+
+    def get_object(self, *, bucket: str, key: str) -> list[bytes]:
+        try:
+            return [self.objects[(bucket, key)]]
+        except KeyError as error:
+            response = SimpleNamespace(request_id="request", headers={}, status=404)
+            raise tos.exceptions.TosServerError(
+                response,
+                "not found",
+                "NoSuchKey",
+                "host",
+                key,
+            ) from error
+
+
+def _optimization_snapshot() -> OptimizationSnapshot:
+    return OptimizationSnapshot(
+        runtimeId="runtime/id",
+        appName="客服/助手",
+        generatedAt=datetime(2026, 8, 11, tzinfo=timezone.utc),
+        optimizerVersion="v1",
+        sourceItemKeys=["case-1"],
+        groups=[
+            OptimizationGroup(
+                priority="high",
+                module="prompt",
+                items=[
+                    OptimizationSuggestion(
+                        suggestion="补充回答格式",
+                        reason="让输出结构更加稳定。",
+                    )
+                ],
+            )
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_tos_optimization_repository_survives_recreation() -> None:
+    client = _FakeTosClient()
+    repository = TosOptimizationRepository(
+        bucket="studio-bucket",
+        client_factory=lambda: client,
+    )
+    snapshot = _optimization_snapshot()
+
+    await repository.put(snapshot)
+    restored = await TosOptimizationRepository(
+        bucket="studio-bucket",
+        client_factory=lambda: client,
+    ).get(snapshot.runtime_id, snapshot.app_name)
+
+    assert restored == snapshot
+    expected_key = (
+        "veadk-studio/v1/evaluation-optimizations/"
+        "runtime%2Fid/%E5%AE%A2%E6%9C%8D%2F%E5%8A%A9%E6%89%8B.json"
+    )
+    assert list(client.objects) == [
+        (
+            "studio-bucket",
+            expected_key,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tos_optimization_repository_returns_none_for_missing_object() -> None:
+    repository = TosOptimizationRepository(
+        bucket="studio-bucket",
+        client_factory=_FakeTosClient,
+    )
+
+    assert await repository.get("runtime", "agent") is None
+
+
+@pytest.mark.asyncio
+async def test_create_service_reads_optimizations_from_configured_tos(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VEADK_STUDIO_TOS_BUCKET", "studio-bucket")
+    monkeypatch.setenv("VEADK_STUDIO_TOS_REGION", "cn-beijing")
+    client = _FakeTosClient()
+    snapshot = _optimization_snapshot()
+    await TosOptimizationRepository(
+        bucket="studio-bucket",
+        client_factory=lambda: client,
+    ).put(snapshot)
+    credentials_calls = 0
+
+    def resolve_credentials() -> tuple[str, str, None]:
+        nonlocal credentials_calls
+        credentials_calls += 1
+        return "ak", "sk", None
+
+    monkeypatch.setattr(tos, "TosClientV2", lambda **kwargs: client)
+
+    async def openapi_post(**kwargs: Any) -> dict[str, Any]:
+        raise AssertionError(kwargs)
+
+    service = create_service(
+        openapi_post=openapi_post,
+        provider="volcengine",
+        resolve_credentials=resolve_credentials,
+    )
+
+    restored = await service.get_optimizations(
+        snapshot.runtime_id,
+        snapshot.app_name,
+    )
+
+    assert restored == snapshot
+    assert credentials_calls == 1
+    await service.close()
 
 
 @pytest.mark.asyncio

--- a/tests/frontend/server/evaluation_automation/test_routes.py
+++ b/tests/frontend/server/evaluation_automation/test_routes.py
@@ -15,12 +15,15 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from frontend.server.evaluation_automation.models import AutomaticEvaluationStatus
+from frontend.server.evaluation_automation.models import (
+    AutomaticEvaluationStatus,
+    OptimizationSnapshot,
+)
 from frontend.server.evaluation_automation.routes import mount_routes
 
 
@@ -72,3 +75,31 @@ def test_status_route_authorizes_and_filters_the_current_user() -> None:
         app_name="agent",
         user_id="user",
     )
+
+
+def test_optimization_route_reads_the_persisted_snapshot() -> None:
+    service = Mock()
+    service.get_optimizations = AsyncMock(
+        return_value=OptimizationSnapshot(
+            runtimeId="runtime",
+            appName="agent",
+            optimizerVersion="v1",
+            sourceItemKeys=["case-1"],
+            groups=[],
+        )
+    )
+    app = FastAPI()
+    mount_routes(app, service, Mock())
+
+    response = TestClient(app).get(
+        "/web/evaluation/optimizations",
+        params={
+            "runtimeId": "runtime",
+            "region": "cn-beijing",
+            "appName": "agent",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["sourceItemKeys"] == ["case-1"]
+    service.get_optimizations.assert_awaited_once_with("runtime", "agent")

--- a/tests/frontend/server/evaluation_automation/test_service.py
+++ b/tests/frontend/server/evaluation_automation/test_service.py
@@ -155,7 +155,7 @@ async def test_service_evaluates_latest_turn_and_updates_optimization_snapshot()
     assert case.kind == "good"
     assert case.source == "auto"
     assert case.reason == "回答准确且完整。"
-    snapshot = optimizations.get("runtime", "agent")
+    snapshot = await optimizations.get("runtime", "agent")
     assert snapshot is not None
     assert snapshot.groups[0].module == "prompt"
     await service.close()

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -5057,6 +5057,8 @@ def _run_frontend_server(
 
         evaluation_automation = create_evaluation_automation_service(
             openapi_post=_evaluation_automation_openapi_post,
+            provider=provider,
+            resolve_credentials=_resolve_ve_credentials,
         )
         app.state.evaluation_automation = evaluation_automation
         original_lifespan = app.router.lifespan_context


### PR DESCRIPTION
## Summary

- persist Studio evaluation optimization snapshots in the configured TOS bucket
- isolate snapshots by encoded Runtime ID and app name under `veadk-studio/v1/evaluation-optimizations/`
- keep process-local storage only when Studio TOS is not configured, and surface configured-storage failures
- cover TOS reads, writes, missing objects, invalid payloads, route behavior, and CLI environment forwarding

## Testing

- `uv run pre-commit run --files <changed files>`
- `uv run pytest -q tests/frontend/server/evaluation_automation/test_repository.py tests/frontend/server/evaluation_automation/test_routes.py tests/frontend/server/evaluation_automation/test_service.py tests/cli/test_frontend_evaluation_feedback.py tests/cli/test_frontend_runtime_proxy.py` (48 passed)
- `uv run pyright frontend/server/evaluation_automation/__init__.py frontend/server/evaluation_automation/repository.py frontend/server/evaluation_automation/routes.py frontend/server/evaluation_automation/service.py`
- cloud end-to-end verification of automatic Good/Bad evaluation, optimization generation, TOS persistence, and reload recovery
