### PR TITLE
fix(auth): prevent OAuth open redirects

### DIFF
--- a/tests/auth/test_oauth2_auth.py
+++ b/tests/auth/test_oauth2_auth.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.testclient import TestClient
+
+from veadk.auth.middleware.oauth2_auth import (
+    OAuth2Handler,
+    _resolve_redirect_after_auth,
+    register_oauth2_routes,
+)
+
+
+@pytest.fixture
+def login_request() -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "scheme": "https",
+            "server": ("studio.example.com", 443),
+            "path": "/oauth2/login",
+            "raw_path": b"/oauth2/login",
+            "query_string": b"",
+            "headers": [(b"host", b"studio.example.com")],
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("redirect", "expected"),
+    [
+        (None, "/"),
+        ("", "/"),
+        ("/", "/"),
+        ("dashboard?tab=1", "/dashboard?tab=1"),
+        ("?tab=1", "/?tab=1"),
+        ("#activity", "/#activity"),
+        ("/dashboard?tab=1#activity", "/dashboard?tab=1#activity"),
+        ("/search?q=100%", "/search?q=100%"),
+        ("/%ZZ", "/%ZZ"),
+        ("/files/a%2Fb", "/files/a%2Fb"),
+        (
+            "/web/openclaw/sessions/session-1/surface/token-1/openclaw/",
+            "/web/openclaw/sessions/session-1/surface/token-1/openclaw/",
+        ),
+        (
+            "/web/hermes/sessions/session-1/surface/token-1/hermes/"
+            "?theme=dark#workspace",
+            "/web/hermes/sessions/session-1/surface/token-1/hermes/"
+            "?theme=dark#workspace",
+        ),
+        (
+            "/web/sandbox/proxy/cloud-session/terminal/terminal"
+            "?session_id=native-shell-1",
+            "/web/sandbox/proxy/cloud-session/terminal/terminal"
+            "?session_id=native-shell-1",
+        ),
+        (
+            "https://studio.example.com/dashboard?tab=1#activity",
+            "/dashboard?tab=1#activity",
+        ),
+        (
+            "https://studio.example.com/web/openclaw/sessions/session-1/"
+            "surface/token-1/openclaw/",
+            "/web/openclaw/sessions/session-1/surface/token-1/openclaw/",
+        ),
+        ("https://STUDIO.EXAMPLE.COM:443/dashboard", "/dashboard"),
+    ],
+)
+def test_resolve_redirect_after_auth_accepts_safe_targets(
+    login_request: Request, redirect: str | None, expected: str
+) -> None:
+    assert _resolve_redirect_after_auth(login_request, redirect) == expected
+
+
+@pytest.mark.parametrize(
+    "redirect",
+    [
+        " //attacker.example/path",
+        "//attacker.example/path",
+        "///attacker.example/path",
+        r"/\attacker.example/path",
+        r"\\attacker.example\path",
+        "%2f%2fattacker.example/path",
+        "/%2fattacker.example/path",
+        "/%252fattacker.example/path",
+        "/%5c%5cattacker.example/path",
+        "/%255cattacker.example/path",
+        "/\r\nLocation: https://attacker.example",
+        "https://attacker.example/path",
+        "https://studio.example.com.attacker.example/path",
+        "https://studio.example.com@attacker.example/path",
+        "https://user@studio.example.com/path",
+        "https://studio.example.com:444/path",
+        "http://studio.example.com/path",
+        "https://studio.example.com//attacker.example/path",
+        "javascript:alert(1)",
+    ],
+)
+def test_resolve_redirect_after_auth_rejects_unsafe_targets(
+    login_request: Request, redirect: str
+) -> None:
+    assert _resolve_redirect_after_auth(login_request, redirect) == "/"
+
+
+@pytest.mark.parametrize(
+    ("stored_redirect", "expected"),
+    [
+        ("//attacker.example/path", "/"),
+        ("/dashboard?tab=1", "/dashboard?tab=1"),
+        (
+            "https://studio.example.com/web/openclaw/sessions/session-1/"
+            "surface/token-1/openclaw/",
+            "/web/openclaw/sessions/session-1/surface/token-1/openclaw/",
+        ),
+        (
+            "https://studio.example.com/web/sandbox/proxy/cloud-session/"
+            "terminal/terminal?session_id=native-shell-1",
+            "/web/sandbox/proxy/cloud-session/terminal/terminal"
+            "?session_id=native-shell-1",
+        ),
+    ],
+)
+def test_oauth2_callback_revalidates_stored_redirect(
+    stored_redirect: str, expected: str
+) -> None:
+    handler = Mock(spec=OAuth2Handler)
+    handler.state_store = Mock()
+    handler.state_store.validate_and_consume_state.return_value = {
+        "redirect_after_auth": stored_redirect,
+        "code_verifier": None,
+    }
+    handler.exchange_code_for_token = AsyncMock(return_value=Mock())
+    handler.create_session_cookie.return_value = {
+        "key": "veadk_session",
+        "value": "session",
+    }
+    handler.create_user_id_cookie.return_value = None
+
+    app = Starlette()
+    register_oauth2_routes(app, handler)
+
+    with TestClient(app, base_url="https://studio.example.com") as client:
+        response = client.get(
+            "/oauth2/callback",
+            params={"code": "code", "state": "state"},
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == expected

--- a/veadk/auth/middleware/oauth2_auth.py
+++ b/veadk/auth/middleware/oauth2_auth.py
@@ -1318,24 +1318,93 @@ class OAuth2Handler:
         return OAuth2Handler._base64url_encode(digest)
 
 
+_REDIRECT_MAX_DECODE_ROUNDS = 5
+
+
+def _has_unsafe_redirect_text(value: str) -> bool:
+    if value != value.strip():
+        return True
+
+    decoded = value
+    for _ in range(_REDIRECT_MAX_DECODE_ROUNDS):
+        if decoded.startswith("//") or any(
+            character == "\\" or ord(character) < 0x20 or ord(character) == 0x7F
+            for character in decoded
+        ):
+            return True
+        try:
+            next_decoded = urllib.parse.unquote(decoded, errors="strict")
+        except UnicodeDecodeError:
+            return True
+        if next_decoded == decoded:
+            return False
+        decoded = next_decoded
+
+    # Reject inputs that require excessive decoding to reach their final form.
+    return True
+
+
+def _is_safe_local_redirect(value: str) -> bool:
+    if _has_unsafe_redirect_text(value) or not value.startswith("/"):
+        return False
+    try:
+        parsed = urllib.parse.urlsplit(value)
+    except ValueError:
+        return False
+    return not parsed.scheme and not parsed.netloc
+
+
+def _normalized_http_origin(
+    value: urllib.parse.SplitResult,
+) -> Optional[tuple[str, str, int]]:
+    scheme = value.scheme.lower()
+    if scheme not in {"http", "https"} or value.username or value.password:
+        return None
+
+    hostname = value.hostname
+    if not hostname:
+        return None
+    try:
+        hostname = hostname.encode("idna").decode("ascii").lower()
+        port = value.port
+    except (UnicodeError, ValueError):
+        return None
+    if port is None:
+        port = 443 if scheme == "https" else 80
+    return scheme, hostname, port
+
+
 def _resolve_redirect_after_auth(request: Request, redirect: Optional[str]) -> str:
-    """Resolve a safe redirect URL after login."""
-    if not redirect:
+    """Resolve a safe, origin-relative redirect URL after login."""
+    if not isinstance(redirect, str) or not redirect:
         return "/"
 
-    redirect = redirect.strip()
-    if redirect.startswith("/"):
-        return redirect
+    if not _has_unsafe_redirect_text(redirect):
+        try:
+            parsed = urllib.parse.urlsplit(redirect)
+        except ValueError:
+            parsed = None
 
-    parsed = urllib.parse.urlparse(redirect)
-    if not parsed.scheme and not parsed.netloc:
-        return f"/{redirect.lstrip('/')}"
+        if parsed is not None:
+            if not parsed.scheme and not parsed.netloc:
+                local_redirect = (
+                    redirect if redirect.startswith("/") else f"/{redirect}"
+                )
+                if _is_safe_local_redirect(local_redirect):
+                    return local_redirect
+            else:
+                target_origin = _normalized_http_origin(parsed)
+                current_origin = _normalized_http_origin(
+                    urllib.parse.urlsplit(str(request.url))
+                )
+                if target_origin is not None and target_origin == current_origin:
+                    local_redirect = urllib.parse.urlunsplit(
+                        ("", "", parsed.path or "/", parsed.query, parsed.fragment)
+                    )
+                    if _is_safe_local_redirect(local_redirect):
+                        return local_redirect
 
-    current = urllib.parse.urlparse(str(request.url))
-    if parsed.scheme == current.scheme and parsed.netloc == current.netloc:
-        return redirect
-
-    logger.warning("Unsafe redirect ignored: %s", redirect)
+    logger.warning("Unsafe redirect ignored: %r", redirect)
     return "/"
 
 
@@ -1401,7 +1470,9 @@ def register_oauth2_routes(
             # Create session cookie for subsequent requests.
             session_cookie_params = oauth2_handler.create_session_cookie(session)
 
-            redirect_url = state_data.get("redirect_after_auth") or "/"
+            redirect_url = _resolve_redirect_after_auth(
+                request, state_data.get("redirect_after_auth")
+            )
             response = RedirectResponse(url=redirect_url, status_code=302)
             response.set_cookie(**session_cookie_params)
 


### PR DESCRIPTION
## Summary

- validate OAuth redirect targets across encoded, protocol-relative, backslash, control-character, and cross-origin forms
- normalize same-origin absolute URLs to origin-relative paths and revalidate the stored redirect during callback handling
- preserve safe relative redirects and Studio OpenClaw, Hermes, and terminal proxy routes

## Validation

- pre-commit run --all-files
- 252 related tests passed, including auth, sandbox, agent proxy, runtime proxy, and RBAC coverage; 6 subtests passed
- broader suite: 1488 passed and 6 skipped; 4 unrelated tests require optional extensions dependencies not installed in the base environment
- real SSO attack and normal-redirect tests passed on Volcengine and BytePlus deployments
- OpenClaw and Hermes pages and terminals loaded successfully in the Volcengine deployment; both agent entry views loaded in BytePlus
- all temporary Applications, Functions, Tools, Identity callback/origin entries, and smoke sessions were removed after verification