### PR TITLE
fix(studio): scope skill upload name conflicts

### DIFF
--- a/frontend/server/skills/repository.py
+++ b/frontend/server/skills/repository.py
@@ -332,15 +332,12 @@ class AgentKitSkillRepository:
         )
 
         client = self._client_factory(region)
-        existing = client.list_skills(
-            skills_types.ListSkillsRequest(
-                PageNumber=1,
-                PageSize=50,
-                Filter=skills_types.SkillFilter(Name=archive.name),
-                ProjectName=project_name,
-            )
-        )
-        if existing.items:
+        if self._space_has_skill_named(
+            client,
+            skills_types,
+            space_id=space_id,
+            name=archive.name,
+        ):
             raise SkillRepositoryError(
                 "SKILL_NAME_CONFLICT",
                 f"已存在同名 Skill“{archive.name}”，请重命名后上传，或使用优化功能覆盖。",
@@ -400,6 +397,53 @@ class AgentKitSkillRepository:
             "version": version,
             "skillSpaceId": space_id,
         }
+
+    @staticmethod
+    def _space_has_skill_named(
+        client: Any,
+        skills_types: Any,
+        *,
+        space_id: str,
+        name: str,
+    ) -> bool:
+        page = 1
+        page_size = 100
+        expected = name.casefold()
+        while True:
+            response = client.list_skills_by_skill_space(
+                skills_types.ListSkillsBySkillSpaceRequest(
+                    SkillSpaceId=space_id,
+                    PageNumber=page,
+                    PageSize=page_size,
+                )
+            )
+            items = list(getattr(response, "items", None) or [])
+            if any(
+                AgentKitSkillRepository._skill_relation_name(item).casefold()
+                == expected
+                for item in items
+            ):
+                return True
+            total_count = getattr(response, "total_count", None)
+            if total_count is not None:
+                try:
+                    if page * page_size >= int(total_count):
+                        return False
+                except (TypeError, ValueError):
+                    pass
+            if len(items) < page_size:
+                return False
+            page += 1
+
+    @staticmethod
+    def _skill_relation_name(value: Any) -> str:
+        return str(
+            getattr(value, "skill_name", None)
+            or getattr(value, "skillName", None)
+            or getattr(value, "name", None)
+            or getattr(value, "Name", None)
+            or ""
+        )
 
     @staticmethod
     def _space_item(value: Any, region: str) -> dict[str, object]:

--- a/tests/frontend/test_skills_server.py
+++ b/tests/frontend/test_skills_server.py
@@ -17,8 +17,10 @@ from __future__ import annotations
 import base64
 import io
 import json
+import sys
 import stat
 import zipfile
+from types import ModuleType
 from types import SimpleNamespace
 
 import pytest
@@ -35,7 +37,10 @@ from frontend.server.skills.models import (
     UpdateSkillSpaceBody,
 )
 from frontend.server.skills.prompts import decorate_intent
-from frontend.server.skills.repository import AgentKitSkillRepository
+from frontend.server.skills.repository import (
+    AgentKitSkillRepository,
+    SkillRepositoryError,
+)
 from frontend.server.skills.routes import _convert_error
 from frontend.server.skills.service import SkillService
 from veadk.cli.frontend_skill_creator import _sandbox_model_config
@@ -299,6 +304,159 @@ def test_repository_adds_author_tag_when_creating_space() -> None:
     assert request.tags[0].key == "author"
     assert request.tags[0].value == "person@example.com"
     assert result["author"] == "person@example.com"
+
+
+class _FakeSkillRequest:
+    def __init__(self, **kwargs: object) -> None:
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+            setattr(self, _pascal_to_snake(key), value)
+
+
+def _pascal_to_snake(value: str) -> str:
+    result = []
+    for index, char in enumerate(value):
+        if char.isupper() and index > 0:
+            result.append("_")
+        result.append(char.lower())
+    return "".join(result)
+
+
+class _FakeSkillClient:
+    def __init__(self, space_items: list[object]) -> None:
+        self.space_items = space_items
+        self.space_requests: list[object] = []
+        self.create_requests: list[object] = []
+        self.publish_requests: list[object] = []
+
+    def list_skills(self, request: object) -> SimpleNamespace:
+        del request
+        raise AssertionError(
+            "upload conflict checks must stay scoped to the target space"
+        )
+
+    def list_skills_by_skill_space(self, request: object) -> SimpleNamespace:
+        self.space_requests.append(request)
+        return SimpleNamespace(
+            items=self.space_items,
+            total_count=len(self.space_items),
+        )
+
+    def create_skill(self, request: object) -> SimpleNamespace:
+        self.create_requests.append(request)
+        return SimpleNamespace(id="skill-new")
+
+    def publish_skill_to_skill_space(self, request: object) -> None:
+        self.publish_requests.append(request)
+
+
+def _install_fake_agentkit_modules(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_types = SimpleNamespace(
+        ListSkillsBySkillSpaceRequest=_FakeSkillRequest,
+        CreateSkillRequest=_FakeSkillRequest,
+        PublishSkillToSkillSpaceRequest=_FakeSkillRequest,
+        SkillBasicInfo=_FakeSkillRequest,
+        TagForSkill=_FakeSkillRequest,
+    )
+    agentkit = ModuleType("agentkit")
+    sdk = ModuleType("agentkit.sdk")
+    skills = ModuleType("agentkit.sdk.skills")
+    toolkit = ModuleType("agentkit.toolkit")
+    cli = ModuleType("agentkit.toolkit.cli")
+    workflow = ModuleType("agentkit.toolkit.cli.cli_skills_workflow")
+    config = ModuleType("agentkit.toolkit.config")
+    skills.types = fake_types  # type: ignore[attr-defined]
+    workflow._make_content_hashed_zip_copy = (  # type: ignore[attr-defined]
+        lambda archive_path, _name, _directory: archive_path
+    )
+    workflow._wait_for_running_version = (  # type: ignore[attr-defined]
+        lambda **_kwargs: SimpleNamespace(version="v1")
+    )
+
+    class GlobalConfigManager:
+        def load(self) -> SimpleNamespace:
+            return SimpleNamespace(tos=SimpleNamespace(bucket="", prefix=""))
+
+    config.GlobalConfigManager = GlobalConfigManager  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "agentkit", agentkit)
+    monkeypatch.setitem(sys.modules, "agentkit.sdk", sdk)
+    monkeypatch.setitem(sys.modules, "agentkit.sdk.skills", skills)
+    monkeypatch.setitem(sys.modules, "agentkit.toolkit", toolkit)
+    monkeypatch.setitem(sys.modules, "agentkit.toolkit.cli", cli)
+    monkeypatch.setitem(
+        sys.modules,
+        "agentkit.toolkit.cli.cli_skills_workflow",
+        workflow,
+    )
+    monkeypatch.setitem(sys.modules, "agentkit.toolkit.config", config)
+
+
+def _stub_skill_publish_storage(monkeypatch: pytest.MonkeyPatch) -> None:
+    from frontend.server.skills import storage
+
+    monkeypatch.setattr(storage, "ensure_skill_publish_bucket", lambda *_args: None)
+    monkeypatch.setattr(
+        storage,
+        "resolve_skill_publish_credentials",
+        lambda *, provider: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        storage,
+        "resolve_skill_publish_storage",
+        lambda **_kwargs: SimpleNamespace(provider="fake", bucket="skill-bucket"),
+    )
+    monkeypatch.setattr(
+        storage,
+        "upload_skill_archive",
+        lambda *_args: "https://storage.invalid/skill.zip",
+    )
+
+
+def test_publish_archive_allows_same_name_in_other_space(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_agentkit_modules(monkeypatch)
+    _stub_skill_publish_storage(monkeypatch)
+    client = _FakeSkillClient(space_items=[])
+    repository = AgentKitSkillRepository(lambda _region: client)
+    skill_archive = validate_skill_archive(archive({"SKILL.md": SKILL_MD.encode()}))
+
+    result = repository.publish_archive(
+        region="cn-beijing",
+        project_name="default",
+        space_id="space-b",
+        archive=skill_archive,
+        author="person@example.com",
+    )
+
+    assert result["skillId"] == "skill-new"
+    assert client.space_requests[0].skill_space_id == "space-b"
+    assert client.create_requests[0].skill_spaces == ["space-b"]
+    assert client.publish_requests[0].skill_spaces == ["space-b"]
+
+
+def test_publish_archive_rejects_same_name_in_target_space(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_agentkit_modules(monkeypatch)
+    _stub_skill_publish_storage(monkeypatch)
+    client = _FakeSkillClient(space_items=[SimpleNamespace(skill_name="example-skill")])
+    repository = AgentKitSkillRepository(lambda _region: client)
+    skill_archive = validate_skill_archive(archive({"SKILL.md": SKILL_MD.encode()}))
+
+    with pytest.raises(SkillRepositoryError) as raised:
+        repository.publish_archive(
+            region="cn-beijing",
+            project_name="default",
+            space_id="space-b",
+            archive=skill_archive,
+            author="person@example.com",
+        )
+
+    assert raised.value.code == "SKILL_NAME_CONFLICT"
+    assert client.space_requests[0].skill_space_id == "space-b"
+    assert client.create_requests == []
+    assert client.publish_requests == []
 
 
 def test_space_update_and_delete_use_the_selected_region() -> None:


### PR DESCRIPTION
## 背景
在 Studio 的 Skill Center 中，本地上传 Skill 时，A Skill Space 已存在某个 Skill 名称后，向 B Skill Space 上传同名 Skill 会被错误地拦截为 SKILL_NAME_CONFLICT。不同 Skill Space 应允许存在同名 Skill。

## 修改内容
- 将本地上传前的同名检查从项目级 list_skills(Name=...) 改为目标 Skill Space 内的 list_skills_by_skill_space(SkillSpaceId=...)。
- 仅当目标 Skill Space 内已有同名 Skill 时继续返回 SKILL_NAME_CONFLICT。
- 补充单测覆盖跨空间同名允许、目标空间内同名拒绝两个场景。

## 验证
- .venv/bin/pre-commit run --files frontend/server/skills/repository.py tests/frontend/test_skills_server.py
- .venv/bin/python -m pytest tests/frontend/test_skills_server.py -q