### PR TITLE
fix(studio): use provider-specific APMPlus endpoint

### DIFF
--- a/tests/cli/test_frontend_apmplus_trace.py
+++ b/tests/cli/test_frontend_apmplus_trace.py
@@ -23,6 +23,7 @@ from veadk.cli.frontend_apmplus_trace import (
     load_apmplus_trace,
     normalize_apmplus_trace,
 )
+from veadk.utils.cloud_provider import CloudProvider
 
 
 class _Span:
@@ -33,10 +34,20 @@ class _Span:
         return self.value
 
 
-def test_apmplus_trace_filters_session_runtime_and_invocation(
+@pytest.mark.parametrize(
+    ("provider", "expected_host"),
+    [
+        ("volcengine", "https://open.volcengineapi.com"),
+        ("byteplus", "https://open.byteplusapi.com"),
+    ],
+)
+def test_apmplus_trace_uses_provider_endpoint_and_filters_spans(
     monkeypatch: pytest.MonkeyPatch,
+    provider: CloudProvider,
+    expected_host: str,
 ) -> None:
     requests: list[Any] = []
+    hosts: list[str] = []
     rows = [
         _Span(
             {
@@ -69,8 +80,8 @@ def test_apmplus_trace_filters_session_runtime_and_invocation(
     ]
 
     class _FakeApi:
-        def __init__(self, _client: object) -> None:
-            pass
+        def __init__(self, client: Any) -> None:
+            hosts.append(client.configuration.host)
 
         def list_span(self, request: Any) -> SimpleNamespace:
             requests.append(request)
@@ -85,6 +96,7 @@ def test_apmplus_trace_filters_session_runtime_and_invocation(
         access_key="ak",
         secret_key="sk",
         session_token="token",
+        provider=provider,
         region="cn-beijing",
         project_name="default",
         runtime_id="runtime-1",
@@ -94,6 +106,7 @@ def test_apmplus_trace_filters_session_runtime_and_invocation(
     )
 
     assert [span["span_id"] for span in trace] == ["span-1", "span-2"]
+    assert hosts == [expected_host]
     assert requests[0].project_name == "default"
     assert requests[0].order_by == "start_time"
     assert requests[0].filters[0].key == "operation_name"

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -1246,6 +1246,7 @@ def _run_frontend_server(
             access_key=access_key,
             secret_key=secret_key,
             session_token=session_token or "",
+            provider=provider,
             region=region,
             project_name=str(getattr(runtime, "project_name", "") or "default"),
             runtime_id=runtime_id,

--- a/veadk/cli/frontend_apmplus_trace.py
+++ b/veadk/cli/frontend_apmplus_trace.py
@@ -26,6 +26,8 @@ from volcenginesdkapmplusserver import (
     ListSpanRequest,
 )
 
+from veadk.utils.cloud_provider import CloudProvider, apmplus_openapi_host
+
 _SESSION_TAGS = (
     "gen_ai.session.id",
     "gen_ai.conversation.id",
@@ -107,6 +109,7 @@ def load_apmplus_trace(
     access_key: str,
     secret_key: str,
     session_token: str,
+    provider: CloudProvider,
     region: str,
     project_name: str,
     runtime_id: str,
@@ -123,6 +126,7 @@ def load_apmplus_trace(
     configuration.sk = secret_key
     configuration.session_token = session_token
     configuration.region = region
+    configuration.host = f"https://{apmplus_openapi_host(provider)}"
     api = APMPLUSSERVERApi(volcenginesdkcore.ApiClient(configuration))
 
     end_time = now_ms if now_ms is not None else int(time.time() * 1000)

--- a/veadk/utils/cloud_provider.py
+++ b/veadk/utils/cloud_provider.py
@@ -106,6 +106,13 @@ def iam_openapi_host(provider: CloudProvider) -> str:
     return "iam.volcengineapi.com"
 
 
+def apmplus_openapi_host(provider: CloudProvider) -> str:
+    """Return the APMPlus OpenAPI host for a provider."""
+    if provider == "byteplus":
+        return "open.byteplusapi.com"
+    return "open.volcengineapi.com"
+
+
 def agentkit_openapi_base(region: str, provider: CloudProvider) -> str:
     """Return the AgentKit OpenAPI base URL used by Studio proxy helpers."""
     if provider == "byteplus":


### PR DESCRIPTION
## Summary

- pass the configured Studio cloud provider into runtime trace loading
- use `open.byteplusapi.com` for BytePlus APMPlus requests and retain `open.volcengineapi.com` for Volcengine
- add regression coverage for both provider endpoints and existing span filtering

## Problem

BytePlus runtime trace queries were sent to the Volcengine OpenAPI endpoint. APMPlus returned `InvalidEndpoint`, which Studio surfaced as HTTP 502 when opening the trace drawer.

## Verification

- `pre-commit run --all-files`
- `pytest -q` — 1379 passed, 5 skipped, 6 subtests passed
- live read-only `ListSpan` request succeeded against both BytePlus and Volcengine endpoints
- the affected BytePlus session returned its expected trace spans through the updated loader