### PR TITLE
fix(studio): preserve Codex app-server error details

### DIFF
--- a/tests/cli/test_codex_app_server.py
+++ b/tests/cli/test_codex_app_server.py
@@ -325,6 +325,38 @@ class _MissingRolloutWebSocket(_FakeWebSocket):
         await super().send(raw)
 
 
+class _DetailedErrorWebSocket(_FakeWebSocket):
+    async def send(self, raw: str) -> None:
+        message = json.loads(raw)
+        if message.get("method") == "rpc/error":
+            self.messages.append(message)
+            await self.queue.put(
+                json.dumps(
+                    {
+                        "id": message["id"],
+                        "error": {
+                            "code": -32001,
+                            "message": "quota exceeded",
+                            "data": {
+                                "reason": "quota_exceeded",
+                                "retryAfter": 30,
+                            },
+                        },
+                    }
+                )
+            )
+            return
+        await super().send(raw)
+
+
+class _SendFailureWebSocket(_FakeWebSocket):
+    async def send(self, raw: str) -> None:
+        message = json.loads(raw)
+        if message.get("method") == "model/list":
+            raise ConnectionError("socket write failed: transport reset")
+        await super().send(raw)
+
+
 @pytest.mark.asyncio
 async def test_permissions_persist_and_apply_to_every_turn() -> None:
     websocket = _FakeWebSocket()
@@ -447,6 +479,42 @@ async def test_clean_socket_close_rejects_pending_requests() -> None:
 
     with pytest.raises(CodexAppServerError, match="连接已断开"):
         await pending
+    await session.close()
+
+
+@pytest.mark.asyncio
+async def test_send_failure_preserves_transport_error_as_cause() -> None:
+    websocket = _SendFailureWebSocket()
+    session = CodexAppServerSession(
+        "https://sandbox.example?Authorization=secret",
+        websocket_factory=lambda _url: _ready(websocket),
+    )
+    await session.connect()
+
+    with pytest.raises(CodexAppServerError, match="发送请求失败") as captured:
+        await session.list_models()
+
+    assert isinstance(captured.value.__cause__, ConnectionError)
+    assert str(captured.value.__cause__) == "socket write failed: transport reset"
+    await session.close()
+
+
+@pytest.mark.asyncio
+async def test_json_rpc_error_preserves_complete_payload() -> None:
+    websocket = _DetailedErrorWebSocket()
+    session = CodexAppServerSession(
+        "https://sandbox.example?Authorization=secret",
+        websocket_factory=lambda _url: _ready(websocket),
+    )
+    await session.connect()
+
+    with pytest.raises(CodexAppServerError) as captured:
+        await session.request("rpc/error")
+
+    detail = str(captured.value)
+    assert '"code":-32001' in detail
+    assert '"message":"quota exceeded"' in detail
+    assert '"data":{"reason":"quota_exceeded","retryAfter":30}' in detail
     await session.close()
 
 

--- a/tests/cli/test_frontend_sandbox.py
+++ b/tests/cli/test_frontend_sandbox.py
@@ -1851,6 +1851,48 @@ def test_sse_error_has_an_explicit_done_frame() -> None:
     assert 'event: done\ndata: {"reason": "failed"}' in response.text
 
 
+def test_sse_error_includes_redacted_exception_chain() -> None:
+    class _CauseFailCodex(_FakeCodex):
+        async def stream_turn(
+            self, prompt: str, skill_ids: tuple[str, ...] = ()
+        ) -> AsyncIterator[CodexAppServerEvent]:
+            del prompt, skill_ids
+            if False:
+                yield CodexAppServerEvent()
+            try:
+                raise ConnectionError(
+                    "socket write failed: Authorization=transport-secret"
+                )
+            except ConnectionError as error:
+                raise CodexAppServerError(
+                    "向 Codex app-server 发送请求失败。"
+                ) from error
+
+    class _CauseFailGateway(_FakeGateway):
+        async def open_codex(self, session: SandboxCloudSession) -> _FakeCodex:
+            del session
+            connection = _CauseFailCodex(self.thread_ids)
+            self.connections.append(connection)
+            return connection
+
+    with TestClient(_app(_CauseFailGateway())) as client:
+        created = client.post("/web/sandbox/sessions", headers={"X-Test-User": "alice"})
+        client.post(
+            f"/web/sandbox/sessions/{created.json()['sessionId']}/connect",
+            headers={"X-Test-User": "alice"},
+        )
+        response = client.post(
+            f"/web/sandbox/sessions/{created.json()['sessionId']}/messages",
+            headers={"X-Test-User": "alice"},
+            json={"message": "hello"},
+        )
+
+    assert "向 Codex app-server 发送请求失败。" in response.text
+    assert "Caused by ConnectionError: socket write failed" in response.text
+    assert "transport-secret" not in response.text
+    assert "Authorization=***" in response.text
+
+
 @pytest.mark.asyncio
 async def test_cancelled_create_is_deleted_after_sdk_call_finishes(
     monkeypatch: pytest.MonkeyPatch,

--- a/veadk/cli/codex_app_server.py
+++ b/veadk/cli/codex_app_server.py
@@ -52,6 +52,13 @@ class CodexAppServerError(RuntimeError):
     """The Sandbox Codex app-server rejected or interrupted an operation."""
 
 
+def _app_server_error_detail(error: object) -> str:
+    """Preserve the complete JSON-RPC error payload for upstream diagnostics."""
+    if isinstance(error, (dict, list)):
+        return json.dumps(error, ensure_ascii=False, separators=(",", ":"))
+    return str(error)
+
+
 @dataclass(frozen=True)
 class CodexPermissionSettings:
     """Permission settings applied to every Codex thread in one cloud Session."""
@@ -524,9 +531,12 @@ class CodexAppServerSession:
             status = str(turn_result.get("status") or "completed")
             if status.lower() in {"failed", "cancelled"}:
                 error = turn_result.get("error")
-                if isinstance(error, dict):
-                    error = error.get("message")
-                raise CodexAppServerError(str(error or f"Codex Turn 状态：{status}。"))
+                detail = (
+                    _app_server_error_detail(error)
+                    if error is not None
+                    else f"Codex Turn 状态：{status}。"
+                )
+                raise CodexAppServerError(detail)
         except asyncio.CancelledError:
             await self.interrupt()
             raise
@@ -954,11 +964,11 @@ class CodexAppServerSession:
         except asyncio.CancelledError:
             raise
         except Exception as error:  # noqa: BLE001 - transport boundary
-            failure = (
-                error
-                if isinstance(error, CodexAppServerError)
-                else CodexAppServerError("Codex app-server 连接异常。")
-            )
+            if isinstance(error, CodexAppServerError):
+                failure = error
+            else:
+                failure = CodexAppServerError("Codex app-server 连接异常。")
+                failure.__cause__ = error
         else:
             if not self._closed:
                 failure = CodexAppServerError("Codex app-server 连接已断开。")
@@ -978,11 +988,7 @@ class CodexAppServerSession:
             return
         error = message.get("error")
         if error is not None:
-            if isinstance(error, dict):
-                detail = str(error.get("message") or "未知错误")
-            else:
-                detail = str(error)
-            future.set_exception(CodexAppServerError(detail))
+            future.set_exception(CodexAppServerError(_app_server_error_detail(error)))
             return
         result = message.get("result")
         if not isinstance(result, dict):

--- a/veadk/cli/frontend_sandbox.py
+++ b/veadk/cli/frontend_sandbox.py
@@ -165,8 +165,26 @@ def _build_studio_user_session_id() -> str:
 
 
 def _safe_error_message(error: object) -> str:
-    """Return a bounded credential-safe diagnostic message."""
-    message = _redact_public_text(str(error).strip(), maximum=1_000)
+    """Return a bounded, credential-safe message including the exception chain."""
+    parts: list[str] = []
+    current = error if isinstance(error, BaseException) else None
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        detail = str(current).strip()
+        if not parts:
+            parts.append(detail or type(current).__name__)
+        else:
+            label = type(current).__name__
+            parts.append(
+                f"Caused by {label}: {detail}" if detail else f"Caused by {label}"
+            )
+        next_error = current.__cause__
+        if next_error is None and not current.__suppress_context__:
+            next_error = current.__context__
+        current = next_error
+    raw_message = "\n".join(parts) if parts else str(error).strip()
+    message = _redact_public_text(raw_message, maximum=20_000)
     return message or type(error).__name__
 
 


### PR DESCRIPTION
## Summary

- preserve complete JSON-RPC error payloads from Codex app-server responses and failed turns
- propagate transport exception chains through the Studio sandbox SSE boundary
- redact credentials across the full browser-visible error chain
- add coverage for send failures, structured RPC errors, and SSE redaction

## Tests

- `uv run pre-commit run --files veadk/cli/codex_app_server.py veadk/cli/frontend_sandbox.py tests/cli/test_codex_app_server.py tests/cli/test_frontend_sandbox.py`
- `uv run pytest tests/cli/test_codex_app_server.py tests/cli/test_frontend_sandbox.py -q` (57 passed)
- `uv run pytest -n 16` (1566 passed, 5 skipped)