### PR TITLE
fix(tracing): reduce LLM tool declaration overhead

### DIFF
--- a/tests/test_llm_attributes_extractors.py
+++ b/tests/test_llm_attributes_extractors.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from google.adk.models.llm_request import LlmRequest
+from google.adk.tools.function_tool import FunctionTool
+
+from veadk.tracing.telemetry.attributes.extractors.llm_attributes_extractors import (
+    llm_gen_ai_request_functions,
+)
+
+
+def test_request_functions_reuses_adk_request_declaration(monkeypatch):
+    def search(query: str) -> str:
+        """Search indexed documents."""
+        return query
+
+    tool = FunctionTool(search)
+    request = LlmRequest()
+    request.append_tools([tool])
+
+    def fail_if_declaration_is_rebuilt():
+        raise AssertionError("request declaration should be reused")
+
+    monkeypatch.setattr(tool, "_get_declaration", fail_if_declaration_is_rebuilt)
+
+    response = llm_gen_ai_request_functions(SimpleNamespace(llm_request=request))
+
+    function = response.content[0]
+    parameters = json.loads(function["gen_ai.request.functions.0.parameters"])
+    assert function["gen_ai.request.functions.0.name"] == "search"
+    assert function["gen_ai.request.functions.0.description"] == (
+        "Search indexed documents."
+    )
+    assert parameters["type"] == "object"
+    assert "query" in parameters["properties"]
+
+
+def test_request_functions_supports_legacy_parameters_schema():
+    parameters = Mock()
+    parameters.model_dump_json.return_value = '{"type":"object"}'
+    declaration = SimpleNamespace(name="search", parameters=parameters)
+    tool = SimpleNamespace(
+        name="search",
+        description="Search documents.",
+        _get_declaration=Mock(side_effect=AssertionError("unexpected rebuild")),
+    )
+    request = SimpleNamespace(
+        config=SimpleNamespace(
+            tools=[SimpleNamespace(function_declarations=[declaration])]
+        ),
+        tools_dict={"search": tool},
+    )
+
+    response = llm_gen_ai_request_functions(SimpleNamespace(llm_request=request))
+
+    assert response.content[0]["gen_ai.request.functions.0.parameters"] == (
+        '{"type":"object"}'
+    )
+    parameters.model_dump_json.assert_called_once_with(exclude_none=True)
+    tool._get_declaration.assert_not_called()
+
+
+def test_request_functions_builds_missing_declaration_once():
+    declaration = SimpleNamespace(
+        name="search",
+        parameters=None,
+        parameters_json_schema={"type": "object"},
+    )
+    get_declaration = Mock(return_value=declaration)
+    tool = SimpleNamespace(
+        name="search",
+        description="Search documents.",
+        _get_declaration=get_declaration,
+    )
+    request = SimpleNamespace(
+        config=SimpleNamespace(tools=[]),
+        tools_dict={"search": tool},
+    )
+
+    response = llm_gen_ai_request_functions(SimpleNamespace(llm_request=request))
+
+    parameters = json.loads(
+        response.content[0]["gen_ai.request.functions.0.parameters"]
+    )
+    assert parameters == {"type": "object"}
+    get_declaration.assert_called_once_with()

--- a/veadk/tracing/telemetry/attributes/extractors/llm_attributes_extractors.py
+++ b/veadk/tracing/telemetry/attributes/extractors/llm_attributes_extractors.py
@@ -774,6 +774,36 @@ def llm_output_value(params: LLMAttributesParams) -> ExtractorResponse:
     )
 
 
+def _request_function_declarations(llm_request) -> dict[str, object]:
+    """Return function declarations already built for the outgoing request."""
+    declarations = {}
+    config = getattr(llm_request, "config", None)
+
+    for tool_group in getattr(config, "tools", None) or []:
+        for declaration in getattr(tool_group, "function_declarations", None) or []:
+            name = getattr(declaration, "name", None)
+            if name:
+                declarations[name] = declaration
+
+    return declarations
+
+
+def _function_parameters_json(declaration) -> str:
+    """Serialize function parameters across supported google-adk versions."""
+    if declaration is None:
+        return "{}"
+
+    parameters = getattr(declaration, "parameters", None)
+    if parameters is not None:
+        model_dump_json = getattr(parameters, "model_dump_json", None)
+        if callable(model_dump_json):
+            return model_dump_json(exclude_none=True)
+        return safe_json_serialize(parameters)
+
+    parameters_json_schema = getattr(declaration, "parameters_json_schema", None)
+    return safe_json_serialize(parameters_json_schema or {})
+
+
 def llm_gen_ai_request_functions(params: LLMAttributesParams) -> ExtractorResponse:
     """Extract available functions/tools from the LLM request.
 
@@ -788,21 +818,19 @@ def llm_gen_ai_request_functions(params: LLMAttributesParams) -> ExtractorRespon
         ExtractorResponse: Response containing list of function metadata
     """
     functions = []
+    declarations = _request_function_declarations(params.llm_request)
 
-    for idx, (tool_name, tool_instance) in enumerate(
-        params.llm_request.tools_dict.items()
-    ):
+    for idx, tool_instance in enumerate(params.llm_request.tools_dict.values()):
+        declaration = declarations.get(tool_instance.name)
+        if declaration is None:
+            declaration = tool_instance._get_declaration()  # type: ignore
+
         functions.append(
             {
                 f"gen_ai.request.functions.{idx}.name": tool_instance.name,
                 f"gen_ai.request.functions.{idx}.description": tool_instance.description,
-                f"gen_ai.request.functions.{idx}.parameters": str(
-                    tool_instance._get_declaration().parameters.model_dump_json(  # type: ignore
-                        exclude_none=True
-                    )
-                    if tool_instance._get_declaration()
-                    and tool_instance._get_declaration().parameters  # type: ignore
-                    else {}
+                f"gen_ai.request.functions.{idx}.parameters": (
+                    _function_parameters_json(declaration)
                 ),
             }
         )


### PR DESCRIPTION
## Summary

- reuse function declarations already built on the outgoing LLM request
- support both legacy parameters and ADK 2.x parameters_json_schema
- rebuild a missing declaration at most once as a compatibility fallback
- add regression coverage for reuse, compatibility, and fallback behavior

## Testing

- pre-commit run --all-files
- pytest tests/test_llm_attributes_extractors.py tests/test_tracing_content.py tests/test_tracing.py -q (32 passed)

## Local end-to-end latency

Deterministic local BaseLlm through the full VeADK Agent, Runner, ADK request construction, telemetry hook, and OpenTelemetry span path; 40 conversation turns with 24 structured tools.

| Content tracing | Before mean | After mean | Reduction |
| --- | ---: | ---: | ---: |
| Disabled | 73.73 ms/turn | 31.47 ms/turn | 57.3% |
| Enabled (default) | 73.98 ms/turn | 33.97 ms/turn | 54.1% |

Function declaration builds dropped from 72 to 24 per turn, removing both redundant tracing-time rebuilds while retaining the one required by ADK request construction.