### PR TITLE
fix: deduplicate ADK native telemetry

### DIFF
--- a/tests/test_adk_compat_regression.py
+++ b/tests/test_adk_compat_regression.py
@@ -33,16 +33,80 @@ from __future__ import annotations
 
 import importlib
 import importlib.metadata as im
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
 import pytest
+from opentelemetry import context as context_api
 from packaging.version import Version
 
 import veadk.utils.adk_compat as adk_compat
+from veadk.utils.patches import patch_google_adk_telemetry
 from veadk.tracing.telemetry.attributes.extractors.tool_attributes_extractors import (
     tool_gen_ai_tool_output,
 )
 from veadk.tracing.telemetry.attributes.extractors.types import ToolAttributesParams
+
+
+def test_adk_native_telemetry_is_suppressed_only_inside_veadk_context(monkeypatch):
+    """Capability patch leaves plain ADK runs unchanged and is idempotent."""
+    from google.adk.telemetry import tracing as adk_tracing
+
+    monkeypatch.setattr(
+        adk_tracing, "_should_emit_native_telemetry", lambda agent: True
+    )
+
+    patch_google_adk_telemetry()
+    wrapped = adk_tracing._should_emit_native_telemetry
+    patch_google_adk_telemetry()
+
+    assert adk_tracing._should_emit_native_telemetry is wrapped
+    assert wrapped(object()) is True
+
+    token = context_api.attach(
+        context_api.set_value("suppress_language_model_instrumentation", True)
+    )
+    try:
+        assert wrapped(object()) is False
+    finally:
+        context_api.detach(token)
+
+
+@pytest.mark.asyncio
+async def test_legacy_adk_inference_span_is_suppressed_inside_veadk_context(
+    monkeypatch,
+):
+    """ADK 1.34-2.1 uses the inference context manager without a gate."""
+    from google.adk.telemetry import tracing as adk_tracing
+
+    calls = []
+
+    @asynccontextmanager
+    async def use_inference_span(*args, **kwargs):
+        calls.append((args, kwargs))
+        yield "native-span"
+
+    monkeypatch.delattr(adk_tracing, "_should_emit_native_telemetry", raising=False)
+    monkeypatch.setattr(adk_tracing, "use_inference_span", use_inference_span)
+
+    patch_google_adk_telemetry()
+    wrapped = adk_tracing.use_inference_span
+    patch_google_adk_telemetry()
+
+    assert adk_tracing.use_inference_span is wrapped
+    async with wrapped("request", "context", "event") as span:
+        assert span == "native-span"
+    assert len(calls) == 1
+
+    token = context_api.attach(
+        context_api.set_value("suppress_language_model_instrumentation", True)
+    )
+    try:
+        async with wrapped("request", "context", "event") as span:
+            assert span is None
+    finally:
+        context_api.detach(token)
+    assert len(calls) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tracing_content.py
+++ b/tests/test_tracing_content.py
@@ -162,6 +162,26 @@ def test_trace_call_llm_records_content_by_default(monkeypatch):
         assert "gen_ai.choice" in _event_names(span)
 
 
+def test_trace_call_llm_prefers_explicit_adk_span(monkeypatch):
+    """ADK 1.24+ calls the hook while a nested inference span is current."""
+    monkeypatch.delenv("OBSERVABILITY_OPENTELEMETRY_TRACE_CONTENT", raising=False)
+
+    provider = trace_sdk.TracerProvider()
+    tracer = provider.get_tracer(__name__)
+    with tracer.start_as_current_span("call_llm") as call_llm_span:
+        with tracer.start_as_current_span("generate_content") as inference_span:
+            telemetry.trace_call_llm(
+                _FakeInvocationContext(),
+                "event-id",
+                _FakeLlmRequest(),
+                _FakeLlmResponse(),
+                call_llm_span,
+            )
+
+    assert call_llm_span.attributes["gen_ai.request.model"] == "test-model"
+    assert "gen_ai.request.model" not in inference_span.attributes
+
+
 def test_content_tracing_uses_veadk_config_when_env_missing(monkeypatch):
     monkeypatch.delenv("OBSERVABILITY_OPENTELEMETRY_TRACE_CONTENT", raising=False)
     monkeypatch.setattr(settings.opentelemetry_config, "trace_content", False)

--- a/veadk/tracing/telemetry/exporters/inmemory_exporter.py
+++ b/veadk/tracing/telemetry/exporters/inmemory_exporter.py
@@ -174,6 +174,12 @@ class _InMemorySpanProcessor(export.SimpleSpanProcessor):
             span.set_attribute("gen_ai.span.kind", "agent")
 
             ctx = set_value("agent_run_span_instance", span, context=parent_context)
+            # ADK telemetry schema v2 may omit the legacy ``invocation`` span.
+            # Carry the suppression flag on the agent span as well so native
+            # inference spans and metrics remain deduplicated across versions.
+            ctx = set_value(
+                "suppress_language_model_instrumentation", True, context=ctx
+            )
             token = attach(ctx)
             setattr(span, "_agent_run_token", token)  # for later detach
 

--- a/veadk/tracing/telemetry/telemetry.py
+++ b/veadk/tracing/telemetry/telemetry.py
@@ -355,6 +355,7 @@ def trace_call_llm(
     event_id: str,
     llm_request: LlmRequest,
     llm_response: LlmResponse,
+    span: Span | None = None,
     *args,
     **kwargs,
 ) -> None:
@@ -378,8 +379,13 @@ def trace_call_llm(
         event_id: Unique identifier for this LLM call event
         llm_request: The request object sent to the language model
         llm_response: The response object received from the language model
+        span: The owning call_llm span supplied by newer ADK releases
     """
-    span: Span = trace.get_current_span()  # type: ignore
+    # Newer ADK releases pass the owning ``call_llm`` span explicitly because
+    # the current span is the nested model-instrumentation span at this point.
+    # Older ADK releases only pass the original four arguments.
+    if span is None:
+        span = trace.get_current_span()  # type: ignore
 
     from veadk.agent import Agent
 

--- a/veadk/utils/patches.py
+++ b/veadk/utils/patches.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+from contextlib import asynccontextmanager
 import sys
 from typing import Callable
 
@@ -25,6 +26,8 @@ from veadk.utils.logger import get_logger
 from veadk.version import VERSION
 
 logger = get_logger(__name__)
+
+_SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION = "suppress_language_model_instrumentation"
 
 
 def patch_asyncio():
@@ -97,6 +100,54 @@ def patch_google_adk_telemetry() -> None:
                     logger.debug(
                         f"Patch {mod_name} {var_name} with {trace_functions[var_name]}"
                     )
+
+    # Supported ADK releases emit a nested ``generate_content`` span in
+    # addition to ``call_llm``. Newer releases also record the standard GenAI
+    # token metrics from the same path. VeADK owns both while its invocation
+    # context is active, so suppress them through the capability exposed by
+    # each ADK generation. Keep native telemetry unchanged outside VeADK.
+    try:
+        from google.adk.telemetry import tracing as adk_tracing
+        from opentelemetry import context as context_api
+
+        telemetry_gate = getattr(adk_tracing, "_should_emit_native_telemetry", None)
+        if callable(telemetry_gate) and not getattr(
+            telemetry_gate, "_veadk_suppression_wrapped", False
+        ):
+
+            def should_emit_native_telemetry(agent):
+                if context_api.get_value(_SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION):
+                    return False
+                return telemetry_gate(agent)
+
+            should_emit_native_telemetry._veadk_suppression_wrapped = True
+            adk_tracing._should_emit_native_telemetry = should_emit_native_telemetry
+            logger.debug("Patch ADK native telemetry suppression for VeADK runs.")
+        elif not callable(telemetry_gate):
+            # ADK 1.34-2.1 has no native-telemetry gate. Its LLM flow enters
+            # this context manager directly, so suppress that span only while
+            # VeADK owns the surrounding call_llm telemetry.
+            use_inference_span = getattr(adk_tracing, "use_inference_span", None)
+            if callable(use_inference_span) and not getattr(
+                use_inference_span, "_veadk_suppression_wrapped", False
+            ):
+
+                @asynccontextmanager
+                async def veadk_use_inference_span(*args, **kwargs):
+                    if context_api.get_value(_SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION):
+                        yield None
+                        return
+                    async with use_inference_span(*args, **kwargs) as span:
+                        yield span
+
+                veadk_use_inference_span._veadk_suppression_wrapped = True
+                adk_tracing.use_inference_span = veadk_use_inference_span
+                logger.debug(
+                    "Patch legacy ADK inference span suppression for VeADK runs."
+                )
+    except (ImportError, AttributeError) as e:
+        # Older ADK releases do not expose native inference telemetry.
+        logger.debug(f"Skip ADK native telemetry suppression patch: {e}")
 
 
 def patch_tracer() -> None:


### PR DESCRIPTION
## Summary

- bind VeADK LLM attributes to the explicit call_llm span passed by newer ADK releases
- suppress nested ADK inference spans and native token metrics only inside VeADK tracing contexts
- use capability detection for ADK 1.34-2.1 and ADK 2.2+ compatibility
- propagate suppression through both legacy invocation and newer agent-run span schemas

## Verification

- full test suite: 1447 passed, 5 skipped, 6 subtests passed
- pre-commit: ruff check, ruff format, and hardcoded-secret detection passed
- ADK 1.34 and 2.1 legacy suppression smoke tests passed
- Volcengine APMPlus A/B: baseline produced 4 token series and 3.06K total tokens; patched run produced only the 2 VeADK series and 1.39K total tokens
- patched trace keeps model, content, and token dimensions on call_llm and removes duplicate generate_content spans