### PR TITLE
Fix BytePlus Studio model catalog and runtime regions

### DIFF
--- a/frontend/server/skills/devenv.py
+++ b/frontend/server/skills/devenv.py
@@ -79,6 +79,7 @@ from veadk.cli.frontend_skill_creator import (
     _validated_activities,
 )
 from veadk.cli.studio_sandbox_tools import studio_sandbox_agent_model_name
+from veadk.cli.studio_model_catalog import provider_allows_model
 from veadk.skills.skill import Skill
 from veadk.utils.cloud_provider import cloud_provider_from_env
 from veadk.utils.logger import get_logger
@@ -308,11 +309,23 @@ def _model_options(tool: Any) -> list[dict[str, str]]:
     options: list[dict[str, str]] = []
     seen: set[str] = set()
     for model_id, label in candidates:
+        if not provider_allows_model(provider, model_id):
+            continue
         if model_id in seen:
             continue
         seen.add(model_id)
         options.append({"id": model_id, "label": label})
     return options
+
+
+def _validate_model_for_provider(provider: str, model_id: str) -> None:
+    if provider_allows_model(provider, model_id):
+        return
+    raise SkillWorkbenchError(
+        "SKILL_MODEL_UNSUPPORTED",
+        "当前 Studio 环境不支持该模型，请选择可用的模型 ID。",
+        status_code=422,
+    )
 
 
 class SkillWorkbenchError(RuntimeError):
@@ -1074,6 +1087,7 @@ class SkillWorkbenchService:
                 "请填写模型 ID。",
                 status_code=422,
             )
+        _validate_model_for_provider(cloud_provider_from_env(), selected_model)
         request_payload: dict[str, object] = {
             "jobId": job_id,
             "operation": body.operation,

--- a/frontend/src/adk/client.ts
+++ b/frontend/src/adk/client.ts
@@ -20,7 +20,11 @@ import {
 import type { AgentProject } from "../create/project";
 import type { AgentDraft, NetworkConfig } from "../create/types";
 import type { IssueFeedbackReport } from "./issueFeedback";
-import { VOLCENGINE_DEFAULT_REGION } from "./cloudProvider";
+import {
+  BYTEPLUS_DEFAULT_REGION,
+  VOLCENGINE_DEFAULT_REGION,
+  type CloudProvider,
+} from "./cloudProvider";
 
 /** An ADK event as serialised over `/run_sse` (camelCase, by_alias=True). */
 export interface AdkUsage {
@@ -494,10 +498,11 @@ const PRIVATE_RUNTIME_UNREACHABLE_MESSAGE =
   "Runtime 已部署成功，但当前 Studio 无法访问私网 Runtime。请使用已绑定相同 VPC 的 Studio 访问，或改用公网 / 公网+VPC 部署。";
 const RUNTIME_ENDPOINT_UNREACHABLE_MESSAGE =
   "Runtime 已部署成功，但 Studio 暂时无法连接服务。网关域名可能仍在生效，或当前网络/DNS 无法访问该 Runtime，请稍后在智能体管理页重试连接。";
-const RUNTIME_REGION_FALLBACKS = ["cn-beijing", "cn-shanghai"] as const;
+const VOLCENGINE_RUNTIME_REGION_FALLBACKS = ["cn-beijing", "cn-shanghai"] as const;
 const RUNTIME_APPS_CACHE_TTL_MS = 30_000;
 const RUNTIME_METADATA_CACHE_TTL_MS = 5 * 60 * 1000;
 const FEEDBACK_CASES_CACHE_TTL_MS = 60 * 1000;
+let activeCloudProvider: CloudProvider = "volcengine";
 
 interface ClientCacheEntry<T> {
   value?: T;
@@ -522,14 +527,29 @@ function runtimeAppsCacheKey(runtimeId: string, region: string): string {
   return `${region}:${runtimeId}`;
 }
 
-function runtimeRegionCandidates(region?: string): string[] {
-  const primary = region || VOLCENGINE_DEFAULT_REGION;
-  if (!RUNTIME_REGION_FALLBACKS.includes(primary as (typeof RUNTIME_REGION_FALLBACKS)[number])) {
+export function setClientCloudProvider(provider: CloudProvider): void {
+  activeCloudProvider = provider;
+}
+
+export function runtimeRegionCandidates(region?: string): string[] {
+  const raw = (region || "").trim();
+  if (activeCloudProvider === "byteplus") {
+    return [raw && !raw.startsWith("cn-") ? raw : BYTEPLUS_DEFAULT_REGION];
+  }
+  const primary =
+    raw && !raw.startsWith("ap-") ? raw : VOLCENGINE_DEFAULT_REGION;
+  if (
+    !VOLCENGINE_RUNTIME_REGION_FALLBACKS.includes(
+      primary as (typeof VOLCENGINE_RUNTIME_REGION_FALLBACKS)[number],
+    )
+  ) {
     return [primary];
   }
   return [
     primary,
-    ...RUNTIME_REGION_FALLBACKS.filter((candidate) => candidate !== primary),
+    ...VOLCENGINE_RUNTIME_REGION_FALLBACKS.filter(
+      (candidate) => candidate !== primary,
+    ),
   ];
 }
 
@@ -2390,10 +2410,12 @@ export async function getUiConfig(): Promise<UiConfig> {
     const logoUrl = typeof d.branding?.logoUrl === "string"
       ? d.branding.logoUrl
       : DEFAULT_SITE_BRANDING.logoUrl;
+    const provider = d.provider === "byteplus" ? "byteplus" : "volcengine";
+    setClientCloudProvider(provider);
     return {
       studio: d.studio ?? false,
       version: typeof d.version === "string" ? d.version : "",
-      provider: d.provider === "byteplus" ? "byteplus" : "volcengine",
+      provider,
       branding: {
         title: typeof d.branding?.title === "string"
           ? d.branding.title

--- a/frontend/src/adk/cloudProvider.ts
+++ b/frontend/src/adk/cloudProvider.ts
@@ -16,6 +16,12 @@ export const BYTEPLUS_DEFAULT_EMBEDDING_NAME = "skylark-embedding-vision-250615"
 export const VOLCENGINE_DEFAULT_EMBEDDING_NAME = "doubao-embedding-vision-250615";
 export const BYTEPLUS_PLANNER_MODEL_NAME = "seed-2-0-lite-260228";
 export const VOLCENGINE_PLANNER_MODEL_NAME = "doubao-seed-2-0-lite-260428";
+export const BYTEPLUS_DEFAULT_IMAGE_MODEL_NAME = "dola-seedream-5-0-pro-260628";
+export const VOLCENGINE_DEFAULT_IMAGE_MODEL_NAME = "doubao-seedream-5-0-260128";
+export const BYTEPLUS_DEFAULT_IMAGE_EDIT_MODEL_NAME = "seededit-3-0-i2i-250628";
+export const VOLCENGINE_DEFAULT_IMAGE_EDIT_MODEL_NAME = "doubao-seededit-3-0-i2i-250628";
+export const BYTEPLUS_DEFAULT_VIDEO_MODEL_NAME = "dreamina-seedance-2-0-260128";
+export const VOLCENGINE_DEFAULT_VIDEO_MODEL_NAME = "doubao-seedance-2-0-260128";
 
 const VOLCENGINE_REGIONS: CloudRegionOption[] = [
   { value: "cn-beijing", label: "华北 2（北京）" },
@@ -73,4 +79,22 @@ export function plannerModelName(provider: CloudProvider): string {
   return provider === "byteplus"
     ? BYTEPLUS_PLANNER_MODEL_NAME
     : VOLCENGINE_PLANNER_MODEL_NAME;
+}
+
+export function defaultImageModelName(provider: CloudProvider): string {
+  return provider === "byteplus"
+    ? BYTEPLUS_DEFAULT_IMAGE_MODEL_NAME
+    : VOLCENGINE_DEFAULT_IMAGE_MODEL_NAME;
+}
+
+export function defaultImageEditModelName(provider: CloudProvider): string {
+  return provider === "byteplus"
+    ? BYTEPLUS_DEFAULT_IMAGE_EDIT_MODEL_NAME
+    : VOLCENGINE_DEFAULT_IMAGE_EDIT_MODEL_NAME;
+}
+
+export function defaultVideoModelName(provider: CloudProvider): string {
+  return provider === "byteplus"
+    ? BYTEPLUS_DEFAULT_VIDEO_MODEL_NAME
+    : VOLCENGINE_DEFAULT_VIDEO_MODEL_NAME;
 }

--- a/frontend/src/adk/connections.ts
+++ b/frontend/src/adk/connections.ts
@@ -9,6 +9,7 @@ import {
   registerRemoteApp,
   RuntimeAccessDeniedError,
   RuntimeProbeError,
+  runtimeRegionCandidates,
 } from "./client";
 
 export interface RemoteConnection {
@@ -43,23 +44,11 @@ export interface AgentEntry {
 }
 
 const STORAGE_KEY = "veadk_agentkit_connections";
-const RUNTIME_REGION_FALLBACKS = ["cn-beijing", "cn-shanghai"] as const;
 const DEPLOYED_RUNTIME_CONNECT_INTERVAL_MS = 3_000;
 const DEPLOYED_RUNTIME_CONNECT_TIMEOUT_MS = 60_000;
 
 interface ConnectRuntimeOptions {
   waitForReady?: boolean;
-}
-
-function runtimeRegionCandidates(region: string): string[] {
-  const primary = region || "cn-beijing";
-  if (!RUNTIME_REGION_FALLBACKS.includes(primary as (typeof RUNTIME_REGION_FALLBACKS)[number])) {
-    return [primary];
-  }
-  return [
-    primary,
-    ...RUNTIME_REGION_FALLBACKS.filter((candidate) => candidate !== primary),
-  ];
 }
 
 export function loadConnections(): RemoteConnection[] {

--- a/frontend/src/create/CustomCreate.tsx
+++ b/frontend/src/create/CustomCreate.tsx
@@ -127,15 +127,14 @@ import type {
   UiFeatures,
 } from "../adk/client";
 import {
-  BYTEPLUS_DEFAULT_MODEL_NAME,
-  BYTEPLUS_MODELARK_BASE_URL,
   defaultCloudRegion,
   defaultEmbeddingModelName,
+  defaultImageEditModelName,
+  defaultImageModelName,
   defaultModelApiBase,
   defaultModelName,
+  defaultVideoModelName,
   plannerModelName,
-  VOLCENGINE_DEFAULT_MODEL_NAME,
-  VOLCENGINE_MODELARK_BASE_URL,
   type CloudProvider,
 } from "../adk/cloudProvider";
 import { applyEvent, emptyAcc, type Block } from "../blocks";
@@ -404,6 +403,22 @@ function providerRuntimeEnv(
       return { ...item, placeholder: defaultEmbeddingModelName(cloudProvider) };
     }
     if (item.key === "MODEL_EMBEDDING_API_BASE") {
+      return { ...item, placeholder: defaultModelApiBase(cloudProvider) };
+    }
+    if (item.key === "MODEL_IMAGE_NAME") {
+      return { ...item, placeholder: defaultImageModelName(cloudProvider) };
+    }
+    if (item.key === "MODEL_EDIT_NAME") {
+      return { ...item, placeholder: defaultImageEditModelName(cloudProvider) };
+    }
+    if (item.key === "MODEL_VIDEO_NAME") {
+      return { ...item, placeholder: defaultVideoModelName(cloudProvider) };
+    }
+    if (
+      item.key === "MODEL_IMAGE_API_BASE" ||
+      item.key === "MODEL_EDIT_API_BASE" ||
+      item.key === "MODEL_VIDEO_API_BASE"
+    ) {
       return { ...item, placeholder: defaultModelApiBase(cloudProvider) };
     }
     return item;
@@ -1988,6 +2003,61 @@ interface DebugTraceTarget {
   variantName: string;
 }
 
+function sameBaseUrl(a: string | undefined, b: string): boolean {
+  const normalize = (value: string | undefined) =>
+    (value ?? "").trim().replace(/\/+$/, "");
+  return normalize(a) === normalize(b);
+}
+
+function shouldUseProviderDefaultModel(
+  modelName: string | undefined,
+  previousProvider: CloudProvider,
+  nextProvider: CloudProvider,
+): boolean {
+  const trimmed = (modelName ?? "").trim();
+  if (!trimmed) return true;
+  if (trimmed === defaultModelName(previousProvider)) return true;
+  if (trimmed === defaultModelName(nextProvider)) return false;
+  return nextProvider === "byteplus" && trimmed.includes("doubao-");
+}
+
+function draftForCloudProvider(
+  draft: AgentDraft,
+  cloudProvider: CloudProvider,
+): AgentDraft {
+  const previousProvider = draft.cloudProvider ?? "volcengine";
+  const nextSubAgents = draft.subAgents.map((child) =>
+    draftForCloudProvider(child, cloudProvider),
+  );
+  const nextModelName = shouldUseProviderDefaultModel(
+    draft.modelName,
+    previousProvider,
+    cloudProvider,
+  )
+    ? defaultModelName(cloudProvider)
+    : draft.modelName;
+  const shouldUseProviderDefaultBase =
+    sameBaseUrl(draft.modelApiBase, defaultModelApiBase(previousProvider)) ||
+    (cloudProvider === "byteplus" &&
+      (draft.modelApiBase ?? "").includes("volces.com"));
+  const nextModelApiBase = shouldUseProviderDefaultBase
+    ? defaultModelApiBase(cloudProvider)
+    : draft.modelApiBase;
+  const changed =
+    draft.cloudProvider !== cloudProvider ||
+    nextModelName !== draft.modelName ||
+    nextModelApiBase !== draft.modelApiBase ||
+    nextSubAgents.some((child, index) => child !== draft.subAgents[index]);
+  if (!changed) return draft;
+  return {
+    ...draft,
+    cloudProvider,
+    modelName: nextModelName,
+    modelApiBase: nextModelApiBase,
+    subAgents: nextSubAgents,
+  };
+}
+
 function codegenDraft(draft: AgentDraft): AgentDraft {
   const prepared = prepareMcpAuth(draft).draft;
   return {
@@ -2648,36 +2718,14 @@ export function CustomCreate({
   void onBack; // no footer nav in the single-scroll layout; back lives in app chrome
   void onDiscard; // the discard action is intentionally hidden in this flow
   const [draft, setDraft] = useState<AgentDraft>(
-    () => initialDraft ?? emptyDraft(cloudProvider),
+    () =>
+      draftForCloudProvider(
+        initialDraft ?? emptyDraft(cloudProvider),
+        cloudProvider,
+      ),
   );
   useEffect(() => {
-    const otherProviderModel = cloudProvider === "byteplus"
-      ? VOLCENGINE_DEFAULT_MODEL_NAME
-      : BYTEPLUS_DEFAULT_MODEL_NAME;
-    const otherProviderBase = cloudProvider === "byteplus"
-      ? VOLCENGINE_MODELARK_BASE_URL
-      : BYTEPLUS_MODELARK_BASE_URL;
-    setDraft((current) => {
-      const nextModelName =
-        current.modelName?.trim() === otherProviderModel
-          ? defaultModelName(cloudProvider)
-          : current.modelName;
-      const nextModelApiBase =
-        current.modelApiBase?.trim() === otherProviderBase
-          ? defaultModelApiBase(cloudProvider)
-          : current.modelApiBase;
-      if (
-        nextModelName === current.modelName &&
-        nextModelApiBase === current.modelApiBase
-      ) {
-        return current;
-      }
-      return {
-        ...current,
-        modelName: nextModelName,
-        modelApiBase: nextModelApiBase,
-      };
-    });
+    setDraft((current) => draftForCloudProvider(current, cloudProvider));
   }, [cloudProvider]);
   const [aiRequirement, setAiRequirement] = useState("");
   const [aiGenerating, setAiGenerating] = useState(false);
@@ -2701,8 +2749,11 @@ export function CustomCreate({
   useEffect(() => {
     if (draftSnapshot === lastNotifiedDraftSnapshotRef.current) return;
     lastNotifiedDraftSnapshotRef.current = draftSnapshot;
-    onDraftChangeRef.current?.(draft, draftDirty);
-  }, [draft, draftDirty, draftSnapshot]);
+    onDraftChangeRef.current?.(
+      draftForCloudProvider(draft, cloudProvider),
+      draftDirty,
+    );
+  }, [cloudProvider, draft, draftDirty, draftSnapshot]);
   const [workspaceMode, setWorkspaceMode] = useState<WorkspaceMode>("build");
   const [showErrors, setShowErrors] = useState(false);
   const [validationPulse, setValidationPulse] = useState(0);
@@ -2715,21 +2766,27 @@ export function CustomCreate({
   const debugDisabledReason =
     features?.generatedAgentTestRunDisabledReason ||
     "当前后端暂不支持生成 Agent 调试运行。";
-  const [debugVariants, setDebugVariants] = useState<DebugVariant[]>(() => [
-    {
-      id: "baseline",
-      name: "基准组",
-      modelName: defaultDebugModelName(initialDraft ?? emptyDraft(cloudProvider)),
-      description: (initialDraft ?? emptyDraft(cloudProvider)).description,
-      instruction: (initialDraft ?? emptyDraft(cloudProvider)).instruction,
-      optimizations: [],
-      configOpen: false,
-      phase: "idle",
-      runtimeSnapshot: "",
-      messages: [],
-      error: null,
-    },
-  ]);
+  const [debugVariants, setDebugVariants] = useState<DebugVariant[]>(() => {
+    const initialProviderDraft = draftForCloudProvider(
+      initialDraft ?? emptyDraft(cloudProvider),
+      cloudProvider,
+    );
+    return [
+      {
+        id: "baseline",
+        name: "基准组",
+        modelName: defaultDebugModelName(initialProviderDraft),
+        description: initialProviderDraft.description,
+        instruction: initialProviderDraft.instruction,
+        optimizations: [],
+        configOpen: false,
+        phase: "idle",
+        runtimeSnapshot: "",
+        messages: [],
+        error: null,
+      },
+    ];
+  });
   const [selectedVariantId, setSelectedVariantId] = useState("baseline");
   const debugVariantSequenceRef = useRef(1);
   const baselineModelEditedRef = useRef(false);
@@ -2918,7 +2975,15 @@ export function CustomCreate({
     setBuildErr("");
     try {
       const result = await generateAgentDraftFromRequirement(requirement);
-      setDraft(sanitizeGeneratedDraftCapabilities(normalizeDraft(result.draft)));
+      setDraft(
+        draftForCloudProvider(
+          sanitizeGeneratedDraftCapabilities(
+            normalizeDraft(result.draft),
+            cloudProvider,
+          ),
+          cloudProvider,
+        ),
+      );
       setSelectedPath([]);
       setProject(null);
       setShowErrors(false);
@@ -3023,14 +3088,21 @@ export function CustomCreate({
     [draft, duplicateNames],
   );
   const canFinish = problems.length === 0;
+  const providerDraft = useMemo(
+    () => draftForCloudProvider(draft, cloudProvider),
+    [cloudProvider, draft],
+  );
   const currentDebugSnapshot = useMemo(
-    () => debugSnapshotKey(draft),
-    [draft],
+    () => debugSnapshotKey(providerDraft),
+    [providerDraft],
   );
   const selectedDebugVariant =
     debugVariants.find((variant) => variant.id === selectedVariantId) ??
     debugVariants[0];
-  const deploymentEnv = useMemo(() => collectDeploymentEnv(draft), [draft]);
+  const deploymentEnv = useMemo(
+    () => collectDeploymentEnv(providerDraft),
+    [providerDraft],
+  );
 
   // Smooth-scroll to the first invalid section during validation.
   const scrollToSection = (id: StepId) => {
@@ -3145,7 +3217,7 @@ export function CustomCreate({
     }
     const invalidEnv = firstInvalidRuntimeEnv(
       deploymentEnv.specs,
-      draft.deployment?.envValues ?? {},
+      providerDraft.deployment?.envValues ?? {},
     );
     if (invalidEnv) {
       setBuildErr(
@@ -3162,12 +3234,12 @@ export function CustomCreate({
       if (releaseVariant) setSelectedVariantId(releaseVariant.id);
       const releaseDraft = releaseVariant
         ? {
-            ...draft,
-            modelName: releaseVariant.modelName || draft.modelName,
+            ...providerDraft,
+            modelName: releaseVariant.modelName || providerDraft.modelName,
             description: releaseVariant.description,
             instruction: releaseVariant.instruction,
           }
-        : draft;
+        : providerDraft;
       const generated = await generateAgentProject(codegenDraft(releaseDraft));
       if (releaseDraft !== draft) setDraft(releaseDraft);
       setProject(generated);
@@ -3225,8 +3297,8 @@ export function CustomCreate({
       await cleanupDebugVariantRun(id);
       await cleanupStoredDebugRuns();
       const variantDraft: AgentDraft = {
-        ...draft,
-        modelName: variant.modelName || draft.modelName,
+        ...providerDraft,
+        modelName: variant.modelName || providerDraft.modelName,
         description: variant.description,
         instruction: variant.instruction,
       };
@@ -3491,9 +3563,9 @@ export function CustomCreate({
               ...variant,
               modelName: baselineModelEditedRef.current
                 ? variant.modelName
-                : defaultDebugModelName(draft),
-              description: draft.description,
-              instruction: draft.instruction,
+                : defaultDebugModelName(providerDraft),
+              description: providerDraft.description,
+              instruction: providerDraft.instruction,
             }
           : variant,
       ),
@@ -4321,7 +4393,7 @@ export function CustomCreate({
               }}
               deploymentEnv={deploymentEnv.specs}
               deploymentEnvValues={{
-                ...draft.deployment?.envValues,
+                ...providerDraft.deployment?.envValues,
                 ...deploymentEnv.fixedValues,
               }}
               onDeploymentEnvChange={patchDeploymentEnv}
@@ -4344,8 +4416,8 @@ export function CustomCreate({
               }}
               onExportYaml={() =>
                 downloadText(
-                  `${draft.name || "agent"}.yaml`,
-                  draftToYaml(draft),
+                  `${providerDraft.name || "agent"}.yaml`,
+                  draftToYaml(providerDraft),
                   "text/yaml",
                 )
               }

--- a/frontend/tests/deploymentEnv.test.mjs
+++ b/frontend/tests/deploymentEnv.test.mjs
@@ -468,10 +468,30 @@ test("keeps the generated project stable when only deployment channel settings c
   assert.doesNotMatch(customCreateSource, /buildPreviewProject/);
   assert.match(
     customCreateSource,
-    /generateAgentProject\(codegenDraft\(releaseDraft\)\)/,
+    /const releaseDraft = releaseVariant[\s\S]*?\.\.\.providerDraft[\s\S]*?generateAgentProject\(codegenDraft\(releaseDraft\)\)/,
   );
   assert.match(projectPreviewSource, /await onFeishuEnabledChange\(!feishuEnabled\)/);
   assert.match(projectPreviewSource, /deploying \|\| feishuUpdating/);
+});
+
+test("normalizes generated project drafts to the selected cloud provider", () => {
+  assert.match(customCreateSource, /function draftForCloudProvider/);
+  assert.match(
+    customCreateSource,
+    /setDraft\(\(current\) => draftForCloudProvider\(current, cloudProvider\)\)/,
+  );
+  assert.match(
+    customCreateSource,
+    /const providerDraft = useMemo\([\s\S]*?draftForCloudProvider\(draft, cloudProvider\)/,
+  );
+  assert.match(
+    customCreateSource,
+    /return nextProvider === "byteplus" && trimmed\.includes\("doubao-"\)/,
+  );
+  assert.match(
+    customCreateSource,
+    /const variantDraft: AgentDraft = \{[\s\S]*?\.\.\.providerDraft[\s\S]*?debugRuntimeDraft\(variantDraft\)/,
+  );
 });
 
 test("uses concise placeholders for agent names and custom environment variables", () => {
@@ -530,7 +550,7 @@ test("materializes A2A registry defaults for deployment env", () => {
   );
   assert.match(
     customCreateSource,
-    /deploymentEnvValues=\{\{[\s\S]*?\.\.\.draft\.deployment\?\.envValues,[\s\S]*?\.\.\.deploymentEnv\.fixedValues,/,
+    /deploymentEnvValues=\{\{[\s\S]*?\.\.\.providerDraft\.deployment\?\.envValues,[\s\S]*?\.\.\.deploymentEnv\.fixedValues,/,
   );
 });
 

--- a/frontend/tests/generatedAgentPlanner.test.mjs
+++ b/frontend/tests/generatedAgentPlanner.test.mjs
@@ -45,7 +45,7 @@ test("removes hidden capabilities from every generated Agent", () => {
   );
   assert.match(
     createSource,
-    /setDraft\(sanitizeGeneratedDraftCapabilities\(normalizeDraft\(result\.draft\)\)\)/,
+    /setDraft\([\s\S]*?draftForCloudProvider\([\s\S]*?sanitizeGeneratedDraftCapabilities\([\s\S]*?normalizeDraft\(result\.draft\),[\s\S]*?cloudProvider,[\s\S]*?\),[\s\S]*?cloudProvider,[\s\S]*?\)/,
   );
 });
 

--- a/frontend/tests/manageAgentsConnection.test.mjs
+++ b/frontend/tests/manageAgentsConnection.test.mjs
@@ -18,6 +18,10 @@ const connectionsSource = readFileSync(
   new URL("../src/adk/connections.ts", import.meta.url),
   "utf8",
 );
+const clientSource = readFileSync(
+  new URL("../src/adk/client.ts", import.meta.url),
+  "utf8",
+);
 const manageStyles = readFileSync(
   new URL("../src/ui/ManageAgents.css", import.meta.url),
   "utf8",
@@ -38,7 +42,10 @@ test("managed runtimes connect through the Agent page", () => {
 
 test("runtime connection probing is shared with the Agent selector", () => {
   assert.match(connectionsSource, /export async function connectRuntime/);
-  assert.match(connectionsSource, /RUNTIME_REGION_FALLBACKS = \["cn-beijing", "cn-shanghai"\]/);
+  assert.match(clientSource, /VOLCENGINE_RUNTIME_REGION_FALLBACKS = \["cn-beijing", "cn-shanghai"\]/);
+  assert.match(clientSource, /activeCloudProvider === "byteplus"[\s\S]*?BYTEPLUS_DEFAULT_REGION/);
+  assert.match(clientSource, /setClientCloudProvider\(provider\)/);
+  assert.match(connectionsSource, /runtimeRegionCandidates,/);
   assert.match(connectionsSource, /for \(const candidate of runtimeRegionCandidates\(region\)\)/);
   assert.match(connectionsSource, /probeRuntimeApps\(runtimeId, candidate,[\s\S]*?retryProbe: true/);
   assert.match(connectionsSource, /resolvedRegion = candidate/);

--- a/frontend/tests/markdownPromptEditor.test.mjs
+++ b/frontend/tests/markdownPromptEditor.test.mjs
@@ -271,11 +271,11 @@ test("debug variants configure and deploy their own model, description, and prom
   );
   assert.match(
     createSource,
-    /const releaseDraft = releaseVariant[\s\S]*?modelName: releaseVariant\.modelName \|\| draft\.modelName,[\s\S]*?description: releaseVariant\.description,[\s\S]*?instruction: releaseVariant\.instruction/,
+    /const releaseDraft = releaseVariant[\s\S]*?\.\.\.providerDraft[\s\S]*?modelName: releaseVariant\.modelName \|\| providerDraft\.modelName,[\s\S]*?description: releaseVariant\.description,[\s\S]*?instruction: releaseVariant\.instruction/,
   );
   assert.match(
     createSource,
-    /const variantDraft: AgentDraft = \{[\s\S]*?description: variant\.description,[\s\S]*?instruction: variant\.instruction/,
+    /const variantDraft: AgentDraft = \{[\s\S]*?\.\.\.providerDraft[\s\S]*?description: variant\.description,[\s\S]*?instruction: variant\.instruction/,
   );
   assert.match(
     createSource,
@@ -290,7 +290,7 @@ test("baseline debug config defaults to the first configured Agent model", () =>
   );
   assert.match(
     createSource,
-    /id: "baseline",[\s\S]*?modelName: defaultDebugModelName\(initialDraft \?\? emptyDraft\(cloudProvider\)\)/,
+    /const initialProviderDraft = draftForCloudProvider\([\s\S]*?initialDraft \?\? emptyDraft\(cloudProvider\),[\s\S]*?cloudProvider,[\s\S]*?\);[\s\S]*?id: "baseline",[\s\S]*?modelName: defaultDebugModelName\(initialProviderDraft\)/,
   );
   assert.match(
     createSource,
@@ -298,7 +298,7 @@ test("baseline debug config defaults to the first configured Agent model", () =>
   );
   assert.match(
     createSource,
-    /variant\.id === "baseline"[\s\S]*?modelName: baselineModelEditedRef\.current[\s\S]*?variant\.modelName[\s\S]*?defaultDebugModelName\(draft\)/,
+    /variant\.id === "baseline"[\s\S]*?modelName: baselineModelEditedRef\.current[\s\S]*?variant\.modelName[\s\S]*?defaultDebugModelName\(providerDraft\)/,
   );
 });
 
@@ -475,7 +475,10 @@ test("debug workspace compares multiple configurations behind one shared input",
     /const removeDebugVariant = async \(id: string\) => \{[\s\S]*?await cleanupDebugVariantRun\(id\);[\s\S]*?current\.filter\(\(variant\) => variant\.id !== id\)[\s\S]*?setSelectedVariantId\("baseline"\)/,
   );
   assert.match(createSource, /targets\.map\(async \(variant\)/);
-  assert.match(createSource, /modelName: variant\.modelName \|\| draft\.modelName/);
+  assert.match(
+    createSource,
+    /modelName: variant\.modelName \|\| providerDraft\.modelName/,
+  );
   assert.match(createSource, /variants\.length < 3/);
   assert.doesNotMatch(createSource, /name="debug-release-variant"|发布候选/);
   assert.match(

--- a/tests/cli/test_frontend_runtime_proxy.py
+++ b/tests/cli/test_frontend_runtime_proxy.py
@@ -194,6 +194,46 @@ def test_byteplus_runtime_list_uses_vefaas_iam_credentials(
     assert calls == [("iam-ak", "iam-sk", "iam-token", "ap-southeast-1")]
 
 
+def test_byteplus_runtime_detail_coerces_volcengine_region(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app = _create_frontend_app(monkeypatch, tmp_path, provider="byteplus")
+    monkeypatch.setenv("BYTEPLUS_ACCESS_KEY", "bp-ak")
+    monkeypatch.setenv("BYTEPLUS_SECRET_KEY", "bp-sk")
+    monkeypatch.setenv("BYTEPLUS_REGION", "ap-southeast-1")
+    calls: list[str] = []
+
+    class _FakeRuntimeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            calls.append(kwargs["region"])
+
+        def get_runtime(self, request: Any) -> SimpleNamespace:
+            return SimpleNamespace(
+                runtime_id=getattr(request, "runtime_id", ""),
+                name="runtime-bp",
+                status="Ready",
+                network_configurations=[],
+                envs=[],
+                tags=[],
+            )
+
+    monkeypatch.setattr(
+        "agentkit.sdk.runtime.client.AgentkitRuntimeClient",
+        _FakeRuntimeClient,
+    )
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/web/runtime-detail",
+            params={"runtimeId": "runtime-bp-id", "region": "cn-shanghai"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["region"] == "ap-southeast-1"
+    assert calls == ["ap-southeast-1"]
+
+
 def test_ui_config_serves_custom_branding(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/cli/test_frontend_skill_creator.py
+++ b/tests/cli/test_frontend_skill_creator.py
@@ -412,6 +412,33 @@ def test_code_env_credential_accepts_a_provider_specific_default_model() -> None
     assert envs["ANTHROPIC_MODEL"] == "seed-2-0-lite-260228"
 
 
+def test_code_env_credential_defaults_to_byteplus_model() -> None:
+    updates: list[object] = []
+    client = SimpleNamespace(
+        get_tool=lambda _: SimpleNamespace(envs=[]),
+        update_tool=updates.append,
+    )
+
+    with patch(
+        "veadk.auth.veauth.ark_veauth.get_ark_token",
+        return_value=os.urandom(24).hex(),
+    ):
+        ensure_skill_creator_model_credential(
+            tool_id="dev-tool-id",
+            access_key=os.urandom(16).hex(),
+            secret_key=os.urandom(24).hex(),
+            provider="byteplus",
+            client=client,
+        )
+
+    envs = {
+        item.key: item.value for item in cast(list[Any], getattr(updates[0], "envs"))
+    }
+    assert envs["CODEX_MODEL"] == "seed-2-0-lite-260228"
+    assert envs["OPENCODE_MODEL"] == "seed-2-0-lite-260228"
+    assert envs["ANTHROPIC_MODEL"] == "seed-2-0-lite-260228"
+
+
 def test_candidate_session_never_overrides_tool_model_credential(monkeypatch) -> None:
     service = SkillCreatorService(tool_id="tool-id")
     captured: dict[str, object] = {}
@@ -485,6 +512,32 @@ def test_routes_mount_and_report_disabled_without_sandbox(monkeypatch) -> None:
     assert response.json()["enabled"] is False
     assert response.json()["reason"] == "管理员未配置"
     assert len(response.json()["models"]) == 2
+
+
+def test_routes_report_byteplus_skill_creator_models(monkeypatch) -> None:
+    monkeypatch.delenv("SANDBOX_SKILL_CREATOR", raising=False)
+    monkeypatch.delenv("VEADK_SKILL_CREATOR_TOOL_ID", raising=False)
+    monkeypatch.delenv("AGENTKIT_SANDBOX_TOOL_ID", raising=False)
+    monkeypatch.setenv("AGENTKIT_CLOUD_PROVIDER", "byteplus")
+    monkeypatch.setenv("CLOUD_PROVIDER", "byteplus")
+    app = FastAPI()
+    mount_skill_creator_routes(app, lambda request: "test-user")
+
+    response = TestClient(app).get("/web/skill-creator/capabilities")
+
+    assert response.status_code == 200
+    assert response.json()["models"] == [
+        {
+            "candidateId": "a",
+            "id": "seed-2-0-lite-260228",
+            "label": "Seed 2.0 Lite",
+        },
+        {
+            "candidateId": "b",
+            "id": "deepseek-v4-flash-260425",
+            "label": "DeepSeek V4 Flash",
+        },
+    ]
 
 
 def test_skill_creator_reads_only_dedicated_sandbox_tool_env(monkeypatch) -> None:

--- a/tests/cli/test_generated_agent_component_matrix.py
+++ b/tests/cli/test_generated_agent_component_matrix.py
@@ -275,6 +275,7 @@ def test_byteplus_generated_project_uses_byteplus_modelark_defaults() -> None:
             cloudProvider="byteplus",
             knowledgebase=True,
             knowledgebaseBackend="opensearch",
+            builtinTools=["image_generate", "image_edit", "video_generate"],
         )
     )
     env_example = _files(project)[".env.example"]
@@ -289,7 +290,11 @@ def test_byteplus_generated_project_uses_byteplus_modelark_defaults() -> None:
         "MODEL_EMBEDDING_API_BASE=https://ark.ap-southeast.bytepluses.com/api/v3"
         in env_example
     )
+    assert "MODEL_IMAGE_NAME=dola-seedream-5-0-pro-260628" in env_example
+    assert "MODEL_EDIT_NAME=seededit-3-0-i2i-250628" in env_example
+    assert "MODEL_VIDEO_NAME=dreamina-seedance-2-0-260128" in env_example
     assert "ark.cn-beijing.volces.com" not in env_example
+    assert "doubao-" not in env_example
 
 
 def test_run_code_generates_tool_import_and_sandbox_env() -> None:

--- a/tests/frontend/test_skills_server.py
+++ b/tests/frontend/test_skills_server.py
@@ -448,14 +448,14 @@ def test_workbench_byteplus_uses_default_and_catalog_models(
     catalog = {
         "models": [
             {
-                "slug": "default-model",
-                "display_name": "Default model",
+                "slug": "deepseek-v4-flash-260425",
+                "display_name": "DeepSeek V4 Flash",
                 "visibility": "list",
                 "supported_in_api": True,
             },
             {
-                "slug": "optional-model",
-                "display_name": "Optional model",
+                "slug": "custom-admin-model",
+                "display_name": "Admin custom model",
                 "visibility": "list",
                 "supported_in_api": True,
             },
@@ -482,7 +482,7 @@ def test_workbench_byteplus_uses_default_and_catalog_models(
         status="Ready",
         image_url="",
         envs=[
-            SimpleNamespace(key="CODEX_MODEL", value="default-model"),
+            SimpleNamespace(key="CODEX_MODEL", value="doubao-seed-2-0-pro-260215"),
             SimpleNamespace(key="CODEX_API_KEY", value="secret"),
             SimpleNamespace(key="CODEX_BASE_URL", value=base_url),
             SimpleNamespace(
@@ -502,7 +502,7 @@ def test_workbench_byteplus_uses_default_and_catalog_models(
     monkeypatch.setenv("CLOUD_PROVIDER", "byteplus")
     monkeypatch.setenv(
         "VEADK_SKILL_MODELS",
-        "optional-model,admin-model,admin-model",
+        "seed-2-0-mini-260215,doubao-seed-2-0-pro-260215,custom-admin-model",
     )
     monkeypatch.setattr(
         "frontend.server.skills.devenv.requests.post",
@@ -520,21 +520,31 @@ def test_workbench_byteplus_uses_default_and_catalog_models(
     assert capability["enabled"] is True
     assert capability["models"] == [
         {"id": "seed-2-0-lite-260228", "label": "seed-2-0-lite-260228"},
-        {"id": "default-model", "label": "default-model"},
-        {"id": "optional-model", "label": "Optional model"},
-        {"id": "admin-model", "label": "admin-model"},
+        {"id": "deepseek-v4-flash-260425", "label": "DeepSeek V4 Flash"},
+        {"id": "seed-2-0-mini-260215", "label": "seed-2-0-mini-260215"},
     ]
+
+    with pytest.raises(SkillWorkbenchError, match="不支持该模型"):
+        service.create_task(
+            CreateSkillTaskBody(
+                operation="create",
+                intent="Build a BytePlus Skill",
+                model="doubao-seed-2-0-pro-260215",
+            ),
+            "owner-1",
+            "Owner",
+        )
 
     result = service.create_task(
         CreateSkillTaskBody(
             operation="create",
             intent="Build a BytePlus Skill",
-            model="optional-model",
+            model="deepseek-v4-flash-260425",
         ),
         "owner-1",
         "Owner",
     )
 
-    assert result["model"] == "optional-model"
+    assert result["model"] == "deepseek-v4-flash-260425"
     session_envs = {item.key: item.value for item in client.created[0].envs}
-    assert session_envs["CODEX_MODEL"] == "optional-model"
+    assert session_envs["CODEX_MODEL"] == "deepseek-v4-flash-260425"

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -1467,7 +1467,12 @@ def _run_frontend_server(
         return default_region(provider)
 
     def _coerce_cloud_region(region: str | None) -> str:
-        return (region or "").strip() or _default_cloud_region()
+        candidate = (region or "").strip()
+        if provider == "byteplus" and candidate.startswith("cn-"):
+            return _default_cloud_region()
+        if provider == "volcengine" and candidate.startswith("ap-"):
+            return _default_cloud_region()
+        return candidate or _default_cloud_region()
 
     from frontend.server.video.routes import (
         build_video_service,

--- a/veadk/cli/frontend_skill_creator.py
+++ b/veadk/cli/frontend_skill_creator.py
@@ -56,6 +56,10 @@ from veadk.cli.agentkit_sandbox_region import (
     is_agentkit_resource_not_found,
     sandbox_region_candidates,
 )
+from veadk.cli.studio_model_catalog import (
+    BYTEPLUS_SKILL_CREATOR_MODELS,
+    BYTEPLUS_STUDIO_AGENT_MODEL_NAME,
+)
 
 
 _MODELS = (
@@ -703,8 +707,18 @@ def _sandbox_provider() -> str:
     )
 
 
+def _models_for_provider(
+    provider: str | None = None,
+) -> tuple[tuple[str, str, str], ...]:
+    provider_id = (provider or _sandbox_provider()).strip().lower()
+    if provider_id == "byteplus":
+        return BYTEPLUS_SKILL_CREATOR_MODELS
+    return _MODELS
+
+
 def _sandbox_model_config(provider: str | None = None) -> tuple[str, str]:
-    if (provider or _sandbox_provider()) == "byteplus":
+    provider_id = (provider or _sandbox_provider()).strip().lower()
+    if provider_id == "byteplus":
         return _BYTEPLUS_MODEL_PROVIDER, _BYTEPLUS_MODEL_BASE_URL
     return _MODEL_PROVIDER, _MODEL_BASE_URL
 
@@ -732,6 +746,7 @@ def ensure_skill_creator_model_credential(
     """Resolve an Ark API key and bind it directly to the CodeEnv Tool."""
     from veadk.auth.veauth.ark_veauth import get_ark_token
 
+    provider_id = provider.strip().lower()
     tools_client = client or AgentkitToolsClient(
         access_key=access_key,
         secret_key=secret_key,
@@ -746,9 +761,14 @@ def ensure_skill_creator_model_credential(
         secret_key=secret_key,
         session_token=session_token,
     )
-    model_provider, model_base_url = _sandbox_model_config(provider)
+    model_provider, model_base_url = _sandbox_model_config(provider_id)
     session_envs = build_exec_session_envs(
-        model_name=model_name or _MODELS[0][1],
+        model_name=model_name
+        or (
+            BYTEPLUS_STUDIO_AGENT_MODEL_NAME
+            if provider_id == "byteplus"
+            else _MODELS[0][1]
+        ),
         model_api_key=model_api_key,
         model_provider=model_provider,
         model_base_url=model_base_url,
@@ -808,7 +828,7 @@ class SkillCreatorService:
             "reason": reason,
             "models": [
                 {"candidateId": candidate_id, "id": model, "label": label}
-                for candidate_id, model, label in _MODELS
+                for candidate_id, model, label in _models_for_provider()
             ],
             "publishEnabled": enabled,
         }
@@ -845,7 +865,7 @@ class SkillCreatorService:
                     }
                 ],
             }
-            for candidate_id, model, label in _MODELS
+            for candidate_id, model, label in _models_for_provider()
         ]
         failures: list[Exception] = []
 
@@ -872,7 +892,7 @@ class SkillCreatorService:
                         model_base_url,
                         prompt,
                     ): (candidate_id, model, label)
-                    for candidate_id, model, label in _MODELS
+                    for candidate_id, model, label in _models_for_provider()
                 }
                 for future in as_completed(futures):
                     candidate_id, model, label = futures[future]
@@ -913,7 +933,7 @@ class SkillCreatorService:
         tool_id = self._tool_id()
         candidates = [
             self._candidate_status(tool_id, job_id, candidate_id, model, label)
-            for candidate_id, model, label in _MODELS
+            for candidate_id, model, label in _models_for_provider()
         ]
         terminal = all(item["status"] in {"succeeded", "failed"} for item in candidates)
         return {
@@ -1073,7 +1093,7 @@ class SkillCreatorService:
         self._validate_job_owner(job_id, owner_id)
         tool_id = self._tool_id()
         instances = []
-        for candidate_id, _, _ in _MODELS:
+        for candidate_id, _, _ in _models_for_provider():
             try:
                 session = self._find_session(
                     tool_id, self._session_id(job_id, candidate_id)
@@ -1315,7 +1335,7 @@ class SkillCreatorService:
             raise SkillCreatorError("无权访问该 Skill 创建任务")
 
     def _model(self, candidate_id: str) -> tuple[str, str, str]:
-        for item in _MODELS:
+        for item in _models_for_provider():
             if item[0] == candidate_id:
                 return item
         raise SkillCreatorError("Skill 候选方案无效")

--- a/veadk/cli/generated_agent_catalog.py
+++ b/veadk/cli/generated_agent_catalog.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from veadk.cli.studio_model_catalog import provider_env_placeholders
+
 
 @dataclass(frozen=True)
 class EnvVar:
@@ -111,6 +113,23 @@ def embedding_env_for_provider(provider: str) -> tuple[EnvVar, ...]:
             EnvVar("MODEL_EMBEDDING_API_BASE", False, BYTEPLUS_MODELARK_BASE_URL),
         )
     return EMBEDDING_ENV
+
+
+def env_for_provider(provider: str, env: tuple[EnvVar, ...]) -> tuple[EnvVar, ...]:
+    """Return provider-native placeholders for active runtime env specs."""
+    provider_id = provider.strip().lower()
+    if provider_id != "byteplus":
+        return env
+    placeholders = provider_env_placeholders(provider_id)
+    return tuple(
+        EnvVar(
+            item.key,
+            item.required,
+            placeholders.get(item.key, item.placeholder),
+            item.comment,
+        )
+        for item in env
+    )
 
 
 # Studio owns the Volcengine credential chain and forwards it to debug runs and

--- a/veadk/cli/generated_agent_codegen.py
+++ b/veadk/cli/generated_agent_codegen.py
@@ -29,7 +29,7 @@ from veadk.cli.generated_agent_catalog import (
     STM_BY_ID,
     TOOL_BY_ID,
     EnvVar,
-    embedding_env_for_provider,
+    env_for_provider,
     model_env_for_provider,
 )
 
@@ -421,13 +421,7 @@ def _add_import(acc: _Acc, line: str) -> None:
 
 
 def _add_env(acc: _Acc, env: tuple[EnvVar, ...]) -> None:
-    if acc.cloud_provider != "byteplus":
-        acc.env.extend(env)
-        return
-    embedding_env_by_key = {
-        item.key: item for item in embedding_env_for_provider(acc.cloud_provider)
-    }
-    acc.env.extend(embedding_env_by_key.get(item.key, item) for item in env)
+    acc.env.extend(env_for_provider(acc.cloud_provider, env))
 
 
 def _emit_tool_stub(acc: _Acc, name: str, description: str) -> str:

--- a/veadk/cli/studio_model_catalog.py
+++ b/veadk/cli/studio_model_catalog.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provider-native model defaults used by Studio provisioning and codegen."""
+
+from __future__ import annotations
+
+VOLCENGINE_MODELARK_BASE_URL = "https://ark.cn-beijing.volces.com/api/v3"
+BYTEPLUS_MODELARK_BASE_URL = "https://ark.ap-southeast.bytepluses.com/api/v3"
+
+VOLCENGINE_STUDIO_AGENT_MODEL_NAME = "doubao-seed-2-1-pro-260628"
+BYTEPLUS_STUDIO_AGENT_MODEL_NAME = "seed-2-0-lite-260228"
+
+VOLCENGINE_GENERATED_AGENT_MODEL_NAME = "doubao-seed-1-6-250615"
+BYTEPLUS_GENERATED_AGENT_MODEL_NAME = BYTEPLUS_STUDIO_AGENT_MODEL_NAME
+
+VOLCENGINE_EMBEDDING_MODEL_NAME = "doubao-embedding-vision-250615"
+BYTEPLUS_EMBEDDING_MODEL_NAME = "skylark-embedding-vision-250615"
+
+VOLCENGINE_IMAGE_GENERATE_MODEL_NAME = "doubao-seedream-5-0-260128"
+BYTEPLUS_IMAGE_GENERATE_MODEL_NAME = "dola-seedream-5-0-pro-260628"
+
+VOLCENGINE_IMAGE_EDIT_MODEL_NAME = "doubao-seededit-3-0-i2i-250628"
+BYTEPLUS_IMAGE_EDIT_MODEL_NAME = "seededit-3-0-i2i-250628"
+
+VOLCENGINE_VIDEO_MODEL_NAME = "doubao-seedance-2-0-260128"
+BYTEPLUS_VIDEO_MODEL_NAME = "dreamina-seedance-2-0-260128"
+
+BYTEPLUS_MODELARK_MODEL_IDS = frozenset(
+    {
+        "dola-seed-2-1-turbo-260628",
+        "seed-2-0-lite-260428",
+        "seed-2-0-mini-260428",
+        "seed-2-0-pro-260328",
+        "seed-2-0-lite-260228",
+        "seed-2-0-lite-260215",
+        "seed-2-0-mini-260215",
+        "seed-2-0-code-preview-260328",
+        "seed-1-8-251228",
+        "glm-5-2-260617",
+        "glm-4-7-251222",
+        "deepseek-v4-flash-ga-260731",
+        "deepseek-v4-pro-260425",
+        "deepseek-v4-flash-260425",
+        "deepseek-v3-2-251201",
+        "gpt-oss-120b-250805",
+        "seed-1-6-250915",
+        "seed-1-6-250615",
+        "seed-1-6-flash-250715",
+        "seed-1-6-flash-250615",
+        "dreamina-seedance-2-5-260628",
+        "dreamina-seedance-2-0-260128",
+        "dreamina-seedance-2-0-fast-260128",
+        "dreamina-seedance-2-0-mini-260615",
+        "seedance-1-5-pro-251215",
+        "seedance-1-0-pro-250528",
+        "seedance-1-0-pro-fast-251015",
+        "dola-seedream-5-0-pro-260628",
+        "seedream-5-0-260128",
+        "seedream-5-0-lite-260128",
+        "seedream-4-5-251128",
+        "seedream-4-0-250828",
+        "Hyper3d-Rodin-Gen2",
+        "Hitem3d-2.0",
+        "skylark-embedding-vision-251215",
+        "skylark-embedding-vision-250615",
+        BYTEPLUS_IMAGE_EDIT_MODEL_NAME,
+    }
+)
+
+BYTEPLUS_SKILL_CREATOR_MODELS = (
+    ("a", BYTEPLUS_STUDIO_AGENT_MODEL_NAME, "Seed 2.0 Lite"),
+    ("b", "deepseek-v4-flash-260425", "DeepSeek V4 Flash"),
+)
+
+
+def _provider_id(provider: str) -> str:
+    return provider.strip().lower()
+
+
+def studio_agent_model_name(provider: str) -> str:
+    return (
+        BYTEPLUS_STUDIO_AGENT_MODEL_NAME
+        if _provider_id(provider) == "byteplus"
+        else VOLCENGINE_STUDIO_AGENT_MODEL_NAME
+    )
+
+
+def modelark_base_url(provider: str) -> str:
+    return (
+        BYTEPLUS_MODELARK_BASE_URL
+        if _provider_id(provider) == "byteplus"
+        else VOLCENGINE_MODELARK_BASE_URL
+    )
+
+
+def generated_agent_model_name(provider: str) -> str:
+    return (
+        BYTEPLUS_GENERATED_AGENT_MODEL_NAME
+        if _provider_id(provider) == "byteplus"
+        else VOLCENGINE_GENERATED_AGENT_MODEL_NAME
+    )
+
+
+def embedding_model_name(provider: str) -> str:
+    return (
+        BYTEPLUS_EMBEDDING_MODEL_NAME
+        if _provider_id(provider) == "byteplus"
+        else VOLCENGINE_EMBEDDING_MODEL_NAME
+    )
+
+
+def image_generate_model_name(provider: str) -> str:
+    return (
+        BYTEPLUS_IMAGE_GENERATE_MODEL_NAME
+        if _provider_id(provider) == "byteplus"
+        else VOLCENGINE_IMAGE_GENERATE_MODEL_NAME
+    )
+
+
+def image_edit_model_name(provider: str) -> str:
+    return (
+        BYTEPLUS_IMAGE_EDIT_MODEL_NAME
+        if _provider_id(provider) == "byteplus"
+        else VOLCENGINE_IMAGE_EDIT_MODEL_NAME
+    )
+
+
+def video_model_name(provider: str) -> str:
+    return (
+        BYTEPLUS_VIDEO_MODEL_NAME
+        if _provider_id(provider) == "byteplus"
+        else VOLCENGINE_VIDEO_MODEL_NAME
+    )
+
+
+def is_byteplus_model(model_id: str) -> bool:
+    return model_id.strip() in BYTEPLUS_MODELARK_MODEL_IDS
+
+
+def provider_allows_model(provider: str, model_id: str) -> bool:
+    normalized = model_id.strip()
+    if not normalized:
+        return False
+    if _provider_id(provider) == "byteplus":
+        return is_byteplus_model(normalized)
+    return True
+
+
+def provider_env_placeholders(provider: str) -> dict[str, str]:
+    return {
+        "MODEL_AGENT_NAME": generated_agent_model_name(provider),
+        "MODEL_AGENT_API_BASE": modelark_base_url(provider),
+        "MODEL_EMBEDDING_NAME": embedding_model_name(provider),
+        "MODEL_EMBEDDING_API_BASE": modelark_base_url(provider),
+        "MODEL_IMAGE_NAME": image_generate_model_name(provider),
+        "MODEL_IMAGE_API_BASE": modelark_base_url(provider),
+        "MODEL_EDIT_NAME": image_edit_model_name(provider),
+        "MODEL_EDIT_API_BASE": modelark_base_url(provider),
+        "MODEL_VIDEO_NAME": video_model_name(provider),
+        "MODEL_VIDEO_API_BASE": modelark_base_url(provider),
+    }

--- a/veadk/cli/studio_sandbox_tools.py
+++ b/veadk/cli/studio_sandbox_tools.py
@@ -23,14 +23,21 @@ import zlib
 from collections.abc import Callable
 from typing import Any
 
+from veadk.cli.studio_model_catalog import (
+    BYTEPLUS_MODELARK_BASE_URL,
+    BYTEPLUS_STUDIO_AGENT_MODEL_NAME,
+    VOLCENGINE_MODELARK_BASE_URL,
+    VOLCENGINE_STUDIO_AGENT_MODEL_NAME,
+)
+
 _PROJECT_NAME = "default"
 _TOOL_TYPE = "CodeEnv"
 _DEV_TOOL_TYPE = "DevEnv"
-STUDIO_SANDBOX_AGENT_MODEL_NAME = "doubao-seed-2-1-pro-260628"
-STUDIO_SANDBOX_BYTEPLUS_AGENT_MODEL_NAME = "seed-2-0-lite-260228"
+STUDIO_SANDBOX_AGENT_MODEL_NAME = VOLCENGINE_STUDIO_AGENT_MODEL_NAME
+STUDIO_SANDBOX_BYTEPLUS_AGENT_MODEL_NAME = BYTEPLUS_STUDIO_AGENT_MODEL_NAME
 STUDIO_SANDBOX_MODEL_BASE_URLS = {
-    "volcengine": "https://ark.cn-beijing.volces.com/api/v3",
-    "byteplus": "https://ark.ap-southeast.bytepluses.com/api/v3",
+    "volcengine": VOLCENGINE_MODELARK_BASE_URL,
+    "byteplus": BYTEPLUS_MODELARK_BASE_URL,
 }
 _AGENT_TOOL_TYPES = {
     "openclaw": "ArkClawEnv",


### PR DESCRIPTION
## 背景

BP 环境下 Studio 仍可能展示或生成火山侧模型名，例如 doubao / deepseek-v4-*；同时 Runtime 连接链路里存在火山地域 fallback，BP provider 下可能把请求打到 cn-beijing / cn-shanghai。

## 修改内容

- 新增 Studio 模型目录，集中维护 Volcengine 与 BytePlus 的默认模型、ModelArk Base URL 和 BP allowlist。
- 在 Skill Workbench、Skill Creator、生成 Agent 的代码预览/调试/发布链路中按 provider 归一化模型，BP 只使用 BP 模型。
- 生成项目的 `.env.example`、draft metadata、部署 env 默认值按 BP provider 写入 BytePlus ModelArk 配置。
- Runtime region fallback 改为 provider-aware；BP 只使用 ap-southeast-1，后端也会兜底纠正错误的 cn-* region。

## 验证

- `npm --prefix frontend test`
- `cd frontend && ./node_modules/.bin/tsc --noEmit`
- `uv run pytest tests/cli/test_frontend_skill_creator.py tests/cli/test_generated_agent_component_matrix.py tests/frontend/test_skills_server.py tests/cli/test_frontend_runtime_proxy.py::test_byteplus_runtime_detail_coerces_volcengine_region tests/cli/test_frontend_runtime_proxy.py::test_byteplus_runtime_list_uses_vefaas_iam_credentials`
- `uv run pre-commit run --all-files`
- `uv run pre-commit run`