### PR TITLE
fix(studio): harden sandbox tool provisioning

### DIFF
--- a/tests/cli/test_studio_deploy_target.py
+++ b/tests/cli/test_studio_deploy_target.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import threading
+from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
@@ -28,6 +29,7 @@ from volcenginesdkcore.interceptor.interceptors.build_request_interceptor import
 from volcenginesdkcore.rest import ApiException
 
 from veadk.cli.cli_frontend import (
+    _safe_exception_detail,
     _resolve_or_create_studio_identity_resources,
     _resolve_studio_cloud_credentials,
     _resolve_studio_identity_region,
@@ -614,6 +616,161 @@ def test_studio_deploy_surfaces_redacted_provisioning_error_chain(
 
 
 @pytest.mark.parametrize(
+    ("provider", "access_key_option", "secret_key_option", "token_option"),
+    [
+        (
+            "volcengine",
+            "--volcengine-access-key",
+            "--volcengine-secret-key",
+            "--volcengine-session-token",
+        ),
+        (
+            "byteplus",
+            "--byteplus-access-key",
+            "--byteplus-secret-key",
+            "--byteplus-session-token",
+        ),
+    ],
+    ids=["volcengine", "byteplus"],
+)
+def test_studio_deploy_surfaces_tool_id_from_provisioning_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+    access_key_option: str,
+    secret_key_option: str,
+    token_option: str,
+) -> None:
+    failed_tool_id = "tool-failed-4f86b2"
+    access_key = f"ak-{uuid4().hex}"
+    secret_key = f"sk-{uuid4().hex}"
+    session_token = f"token-{uuid4().hex}"
+    environment_prefix = provider.upper()
+    monkeypatch.setenv(f"{environment_prefix}_ACCESS_KEY", access_key)
+    monkeypatch.setenv(f"{environment_prefix}_SECRET_KEY", secret_key)
+    monkeypatch.setenv(f"{environment_prefix}_SESSION_TOKEN", session_token)
+    native_message = "CreateTool rejected by the native cloud service"
+    error_code = "RequestLimitExceeded"
+    status_code = 429
+    request_id = "req-native-tool-123"
+
+    class _NativeToolServiceError(Exception):
+        def __init__(self) -> None:
+            super().__init__(
+                f"{native_message}; access_key={access_key}; "
+                f"secret_key={secret_key}; token={session_token}"
+            )
+            self.error_code = error_code
+            self.status_code = status_code
+            self.request_id = request_id
+
+    class _FakeCloudAgentEngine:
+        def __init__(self, **_: object) -> None:
+            self._vefaas_service = SimpleNamespace()
+
+        def deploy(self, **_: object) -> SimpleNamespace:
+            return SimpleNamespace(
+                vefaas_endpoint="https://studio.example.com",
+                vefaas_application_id="app-id",
+                vefaas_function_id="",
+            )
+
+    def _fail_after_tool_creation(**_: object) -> str:
+        try:
+            raise _NativeToolServiceError
+        except _NativeToolServiceError as cause:
+            raise RuntimeError(
+                f"AgentKit Tool ID '{failed_tool_id}' creation failed after 3 attempts"
+            ) from cause
+
+    monkeypatch.setattr(
+        "veadk.cloud.cloud_agent_engine.CloudAgentEngine", _FakeCloudAgentEngine
+    )
+    monkeypatch.setattr(
+        "veadk.cli.cli_frontend._resolve_studio_identity_region",
+        lambda **kwargs: kwargs["deployment_region"],
+    )
+    monkeypatch.setattr(
+        "veadk.integrations.ve_identity.identity_client.IdentityClient.register_callback_for_user_pool_client",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "veadk.integrations.ve_identity.identity_client.IdentityClient.configure_user_pool_for_idp_only",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "veadk.cli.studio_sandbox_tools.ensure_studio_code_env_tool",
+        _fail_after_tool_creation,
+    )
+    monkeypatch.setattr("veadk.cli.cli_frontend.sleep", lambda _: None)
+
+    provider_args = [
+        access_key_option,
+        access_key,
+        secret_key_option,
+        secret_key,
+        token_option,
+        session_token,
+    ]
+    if provider == "byteplus":
+        provider_args[:0] = ["--provider", provider]
+
+    result = CliRunner().invoke(
+        studio,
+        [
+            "deploy",
+            "--user-pool-id",
+            "pool-id",
+            "--allowed-client-id",
+            "client-id",
+            "--vefaas-app-name",
+            "studio-app",
+            "--iam-role",
+            "trn:iam::role/test",
+            "--gateway-name",
+            "gateway",
+            *provider_args,
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Failed to provision the AgentKit Codex Tool" in result.output
+    assert f"AgentKit Tool ID '{failed_tool_id}' creation failed" in result.output
+    assert native_message in result.output
+    assert (
+        "Server metadata: "
+        f"error_code={error_code}, status_code={status_code}, request_id={request_id}"
+        in result.output
+    )
+    assert "Caused by:" in result.output
+    assert "access_key=***" in result.output
+    assert "secret_key=***" in result.output
+    assert "token=***" in result.output
+    assert access_key not in result.output
+    assert secret_key not in result.output
+    assert session_token not in result.output
+
+
+def test_safe_exception_detail_preserves_real_agentkit_api_error_shape() -> None:
+    from agentkit.toolkit.errors import ApiError
+
+    native_error = ApiError(
+        "Failed to CreateTool: native quota exceeded",
+        error_code="RequestLimitExceeded",
+    )
+    try:
+        raise RuntimeError(
+            "Tool provisioning failed after 3 attempts."
+        ) from native_error
+    except RuntimeError as error:
+        detail = _safe_exception_detail(error)
+
+    assert "Tool provisioning failed after 3 attempts." in detail
+    assert "Failed to CreateTool: native quota exceeded" in detail
+    assert "Server metadata: error_code=RequestLimitExceeded" in detail
+    assert "Caused by:" in detail
+
+
+@pytest.mark.parametrize(
     (
         "target_args",
         "expected_region",
@@ -1045,7 +1202,7 @@ def test_studio_deploy_byteplus_auto_provisions_four_sandbox_tools(
 ) -> None:
     captured: dict[str, object] = {}
     code_tools: list[dict[str, object]] = []
-    dev_tools: list[str] = []
+    dev_tools: list[dict[str, object]] = []
     agent_tools: list[dict[str, object]] = []
     code_credentials: list[dict[str, object]] = []
     agent_credentials: list[dict[str, object]] = []
@@ -1081,7 +1238,7 @@ def test_studio_deploy_byteplus_auto_provisions_four_sandbox_tools(
         return f"{kwargs['kind']}{suffix}-tool"
 
     def _ensure_dev_tool(**kwargs: object) -> str:
-        dev_tools.append(str(kwargs["name"]))
+        dev_tools.append(kwargs)
         return "dev-tool"
 
     monkeypatch.setattr(
@@ -1151,6 +1308,11 @@ def test_studio_deploy_byteplus_auto_provisions_four_sandbox_tools(
     assert {str(call["kind"]) for call in agent_tools} == {"openclaw", "hermes"}
     assert {bool(call["enable_snapshot"]) for call in agent_tools} == {False, True}
     assert {str(call["model_name"]) for call in agent_tools} == {"seed-2-0-lite-260228"}
+    assert len(code_tools + dev_tools + agent_tools) == 7
+    assert {
+        float(call["create_min_interval"])
+        for call in code_tools + dev_tools + agent_tools
+    } == {0.5}
     assert {str(call["provider"]) for call in code_credentials} == {"byteplus"}
     code_credentials_by_tool = {str(call["tool_id"]): call for call in code_credentials}
     assert code_credentials_by_tool["chat-tool"]["model_name"] == (
@@ -1317,6 +1479,35 @@ def test_studio_deploy_creates_distinct_sandbox_tools_when_ids_are_omitted(
     agent_credential_kinds: list[str] = []
     creation_barrier = threading.Barrier(7)
     created_kinds_lock = threading.Lock()
+    virtual_time = 0.0
+    tool_start_times: list[float] = []
+
+    def _fake_sleep(seconds: float) -> None:
+        nonlocal virtual_time
+        with created_kinds_lock:
+            virtual_time += seconds
+
+    class _StartSynchronizedThreadPoolExecutor(ThreadPoolExecutor):
+        def submit(  # type: ignore[override]
+            self,
+            fn: object,
+            /,
+            *args: object,
+            **kwargs: object,
+        ) -> Future[object]:
+            worker_started = threading.Event()
+
+            def _run() -> object:
+                if "name" in kwargs:
+                    with created_kinds_lock:
+                        tool_start_times.append(virtual_time)
+                worker_started.set()
+                assert callable(fn)
+                return fn(*args, **kwargs)
+
+            future = super().submit(_run)
+            assert worker_started.wait(timeout=5)
+            return future
 
     class _FakeCloudAgentEngine:
         def __init__(self, **_: object) -> None:
@@ -1331,6 +1522,7 @@ def test_studio_deploy_creates_distinct_sandbox_tools_when_ids_are_omitted(
 
     def _ensure_tool(**kwargs: object) -> str:
         creation_barrier.wait(timeout=5)
+        assert kwargs["create_min_interval"] == 0.5
         snapshot = bool(kwargs["enable_snapshot"])
         with created_kinds_lock:
             created_kinds.append("codex_snapshot" if snapshot else "codex")
@@ -1342,6 +1534,7 @@ def test_studio_deploy_creates_distinct_sandbox_tools_when_ids_are_omitted(
         kind = str(kwargs["kind"])
         snapshot = bool(kwargs["enable_snapshot"])
         creation_barrier.wait(timeout=5)
+        assert kwargs["create_min_interval"] == 0.5
         with created_kinds_lock:
             created_kinds.append(f"{kind}_snapshot" if snapshot else kind)
         agent_tool_kinds.append(f"{kind}_snapshot" if snapshot else kind)
@@ -1350,8 +1543,9 @@ def test_studio_deploy_creates_distinct_sandbox_tools_when_ids_are_omitted(
         suffix = "-snapshot" if snapshot else ""
         return f"{kind}{suffix}-tool"
 
-    def _ensure_dev_tool(**_: object) -> str:
+    def _ensure_dev_tool(**kwargs: object) -> str:
         creation_barrier.wait(timeout=5)
+        assert kwargs["create_min_interval"] == 0.5
         with created_kinds_lock:
             created_kinds.append("dev")
         return "dev-tool"
@@ -1394,6 +1588,11 @@ def test_studio_deploy_creates_distinct_sandbox_tools_when_ids_are_omitted(
         "veadk.cli.frontend_skill_creator.ensure_skill_creator_model_credential",
         _ensure_code_credential,
     )
+    monkeypatch.setattr(
+        "veadk.cli.cli_frontend.ThreadPoolExecutor",
+        _StartSynchronizedThreadPoolExecutor,
+    )
+    monkeypatch.setattr("veadk.cli.cli_frontend.sleep", _fake_sleep)
 
     result = CliRunner().invoke(
         studio,
@@ -1426,6 +1625,11 @@ def test_studio_deploy_creates_distinct_sandbox_tools_when_ids_are_omitted(
         "openclaw",
         "openclaw_snapshot",
     ]
+    assert len(tool_start_times) == 7
+    assert all(
+        later - earlier >= 0.5
+        for earlier, later in zip(tool_start_times, tool_start_times[1:])
+    )
     assert veadk_environments["SANDBOX_CHAT_CODEX"] == "chat-tool"
     assert veadk_environments["SANDBOX_CHAT_CODEX_SNAPSHOT"] == ("chat-snapshot-tool")
     assert "SANDBOX_SKILL_CREATOR" not in veadk_environments

--- a/tests/cli/test_studio_sandbox_tools.py
+++ b/tests/cli/test_studio_sandbox_tools.py
@@ -20,7 +20,10 @@ from typing import cast
 from unittest.mock import patch
 
 import pytest
+from agentkit.auth.errors import NetworkError
+from agentkit.toolkit.errors import ApiError
 
+import veadk.cli.studio_sandbox_tools as studio_sandbox_tools
 from veadk.cli.studio_sandbox_tools import (
     ensure_studio_agent_model_credential,
     ensure_studio_agent_tool,
@@ -86,10 +89,167 @@ def test_ensure_studio_code_env_tool_creates_ready_code_env() -> None:
     assert getattr(request, "name") == "veadk-studio-demo-skill-12345678"
     assert getattr(request, "tool_type") == "CodeEnv"
     assert getattr(request, "project_name") == "default"
+    assert len(getattr(request, "client_token")) == 32
     assert getattr(request, "cpu_milli") == 4000
     assert getattr(request, "memory_mb") == 8192
     assert getattr(request, "envs") is None
     assert getattr(request, "enable_snapshot") is False
+
+
+@pytest.mark.parametrize(
+    "transient_error",
+    [
+        RuntimeError("QPS limit exceeded"),
+        ConnectionError("temporary connection failure"),
+        NetworkError("Failed to CreateTool: network error"),
+        ApiError(
+            "Failed to CreateTool: request limit exceeded",
+            error_code="RequestLimitExceeded",
+        ),
+    ],
+    ids=[
+        "qps-limit",
+        "connection-error",
+        "agentkit-network-error",
+        "agentkit-request-limit",
+    ],
+)
+def test_ensure_studio_code_env_tool_retries_transient_create_errors(
+    transient_error: Exception,
+) -> None:
+    create_calls = 0
+    client_tokens: list[str] = []
+    sleeps: list[float] = []
+
+    def _create(request: object) -> SimpleNamespace:
+        nonlocal create_calls
+        create_calls += 1
+        client_tokens.append(str(getattr(request, "client_token")))
+        if create_calls == 1:
+            raise transient_error
+        return SimpleNamespace(tool_id="tool-after-retry")
+
+    client = SimpleNamespace(
+        list_tools=lambda _: SimpleNamespace(tools=[], next_token=None),
+        get_tool=lambda _: SimpleNamespace(status="Ready"),
+        create_tool=_create,
+    )
+
+    assert (
+        ensure_studio_code_env_tool(
+            name="veadk-studio-demo-retry-12345678",
+            client=client,
+            timeout_seconds=0,
+            create_max_attempts=3,
+            create_retry_delay=0.25,
+            sleep=sleeps.append,
+        )
+        == "tool-after-retry"
+    )
+    assert create_calls == 2
+    assert len(set(client_tokens)) == 1
+    assert len(client_tokens[0]) == 32
+    assert sleeps == [0.25]
+
+
+def test_ensure_studio_code_env_tool_spaces_create_api_starts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 100.0
+    create_started_at: list[float] = []
+    sleeps: list[float] = []
+
+    def _sleep(delay: float) -> None:
+        nonlocal now
+        sleeps.append(delay)
+        now += delay
+
+    def _create(_: object) -> SimpleNamespace:
+        create_started_at.append(now)
+        return SimpleNamespace(tool_id=f"tool-{len(create_started_at)}")
+
+    monkeypatch.setattr(studio_sandbox_tools.time, "monotonic", lambda: now)
+    monkeypatch.setattr(studio_sandbox_tools, "_NEXT_CREATE_TOOL_AT", 0.0)
+    client = SimpleNamespace(
+        list_tools=lambda _: SimpleNamespace(tools=[], next_token=None),
+        get_tool=lambda _: SimpleNamespace(status="Ready"),
+        create_tool=_create,
+    )
+
+    for suffix in ("first", "second"):
+        ensure_studio_code_env_tool(
+            name=f"veadk-studio-demo-{suffix}-12345678",
+            client=client,
+            timeout_seconds=0,
+            create_min_interval=0.5,
+            sleep=_sleep,
+        )
+
+    assert create_started_at == [100.0, 100.5]
+    assert create_started_at[1] - create_started_at[0] >= 0.5
+    assert sleeps == [0.5]
+
+
+def test_ensure_studio_code_env_tool_preserves_exhausted_create_error() -> None:
+    create_calls = 0
+    sleeps: list[float] = []
+    last_error = TimeoutError("temporary create timeout")
+
+    def _create(_: object) -> SimpleNamespace:
+        nonlocal create_calls
+        create_calls += 1
+        raise last_error
+
+    client = SimpleNamespace(
+        list_tools=lambda _: SimpleNamespace(tools=[], next_token=None),
+        create_tool=_create,
+    )
+
+    with pytest.raises(RuntimeError, match="veadk-studio-demo-retry-12345678") as exc:
+        ensure_studio_code_env_tool(
+            name="veadk-studio-demo-retry-12345678",
+            client=client,
+            timeout_seconds=0,
+            create_max_attempts=3,
+            create_retry_delay=0.25,
+            sleep=sleeps.append,
+        )
+
+    assert create_calls == 3
+    assert sleeps == [0.25, 0.5]
+    assert exc.value.__cause__ is last_error
+
+
+@pytest.mark.parametrize(
+    ("get_tool", "timeout_seconds"),
+    [
+        (lambda _: SimpleNamespace(status="Failed"), 60),
+        (lambda _: SimpleNamespace(status="Creating"), 0),
+        (
+            lambda _: (_ for _ in ()).throw(
+                ConnectionError("temporary status lookup failure")
+            ),
+            60,
+        ),
+    ],
+    ids=["failed", "timeout", "get-tool-error"],
+)
+def test_ensure_studio_code_env_tool_ready_errors_include_tool_id(
+    get_tool: object,
+    timeout_seconds: float,
+) -> None:
+    client = SimpleNamespace(
+        list_tools=lambda _: SimpleNamespace(tools=[], next_token=None),
+        create_tool=lambda _: SimpleNamespace(tool_id="tool-with-ready-error"),
+        get_tool=get_tool,
+    )
+
+    with pytest.raises(RuntimeError, match="tool-with-ready-error"):
+        ensure_studio_code_env_tool(
+            name="veadk-studio-demo-ready-error-12345678",
+            client=client,
+            timeout_seconds=timeout_seconds,
+        )
 
 
 def test_ensure_studio_code_env_tool_creates_snapshot_enabled_code_env() -> None:
@@ -225,22 +385,43 @@ def test_ensure_studio_agent_tool_creates_snapshot_enabled_managed_tool(
     assert requests[0].enable_snapshot is True
 
 
-def test_snapshot_tool_name_is_distinct_and_has_snapshot_suffix() -> None:
-    standard = studio_sandbox_tool_name("Studio App", "chat")
-    snapshot = studio_sandbox_tool_name("Studio App", "chat", snapshot=True)
+def test_studio_sandbox_tool_name_uses_short_studio_format() -> None:
+    assert studio_sandbox_tool_name("Studio App", "chat") == (
+        "studio-studio-app-chat-1d66ce"
+    )
 
-    assert snapshot == f"{standard}_snapshot"
-    assert snapshot.endswith("_snapshot")
+
+def test_studio_sandbox_tool_name_normalizes_invalid_characters() -> None:
+    assert studio_sandbox_tool_name("  My_App@2026!  ", "skill") == (
+        "studio-my-app-2026-skill-6c7faf"
+    )
+
+
+def test_studio_sandbox_tool_name_truncates_normalized_app_name_to_20_chars() -> None:
+    assert (
+        studio_sandbox_tool_name(
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+            "chat",
+        )
+        == "studio-abcdefghijklmnopqrst-chat-1655ef"
+    )
+
+
+def test_studio_sandbox_tool_name_hash_distinguishes_normalization_collisions() -> None:
+    underscore_name = studio_sandbox_tool_name("My_App", "chat")
+    space_name = studio_sandbox_tool_name("My App", "chat")
+
+    assert underscore_name == "studio-my-app-chat-6bcaca"
+    assert space_name == "studio-my-app-chat-58967a"
+    assert underscore_name != space_name
 
 
 @pytest.mark.parametrize("purpose", ["chat", "openclaw", "hermes"])
-def test_snapshot_tool_name_preserves_the_standard_length_bound(purpose: str) -> None:
-    application_name = "a" * 100
-    standard = studio_sandbox_tool_name(application_name, purpose)
-    snapshot = studio_sandbox_tool_name(application_name, purpose, snapshot=True)
+def test_snapshot_tool_name_appends_snapshot_suffix(purpose: str) -> None:
+    standard = studio_sandbox_tool_name("Studio App", purpose)
+    snapshot = studio_sandbox_tool_name("Studio App", purpose, snapshot=True)
 
-    assert len(snapshot) <= len(standard)
-    assert snapshot.endswith("_snapshot")
+    assert snapshot == f"{standard}_snapshot"
 
 
 def test_agent_model_credential_is_bound_to_tool_as_complete_env_set() -> None:

--- a/tests/cli/test_studio_update.py
+++ b/tests/cli/test_studio_update.py
@@ -689,6 +689,7 @@ def test_volcengine_studio_update_repairs_missing_snapshot_tools(
     agent_tools: list[dict[str, object]] = []
     code_credentials: list[dict[str, object]] = []
     agent_credentials: list[dict[str, object]] = []
+    stagger_delays: list[float] = []
     monkeypatch.setattr(
         "veadk.cli.studio_update.find_studio_deployments", lambda **_: [target]
     )
@@ -709,14 +710,16 @@ def test_volcengine_studio_update_repairs_missing_snapshot_tools(
         "veadk.cli.cli_frontend._new_studio_deploy_id",
         lambda: "stddep_update",
     )
+    monkeypatch.setattr("veadk.cli.cli_frontend.sleep", stagger_delays.append)
     monkeypatch.setattr(
         "veadk.cli.studio_sandbox_tools.ensure_studio_code_env_tool",
         lambda **kwargs: code_tools.append(kwargs) or "codex-snapshot-tool",
     )
     monkeypatch.setattr(
         "veadk.cli.studio_sandbox_tools.ensure_studio_agent_tool",
-        lambda **kwargs: agent_tools.append(kwargs)
-        or f"{kwargs['kind']}-snapshot-tool",
+        lambda **kwargs: (
+            agent_tools.append(kwargs) or f"{kwargs['kind']}-snapshot-tool"
+        ),
     )
     monkeypatch.setattr(
         "veadk.cli.frontend_skill_creator.ensure_skill_creator_model_credential",
@@ -764,9 +767,12 @@ def test_volcengine_studio_update_repairs_missing_snapshot_tools(
     assert result.exit_code == 0, result.output
     assert len(code_tools) == 1
     assert code_tools[0]["enable_snapshot"] is True
+    assert code_tools[0]["create_min_interval"] == 0.5
     assert str(code_tools[0]["name"]).endswith("_snapshot")
     assert {str(call["kind"]) for call in agent_tools} == {"openclaw", "hermes"}
     assert {bool(call["enable_snapshot"]) for call in agent_tools} == {True}
+    assert {float(call["create_min_interval"]) for call in agent_tools} == {0.5}
+    assert stagger_delays == [0.5, 0.5]
     assert {str(call["provider"]) for call in code_credentials} == {"volcengine"}
     assert {str(call["provider"]) for call in agent_credentials} == {"volcengine"}
     overrides = captured["environment_overrides"]
@@ -819,11 +825,13 @@ def test_byteplus_studio_update_repairs_missing_sandbox_tools(
     )
     monkeypatch.setattr(
         "veadk.cli.studio_sandbox_tools.ensure_studio_agent_tool",
-        lambda **kwargs: agent_tools.append(kwargs)
-        or (
-            f"{kwargs['kind']}-snapshot-tool"
-            if kwargs["enable_snapshot"]
-            else f"{kwargs['kind']}-tool"
+        lambda **kwargs: (
+            agent_tools.append(kwargs)
+            or (
+                f"{kwargs['kind']}-snapshot-tool"
+                if kwargs["enable_snapshot"]
+                else f"{kwargs['kind']}-tool"
+            )
         ),
     )
     monkeypatch.setattr(

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -34,7 +34,7 @@ import zipfile
 from collections.abc import Iterable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from time import monotonic
+from time import monotonic, sleep
 from typing import Any, Literal
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -97,6 +97,7 @@ _SENSITIVE_LOG_PATTERNS = (
 )
 _CP_BUILD_LOG_MAX_CHARS = 16000
 _CP_BUILD_LOG_MAX_LINES = 260
+_SANDBOX_TOOL_CREATE_STAGGER_SECONDS = 0.5
 _CP_PIPELINE_CREATED_RE = re.compile(
     r"Pipeline created successfully:\s*(?P<name>.*?)\s*\(ID:\s*(?P<id>[^)]+)\)"
 )
@@ -365,6 +366,94 @@ def _redact_debug_text(text: str) -> str:
     )
 
 
+def _service_error_payload(value: object) -> Mapping[str, object] | None:
+    if isinstance(value, Mapping):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (TypeError, ValueError):
+            return None
+        return parsed if isinstance(parsed, Mapping) else None
+    json_method = getattr(value, "json", None)
+    if callable(json_method):
+        try:
+            parsed = json_method()
+        except Exception:
+            return None
+        return parsed if isinstance(parsed, Mapping) else None
+    return None
+
+
+def _service_error_context(error: BaseException) -> tuple[str, dict[str, str]]:
+    """Extract native cloud error fields without replacing its original message."""
+    metadata: dict[str, str] = {}
+    attribute_names = {
+        "error_code": ("error_code", "code"),
+        "status_code": ("status_code",),
+        "request_id": ("request_id", "requestId", "requestid"),
+    }
+    for field, names in attribute_names.items():
+        for name in names:
+            value = getattr(error, name, None)
+            if value is None or callable(value):
+                continue
+            text = str(getattr(value, "value", value)).strip()
+            if text:
+                metadata[field] = text
+                break
+
+    service_message = ""
+    payloads = []
+    for candidate in (
+        getattr(error, "response", None),
+        getattr(error, "body", None),
+        getattr(error, "data", None),
+    ):
+        payload = _service_error_payload(candidate)
+        if payload is not None:
+            payloads.append(payload)
+        if candidate is not None and "status_code" not in metadata:
+            status_code = getattr(candidate, "status_code", None)
+            if status_code is not None:
+                metadata["status_code"] = str(status_code)
+        headers = getattr(candidate, "headers", None)
+        if isinstance(headers, Mapping) and "request_id" not in metadata:
+            for key in ("x-request-id", "x-tt-logid", "x-response-id"):
+                request_id = headers.get(key)
+                if request_id:
+                    metadata["request_id"] = str(request_id)
+                    break
+
+    for payload in payloads:
+        response_metadata = payload.get("ResponseMetadata")
+        if not isinstance(response_metadata, Mapping):
+            response_metadata = payload.get("response_metadata")
+        if isinstance(response_metadata, Mapping):
+            request_id = response_metadata.get("RequestId") or response_metadata.get(
+                "RequestID"
+            )
+            if request_id and "request_id" not in metadata:
+                metadata["request_id"] = str(request_id)
+            error_payload = response_metadata.get("Error")
+        else:
+            error_payload = payload.get("Error") or payload.get("error")
+        if not isinstance(error_payload, Mapping):
+            error_payload = payload
+
+        code = error_payload.get("Code") or error_payload.get("code")
+        if code and "error_code" not in metadata:
+            metadata["error_code"] = str(code)
+        message = error_payload.get("Message") or error_payload.get("message")
+        if message and not service_message:
+            service_message = str(message).strip()
+        request_id = error_payload.get("RequestId") or error_payload.get("request_id")
+        if request_id and "request_id" not in metadata:
+            metadata["request_id"] = str(request_id)
+
+    return service_message, metadata
+
+
 def _safe_exception_detail(
     error: BaseException,
     *,
@@ -377,6 +466,14 @@ def _safe_exception_detail(
     while current is not None and id(current) not in seen:
         seen.add(id(current))
         message = _ANSI_ESCAPE_RE.sub("", str(current)).strip()
+        service_message, service_metadata = _service_error_context(current)
+        if service_message and service_message not in message:
+            message = f"{message}\nServer message: {service_message}".strip()
+        if service_metadata:
+            metadata_text = ", ".join(
+                f"{key}={value}" for key, value in service_metadata.items()
+            )
+            message = f"{message}\nServer metadata: {metadata_text}".strip()
         for secret in secrets:
             if secret:
                 message = message.replace(secret, "***")
@@ -8028,6 +8125,8 @@ def frontend_deploy(
         with ThreadPoolExecutor(max_workers=len(missing_sandbox_tools)) as executor:
             tool_futures = {}
             for kind, tool_name in missing_sandbox_tools.items():
+                if tool_futures:
+                    sleep(_SANDBOX_TOOL_CREATE_STAGGER_SECONDS)
                 base_kind = kind.removesuffix("_snapshot")
                 enable_snapshot = kind.endswith("_snapshot")
                 if base_kind == "codex":
@@ -8035,6 +8134,7 @@ def frontend_deploy(
                         ensure_studio_code_env_tool,
                         name=tool_name,
                         enable_snapshot=enable_snapshot,
+                        create_min_interval=_SANDBOX_TOOL_CREATE_STAGGER_SECONDS,
                         region=region,
                         access_key=ak,
                         secret_key=sk,
@@ -8044,6 +8144,7 @@ def frontend_deploy(
                     future = executor.submit(
                         ensure_studio_dev_env_tool,
                         name=tool_name,
+                        create_min_interval=_SANDBOX_TOOL_CREATE_STAGGER_SECONDS,
                         region=region,
                         access_key=ak,
                         secret_key=sk,
@@ -8056,6 +8157,7 @@ def frontend_deploy(
                         kind=base_kind,
                         enable_snapshot=enable_snapshot,
                         model_name=sandbox_agent_model_name,
+                        create_min_interval=_SANDBOX_TOOL_CREATE_STAGGER_SECONDS,
                         region=region,
                         access_key=ak,
                         secret_key=sk,
@@ -8713,6 +8815,8 @@ def frontend_update(
                 ) as executor:
                     tool_futures = {}
                     for kind, tool_name in missing_snapshot_tools.items():
+                        if tool_futures:
+                            sleep(_SANDBOX_TOOL_CREATE_STAGGER_SECONDS)
                         label = snapshot_labels[kind]
                         click.echo(f"Creating AgentKit {label} Tool '{tool_name}'…")
                         base_kind = kind.removesuffix("_snapshot")
@@ -8721,6 +8825,9 @@ def frontend_update(
                                 ensure_studio_code_env_tool,
                                 name=tool_name,
                                 enable_snapshot=True,
+                                create_min_interval=(
+                                    _SANDBOX_TOOL_CREATE_STAGGER_SECONDS
+                                ),
                                 region=target.region,
                                 access_key=ak,
                                 secret_key=sk,
@@ -8733,6 +8840,9 @@ def frontend_update(
                                 kind=base_kind,
                                 enable_snapshot=True,
                                 model_name=sandbox_agent_model_name,
+                                create_min_interval=(
+                                    _SANDBOX_TOOL_CREATE_STAGGER_SECONDS
+                                ),
                                 region=target.region,
                                 access_key=ak,
                                 secret_key=sk,
@@ -8893,6 +9003,8 @@ def frontend_update(
                     ) as ex:
                         tool_futures = {}
                         for kind, tool_name in missing_sandbox_tools.items():
+                            if tool_futures:
+                                sleep(_SANDBOX_TOOL_CREATE_STAGGER_SECONDS)
                             base_kind = kind.removesuffix("_snapshot")
                             enable_snapshot = kind.endswith("_snapshot")
                             if base_kind == "codex":
@@ -8900,6 +9012,9 @@ def frontend_update(
                                     ensure_studio_code_env_tool,
                                     name=tool_name,
                                     enable_snapshot=enable_snapshot,
+                                    create_min_interval=(
+                                        _SANDBOX_TOOL_CREATE_STAGGER_SECONDS
+                                    ),
                                     region=target.region,
                                     access_key=ak,
                                     secret_key=sk,
@@ -8909,6 +9024,9 @@ def frontend_update(
                                 future = ex.submit(
                                     ensure_studio_dev_env_tool,
                                     name=tool_name,
+                                    create_min_interval=(
+                                        _SANDBOX_TOOL_CREATE_STAGGER_SECONDS
+                                    ),
                                     region=target.region,
                                     access_key=ak,
                                     secret_key=sk,
@@ -8921,6 +9039,9 @@ def frontend_update(
                                     kind=base_kind,
                                     enable_snapshot=enable_snapshot,
                                     model_name=sandbox_agent_model_name,
+                                    create_min_interval=(
+                                        _SANDBOX_TOOL_CREATE_STAGGER_SECONDS
+                                    ),
                                     region=target.region,
                                     access_key=ak,
                                     secret_key=sk,

--- a/veadk/cli/studio_sandbox_tools.py
+++ b/veadk/cli/studio_sandbox_tools.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import re
 import secrets
+import threading
 import time
 import zlib
 from collections.abc import Callable
@@ -33,6 +34,8 @@ from veadk.cli.studio_model_catalog import (
 _PROJECT_NAME = "default"
 _TOOL_TYPE = "CodeEnv"
 _DEV_TOOL_TYPE = "DevEnv"
+_TOOL_NAME_APP_MAX_LENGTH = 20
+_TOOL_NAME_HASH_LENGTH = 6
 STUDIO_SANDBOX_AGENT_MODEL_NAME = VOLCENGINE_STUDIO_AGENT_MODEL_NAME
 STUDIO_SANDBOX_BYTEPLUS_AGENT_MODEL_NAME = BYTEPLUS_STUDIO_AGENT_MODEL_NAME
 STUDIO_SANDBOX_MODEL_BASE_URLS = {
@@ -45,6 +48,35 @@ _AGENT_TOOL_TYPES = {
 }
 _READY_STATUS = "Ready"
 _FAILED_STATUSES = frozenset({"Error", "Failed", "CreateFailed", "Deleting", "Deleted"})
+_RETRYABLE_CREATE_STATUS_CODES = frozenset({408, 409, 425, 429})
+_RETRYABLE_CREATE_ERROR_CODES = frozenset(
+    {
+        "internalerror",
+        "internalservererror",
+        "requestlimitexceeded",
+        "serviceunavailable",
+        "throttling",
+        "toomanyrequests",
+    }
+)
+_RETRYABLE_CREATE_ERROR_MARKERS = (
+    "connection aborted",
+    "connection error",
+    "connection reset",
+    "internal server error",
+    "network error",
+    "qps",
+    "rate limit",
+    "request limit",
+    "service unavailable",
+    "temporarily unavailable",
+    "throttl",
+    "timed out",
+    "timeout",
+    "too many requests",
+)
+_CREATE_TOOL_RATE_LOCK = threading.Lock()
+_NEXT_CREATE_TOOL_AT = 0.0
 
 
 def studio_sandbox_agent_model_name(provider: str) -> str:
@@ -69,9 +101,9 @@ def studio_sandbox_tool_name(
     """Return a stable, account-local Tool name for one Studio capability."""
     safe_name = re.sub(r"[^a-z0-9-]+", "-", application_name.lower()).strip("-")
     suffix = "_snapshot" if snapshot else ""
-    safe_name = safe_name[: 30 - len(suffix)].rstrip("-") or "studio"
-    digest = f"{zlib.crc32(application_name.encode()):08x}"
-    name = f"veadk-studio-{safe_name}-{purpose}-{digest}"
+    safe_name = safe_name[:_TOOL_NAME_APP_MAX_LENGTH].rstrip("-") or "app"
+    digest = f"{zlib.crc32(application_name.encode()):08x}"[:_TOOL_NAME_HASH_LENGTH]
+    name = f"studio-{safe_name}-{purpose}-{digest}"
     return f"{name}{suffix}"
 
 
@@ -88,7 +120,13 @@ def _wait_for_ready_tool(
 ) -> str:
     deadline = time.monotonic() + timeout_seconds
     while True:
-        tool = tools_client.get_tool(tools_types.GetToolRequest(ToolId=tool_id))
+        try:
+            tool = tools_client.get_tool(tools_types.GetToolRequest(ToolId=tool_id))
+        except Exception as error:
+            raise RuntimeError(
+                f"Failed to query AgentKit Tool '{name}' "
+                f"(Tool ID: '{tool_id}') status: {error}"
+            ) from error
         status = (tool.status or "").strip()
         if status == _READY_STATUS:
             actual_snapshot = bool(getattr(tool, "enable_snapshot", False))
@@ -96,17 +134,147 @@ def _wait_for_ready_tool(
                 expected = "enabled" if enable_snapshot else "disabled"
                 actual = "enabled" if actual_snapshot else "disabled"
                 raise RuntimeError(
-                    f"AgentKit Tool '{name}' has snapshot {actual}; "
+                    f"AgentKit Tool '{name}' (Tool ID: '{tool_id}') "
+                    f"has snapshot {actual}; "
                     f"expected snapshot {expected}."
                 )
             return tool_id
         if status in _FAILED_STATUSES:
             raise RuntimeError(
-                f"AgentKit Tool '{name}' failed to become ready: {status}."
+                f"AgentKit Tool '{name}' (Tool ID: '{tool_id}') "
+                f"failed to become ready: {status}."
             )
         if time.monotonic() >= deadline:
-            raise RuntimeError(f"Timed out waiting for AgentKit Tool '{name}'.")
+            raise RuntimeError(
+                f"Timed out waiting for AgentKit Tool '{name}' (Tool ID: '{tool_id}')."
+            )
         sleep(poll_interval)
+
+
+def _is_retryable_tool_creation_error(error: Exception) -> bool:
+    """Return whether a Tool creation failure is safe to retry."""
+    candidates: list[Any] = []
+    current: BaseException | None = error
+    while current is not None and current not in candidates:
+        candidates.append(current)
+        current = current.__cause__ or current.__context__
+    response = getattr(error, "response", None)
+    if response is not None and response not in candidates:
+        candidates.append(response)
+
+    details = []
+    for candidate in candidates:
+        if isinstance(candidate, (ConnectionError, TimeoutError)):
+            return True
+        details.append(str(candidate))
+        for attribute in ("status_code", "status", "code", "error_code"):
+            value = getattr(candidate, attribute, None)
+            if value is not None:
+                details.append(str(value))
+                normalized_code = re.sub(r"[^a-z0-9]", "", str(value).lower())
+                if normalized_code in _RETRYABLE_CREATE_ERROR_CODES:
+                    return True
+            try:
+                status_code = int(value)
+            except (TypeError, ValueError):
+                continue
+            if (
+                status_code in _RETRYABLE_CREATE_STATUS_CODES
+                or 500 <= status_code < 600
+            ):
+                return True
+
+    detail = " ".join(details).lower()
+    return any(marker in detail for marker in _RETRYABLE_CREATE_ERROR_MARKERS)
+
+
+def _created_tool_id(match: Any | None, *, name: str) -> str | None:
+    if match is None:
+        return None
+    tool_id = (match.tool_id or "").strip()
+    if not tool_id:
+        raise RuntimeError(f"AgentKit Tool '{name}' did not return a Tool ID.")
+    return tool_id
+
+
+def _wait_for_tool_creation_slot(
+    interval_seconds: float,
+    *,
+    sleep: Callable[[float], None],
+) -> None:
+    """Serialize create_tool starts while leaving other provisioning work parallel."""
+    if interval_seconds < 0:
+        raise ValueError("create_min_interval must not be negative")
+    if interval_seconds == 0:
+        return
+
+    global _NEXT_CREATE_TOOL_AT
+    with _CREATE_TOOL_RATE_LOCK:
+        now = time.monotonic()
+        delay = max(0.0, _NEXT_CREATE_TOOL_AT - now)
+        if delay:
+            sleep(delay)
+            now = time.monotonic()
+        _NEXT_CREATE_TOOL_AT = max(now, _NEXT_CREATE_TOOL_AT) + interval_seconds
+
+
+def _create_tool_with_retry(
+    tools_client: Any,
+    tools_types: Any,
+    *,
+    request: Any,
+    name: str,
+    tool_type: str,
+    create_max_attempts: int,
+    create_retry_delay: float,
+    create_min_interval: float,
+    sleep: Callable[[float], None],
+) -> str:
+    if create_max_attempts < 1:
+        raise ValueError("create_max_attempts must be at least 1")
+    if create_retry_delay < 0:
+        raise ValueError("create_retry_delay must not be negative")
+    if create_min_interval < 0:
+        raise ValueError("create_min_interval must not be negative")
+
+    for attempt in range(1, create_max_attempts + 1):
+        if attempt > 1:
+            sleep(create_retry_delay * (2 ** (attempt - 2)))
+            try:
+                recovered_id = _created_tool_id(
+                    _find_exact_tool(
+                        tools_client,
+                        tools_types,
+                        name=name,
+                        tool_type=tool_type,
+                    ),
+                    name=name,
+                )
+            except Exception:
+                recovered_id = None
+            if recovered_id:
+                return recovered_id
+
+        try:
+            _wait_for_tool_creation_slot(create_min_interval, sleep=sleep)
+            response = tools_client.create_tool(request)
+        except Exception as error:
+            if attempt < create_max_attempts and _is_retryable_tool_creation_error(
+                error
+            ):
+                continue
+            raise RuntimeError(
+                f"Creating AgentKit Tool '{name}' failed after {attempt} attempt(s)."
+            ) from error
+
+        tool_id = (response.tool_id or "").strip()
+        if not tool_id:
+            raise RuntimeError(
+                f"Creating AgentKit Tool '{name}' did not return a Tool ID."
+            )
+        return tool_id
+
+    raise AssertionError("unreachable")
 
 
 def _find_exact_tool(
@@ -161,6 +329,9 @@ def _ensure_studio_environment_tool(
     client: Any | None = None,
     timeout_seconds: float = 600.0,
     poll_interval: float = 5.0,
+    create_max_attempts: int = 3,
+    create_retry_delay: float = 1.0,
+    create_min_interval: float = 0.0,
     sleep: Callable[[float], None] = time.sleep,
 ) -> str:
     """Reuse or create one ready managed environment Tool."""
@@ -180,15 +351,17 @@ def _ensure_studio_environment_tool(
         tool_type=tool_type,
     )
     if match is not None:
-        tool_id = (match.tool_id or "").strip()
-        if not tool_id:
-            raise RuntimeError(f"AgentKit Tool '{name}' did not return a Tool ID.")
+        tool_id = _created_tool_id(match, name=name)
+        assert tool_id is not None
     else:
-        response = tools_client.create_tool(
-            tools_types.CreateToolRequest(
+        tool_id = _create_tool_with_retry(
+            tools_client,
+            tools_types,
+            request=tools_types.CreateToolRequest(
                 Name=name,
                 ToolType=tool_type,
                 ProjectName=_PROJECT_NAME,
+                ClientToken=secrets.token_hex(16),
                 EnableSnapshot=enable_snapshot,
                 CpuMilli=4000,
                 MemoryMb=8192,
@@ -202,13 +375,14 @@ def _ensure_studio_environment_tool(
                     EnablePublicNetwork=True,
                     EnablePrivateNetwork=False,
                 ),
-            )
+            ),
+            name=name,
+            tool_type=tool_type,
+            create_max_attempts=create_max_attempts,
+            create_retry_delay=create_retry_delay,
+            create_min_interval=create_min_interval,
+            sleep=sleep,
         )
-        tool_id = (response.tool_id or "").strip()
-        if not tool_id:
-            raise RuntimeError(
-                f"Creating AgentKit Tool '{name}' did not return a Tool ID."
-            )
 
     return _wait_for_ready_tool(
         tools_client,
@@ -245,6 +419,9 @@ def ensure_studio_agent_tool(
     client: Any | None = None,
     timeout_seconds: float = 600.0,
     poll_interval: float = 5.0,
+    create_max_attempts: int = 3,
+    create_retry_delay: float = 1.0,
+    create_min_interval: float = 0.0,
     sleep: Callable[[float], None] = time.sleep,
 ) -> str:
     """Reuse or create one ready managed Hermes/OpenClaw Tool."""
@@ -271,15 +448,17 @@ def ensure_studio_agent_tool(
         tool_type=tool_type,
     )
     if match is not None:
-        tool_id = (match.tool_id or "").strip()
-        if not tool_id:
-            raise RuntimeError(f"AgentKit Tool '{name}' did not return a Tool ID.")
+        tool_id = _created_tool_id(match, name=name)
+        assert tool_id is not None
     else:
-        response = tools_client.create_tool(
-            tools_types.CreateToolRequest(
+        tool_id = _create_tool_with_retry(
+            tools_client,
+            tools_types,
+            request=tools_types.CreateToolRequest(
                 Name=name,
                 ToolType=tool_type,
                 ProjectName=_PROJECT_NAME,
+                ClientToken=secrets.token_hex(16),
                 EnableSnapshot=enable_snapshot,
                 ModelAgentName=normalized_model_name,
                 CpuMilli=4000,
@@ -294,13 +473,14 @@ def ensure_studio_agent_tool(
                     EnablePublicNetwork=True,
                     EnablePrivateNetwork=False,
                 ),
-            )
+            ),
+            name=name,
+            tool_type=tool_type,
+            create_max_attempts=create_max_attempts,
+            create_retry_delay=create_retry_delay,
+            create_min_interval=create_min_interval,
+            sleep=sleep,
         )
-        tool_id = (response.tool_id or "").strip()
-        if not tool_id:
-            raise RuntimeError(
-                f"Creating AgentKit {tool_type} Tool '{name}' did not return a Tool ID."
-            )
 
     return _wait_for_ready_tool(
         tools_client,


### PR DESCRIPTION
## Summary
- shorten stable Studio Sandbox Tool names while retaining collision-resistant app hashes
- stagger Tool creation by 0.5 seconds and retry transient AgentKit failures with exponential backoff
- reuse a stable ClientToken across retries to prevent duplicate Tool creation
- surface failed Tool IDs and native Volcengine/BytePlus service errors while redacting credentials
- apply the same provisioning safeguards to deploy and update repair paths

## Validation
- live Volcengine Studio deployment completed with all seven Sandbox Tools reaching Ready
- `uv run pytest tests/cli/test_studio_sandbox_tools.py tests/cli/test_studio_deploy_target.py tests/cli/test_studio_update.py -q` (93 passed)
- `uv run pre-commit run --files veadk/cli/studio_sandbox_tools.py veadk/cli/cli_frontend.py tests/cli/test_studio_sandbox_tools.py tests/cli/test_studio_deploy_target.py tests/cli/test_studio_update.py`