### PR TITLE
fix(skills): configure default executor for generated agents

### DIFF
--- a/tests/cli/test_generated_agent_backend_codegen_extended.py
+++ b/tests/cli/test_generated_agent_backend_codegen_extended.py
@@ -77,7 +77,7 @@ _MINIMAL_FRONTEND_GOLDEN = {
 _FULL_FRONTEND_GOLDEN = {
     "app.py": "56183a125e505c543294356fc9c7662a5eedb3b8661070f6be1df9b579e35ed4",
     "agents/__init__.py": "a6449a6cac3bfda8b834ea39ea95ca2f8d0471ac480e1e876313d7398eea59ba",
-    "agents/full_agent/agent.py": "e355eea82be49e735b5ea740ed9115980d05c5b1b083a19a8b75b3242f5f00bb",
+    "agents/full_agent/agent.py": "cc2b0b6be7f781573fbbd744becdf2608b8ebff881b9e58a979fe695485ffe30",
     "agents/full_agent/__init__.py": "ba3abbb199bbae74dc75151a44ba53a557e5f47d509835950ca756346c5a9582",
     "agents/full_agent/dynamic_a2a.py": "d136f27d6a77439708c415686a3d167f2ad2fb9a96a5f8a0751916b09d46e364",
     ".env.example": "3e6a5c1ee1c96ed7394240f9c0503c295552cb497ad51c68dd867dd4945f750b",
@@ -190,7 +190,9 @@ def test_full_project_matches_frontend_codegen_golden() -> None:
     assert project.name == "full_agent"
     assert "enableA2ui" not in draft.model_dump()
     assert "enable_a2ui" not in agent_py
-    assert "skills_agent = SkillToolset(skills=[" in agent_py
+    assert "skills_agent = SkillToolset(" in agent_py
+    assert "from google.adk.code_executors import UnsafeLocalCodeExecutor" in agent_py
+    assert "code_executor=UnsafeLocalCodeExecutor()" in agent_py
     root_agent_block = agent_py.rsplit("agent = Agent(", 1)[1].split(
         "\n)\n\nAGENT_DISPLAY_NAMES",
         1,

--- a/tests/cloud/test_harness_skill_download.py
+++ b/tests/cloud/test_harness_skill_download.py
@@ -18,8 +18,17 @@ from __future__ import annotations
 
 import io
 import zipfile
+from types import SimpleNamespace
 
 import httpx
+import pytest
+from google.adk.agents import LlmAgent
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.code_executors import UnsafeLocalCodeExecutor
+from google.adk.sessions import InMemorySessionService, Session
+from google.adk.skills import load_skill_from_dir
+from google.adk.tools import ToolContext
+from google.adk.tools.skill_toolset import SkillToolset
 
 from veadk.cloud.harness_app import utils
 from veadk.skills.skill import Skill as VeADKSkill
@@ -140,3 +149,86 @@ def test_build_skill_toolset_loads_skills_center_space(monkeypatch, tmp_path):
 
     assert calls == ["ss-test"]
     assert [skill.name for skill in toolset._list_skills()] == ["center-skill"]
+    assert isinstance(toolset._code_executor, UnsafeLocalCodeExecutor)
+
+
+def test_incremental_skills_preserve_existing_code_executor(monkeypatch, tmp_path):
+    existing_dir = tmp_path / "existing"
+    incoming_dir = tmp_path / "incoming"
+    _write_adk_skill(existing_dir, name="existing")
+    _write_adk_skill(incoming_dir, name="incoming")
+
+    executor = UnsafeLocalCodeExecutor()
+    existing_toolset = SkillToolset(
+        skills=[load_skill_from_dir(existing_dir)],
+        code_executor=executor,
+    )
+    incoming_toolset = SkillToolset(
+        skills=[load_skill_from_dir(incoming_dir)],
+        code_executor=UnsafeLocalCodeExecutor(),
+    )
+    agent = SimpleNamespace(tools=[existing_toolset])
+    monkeypatch.setattr(
+        utils,
+        "build_skill_toolset",
+        lambda skill_ids, download_dir=None: incoming_toolset,
+    )
+
+    utils._add_incremental_skills(agent, ["incoming"])
+
+    merged_toolset = agent.tools[0]
+    assert [skill.name for skill in merged_toolset._list_skills()] == [
+        "existing",
+        "incoming",
+    ]
+    assert merged_toolset._code_executor is executor
+
+
+@pytest.mark.asyncio
+async def test_build_skill_toolset_runs_python_script(monkeypatch, tmp_path):
+    skill_dir = tmp_path / "python-sum"
+    _write_adk_skill(skill_dir, name="python-sum")
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "add.py").write_text(
+        "import sys\nprint(int(sys.argv[1]) + int(sys.argv[2]))\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        utils,
+        "_download_and_extract_skill",
+        lambda skill, download_dir: skill_dir,
+    )
+
+    toolset = utils.build_skill_toolset(["python-sum"], download_dir=tmp_path)
+    run_script = next(
+        tool for tool in await toolset.get_tools() if tool.name == "run_skill_script"
+    )
+    agent = LlmAgent(name="test_agent", model="gemini-2.0-flash")
+    invocation_context = InvocationContext(
+        session_service=InMemorySessionService(),
+        invocation_id="test-invocation",
+        agent=agent,
+        session=Session(
+            id="test-session",
+            appName=agent.name,
+            userId="test-user",
+        ),
+    )
+
+    result = await run_script.run_async(
+        args={
+            "skill_name": "python-sum",
+            "file_path": "scripts/add.py",
+            "args": ["17", "25"],
+        },
+        tool_context=ToolContext(invocation_context),
+    )
+
+    assert result == {
+        "skill_name": "python-sum",
+        "file_path": "scripts/add.py",
+        "stdout": "42\n",
+        "stderr": "",
+        "status": "success",
+    }

--- a/tests/integrations/agentkit/test_session_capabilities.py
+++ b/tests/integrations/agentkit/test_session_capabilities.py
@@ -20,6 +20,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from google.adk.agents import LlmAgent
+from google.adk.code_executors import UnsafeLocalCodeExecutor
 from google.adk.sessions import InMemorySessionService
 
 import veadk.integrations.agentkit.app as agentkit_app
@@ -247,6 +248,7 @@ async def test_build_agent_loads_skill_without_mutating_base(
     assert loaded == [("skill-space-1", "pdf-reader", "")]
     assert len(run_agent.tools) == 1
     assert type(run_agent.tools[0]).__name__ == "SkillToolset"
+    assert isinstance(run_agent.tools[0]._code_executor, UnsafeLocalCodeExecutor)
     assert "`pdf-reader`" in run_agent.instruction
     assert "call list_skills" in run_agent.instruction
     assert root_agent.tools == []

--- a/veadk/cli/generated_agent_codegen.py
+++ b/veadk/cli/generated_agent_codegen.py
@@ -614,6 +614,10 @@ def _build_agent(acc: _Acc, draft: AgentDraft, var_name: str) -> str:
     ]
     if skill_folders:
         _add_import(acc, "from pathlib import Path as _Path")
+        _add_import(
+            acc,
+            "from google.adk.code_executors import UnsafeLocalCodeExecutor",
+        )
         _add_import(acc, "from google.adk.skills import load_skill_from_dir")
         _add_import(acc, "from google.adk.tools.skill_toolset import SkillToolset")
         v = _unique_ident(acc, f"skills_{var_name}", "skill_toolset")
@@ -623,7 +627,12 @@ def _build_agent(acc: _Acc, draft: AgentDraft, var_name: str) -> str:
             for folder in skill_folders
         ]
         joined_loaders = ",\n".join(loaders)
-        acc.pre_lines.append(f"{v} = SkillToolset(skills=[\n{joined_loaders},\n    ])")
+        acc.pre_lines.append(
+            f"{v} = SkillToolset(\n"
+            f"    skills=[\n{joined_loaders},\n    ],\n"
+            "    code_executor=UnsafeLocalCodeExecutor(),\n"
+            ")"
+        )
         tool_exprs.append(v)
 
     kwargs = [

--- a/veadk/cloud/harness_app/utils.py
+++ b/veadk/cloud/harness_app/utils.py
@@ -38,6 +38,7 @@ from urllib.parse import urlencode
 
 import frontmatter
 import httpx
+from google.adk.code_executors import UnsafeLocalCodeExecutor
 from google.adk.skills import load_skill_from_dir
 from google.adk.tools.skill_toolset import SkillToolset
 
@@ -371,7 +372,10 @@ def build_skill_toolset(
                 )
         except Exception as e:
             raise SkillLoadError(f"Skill '{skill}' failed to load: {e}") from e
-    return SkillToolset(skills=loaded_skills)
+    return SkillToolset(
+        skills=loaded_skills,
+        code_executor=UnsafeLocalCodeExecutor(),
+    )
 
 
 def config_from_env() -> HarnessConfig:
@@ -525,7 +529,12 @@ def _add_incremental_skills(
         return
 
     agent.tools.remove(existing_toolset)
-    agent.tools.append(SkillToolset(skills=existing_skills + new_skills))
+    agent.tools.append(
+        SkillToolset(
+            skills=existing_skills + new_skills,
+            code_executor=(existing_toolset._code_executor or toolset._code_executor),
+        )
+    )
 
 
 def _remove_a2a_registry_tools(agent: Agent) -> None:

--- a/veadk/integrations/agentkit/session_capabilities.py
+++ b/veadk/integrations/agentkit/session_capabilities.py
@@ -27,6 +27,7 @@ from uuid import uuid4
 
 from fastapi import APIRouter, FastAPI, HTTPException, Query
 from google.adk.agents.base_agent import BaseAgent
+from google.adk.code_executors import UnsafeLocalCodeExecutor
 from google.adk.events import Event, EventActions
 from google.adk.sessions import BaseSessionService, Session
 from google.adk.tools.skill_toolset import SkillToolset
@@ -491,7 +492,12 @@ class SessionCapabilityService:
                 )
             )
         if loaded_skills:
-            agent_tools.append(SkillToolset(skills=loaded_skills))
+            agent_tools.append(
+                SkillToolset(
+                    skills=loaded_skills,
+                    code_executor=UnsafeLocalCodeExecutor(),
+                )
+            )
             instruction = getattr(agent, "instruction", None)
             if isinstance(instruction, str):
                 skill_names = ", ".join(


### PR DESCRIPTION
## Summary
- configure `UnsafeLocalCodeExecutor` for generated and harness-mounted skill toolsets
- preserve the configured executor when dynamically merging skills
- enable script execution for session-mounted AgentKit skills
- add regression coverage for generated code, dynamic merging, and real Python skill execution

## Validation
- `uv run pre-commit run --all-files`
- `uv run pytest -q` (`1374 passed, 5 skipped, 6 subtests passed`)
- locally served a generated agent before and after the change; the same Python skill changed from `NO_CODE_EXECUTOR` to `SCRIPT_RESULT=42`