### PR TITLE
fix(studio): skip IAM fallback during deploy

### DIFF
--- a/tests/cli/test_studio_deploy_target.py
+++ b/tests/cli/test_studio_deploy_target.py
@@ -236,6 +236,7 @@ def test_studio_identity_resources_are_created_in_deployment_region(
         "session_token": "token",
         "region": region,
         "provider": provider,
+        "enable_vefaas_iam_fallback": False,
     }
     assert captured["get_pool"] == {"name": "veadk-studio-my-studio"}
     assert captured["create_pool"] == "veadk-studio-my-studio"
@@ -488,6 +489,9 @@ def test_studio_deploy_auto_identity_is_injected_and_printed(
     assert f"Identity console: {identity_console}" in result.output
     assert "Password sign-in is disabled by default for security." in result.output
     assert "Configure an SSO identity provider before inviting users." in result.output
+    callback_client = captured["callback_client"]
+    assert isinstance(callback_client, dict)
+    assert callback_client["enable_vefaas_iam_fallback"] is False
 
 
 def test_studio_credentials_fall_back_to_volc_default_profile(
@@ -958,6 +962,7 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
         "session_token": "sts-token",
         "region": expected_identity_region,
         "provider": "volcengine",
+        "enable_vefaas_iam_fallback": False,
     }
     assert captured["provider"] == "volcengine"
     assert veadk_environments["CLOUD_PROVIDER"] == "volcengine"
@@ -1222,6 +1227,7 @@ def test_studio_deploy_byteplus_wires_provider_to_cloud_engine_and_package(
     assert isinstance(identity, dict)
     assert identity["provider"] == "byteplus"
     assert identity["region"] == "ap-southeast-1"
+    assert identity["enable_vefaas_iam_fallback"] is False
     assert captured["deploy"]["enable_mcp_session"] is False
     assert "--provider byteplus --auth-mode frontend" in str(captured["run_script"])
     assert str(captured["requirements"]).startswith(
@@ -1831,11 +1837,20 @@ def test_studio_identity_region_searches_deployment_region_first(
 ) -> None:
     checked_regions: list[str] = []
     checked_tokens: list[str] = []
+    checked_vefaas_fallbacks: list[bool] = []
 
     class _FakeIdentityClient:
-        def __init__(self, **kwargs: str) -> None:
-            self.region = kwargs["region"]
-            checked_tokens.append(kwargs["session_token"])
+        def __init__(
+            self,
+            *,
+            region: str,
+            session_token: str,
+            enable_vefaas_iam_fallback: bool,
+            **_: object,
+        ) -> None:
+            self.region = region
+            checked_tokens.append(session_token)
+            checked_vefaas_fallbacks.append(enable_vefaas_iam_fallback)
 
         def user_pool_client_exists(self, **_: str) -> bool:
             checked_regions.append(self.region)
@@ -1858,6 +1873,53 @@ def test_studio_identity_region_searches_deployment_region_first(
     assert resolved == "cn-beijing"
     assert checked_regions == ["cn-shanghai", "cn-beijing"]
     assert checked_tokens == ["sts-token", "sts-token"]
+    assert checked_vefaas_fallbacks == [False, False]
+
+
+def test_identity_client_can_disable_vefaas_iam_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    get_vefaas_credentials = Mock()
+    monkeypatch.setattr(
+        "veadk.integrations.ve_identity.identity_client.get_credential_from_vefaas_iam",
+        get_vefaas_credentials,
+    )
+    identity_client = IdentityClient(
+        access_key="test_access_key",
+        secret_key="test_secret_key",
+        enable_vefaas_iam_fallback=False,
+    )
+    identity_client._api_client.get_user_pool_client = Mock(return_value=object())
+
+    assert identity_client.user_pool_client_exists("pool-id", "client-id")
+    get_vefaas_credentials.assert_not_called()
+
+
+def test_identity_client_keeps_vefaas_iam_fallback_enabled_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    get_vefaas_credentials = Mock(
+        return_value=SimpleNamespace(
+            access_key_id="iam-access-key",
+            secret_access_key="iam-secret-key",
+            session_token="iam-session-token",
+        )
+    )
+    monkeypatch.setattr(
+        "veadk.integrations.ve_identity.identity_client.get_credential_from_vefaas_iam",
+        get_vefaas_credentials,
+    )
+    identity_client = IdentityClient(
+        access_key="test_access_key",
+        secret_key="test_secret_key",
+    )
+    identity_client._api_client.get_user_pool_client = Mock(return_value=object())
+
+    assert identity_client.user_pool_client_exists("pool-id", "client-id")
+    get_vefaas_credentials.assert_called_once_with()
+    assert identity_client._api_client.api_client.configuration.session_token == (
+        "iam-session-token"
+    )
 
 
 def test_identity_client_preserves_external_sts_token() -> None:

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -7942,6 +7942,7 @@ def _resolve_studio_identity_region(
             session_token=session_token,
             region=candidate_region,
             provider=provider,
+            enable_vefaas_iam_fallback=False,
         )
         if identity_client.user_pool_client_exists(
             user_pool_uid=user_pool_id,
@@ -7985,6 +7986,7 @@ def _resolve_or_create_studio_identity_resources(
         session_token=session_token,
         region=region,
         provider=provider,
+        enable_vefaas_iam_fallback=False,
     )
 
     if resolved_pool_id:
@@ -8952,6 +8954,7 @@ def frontend_deploy(
             session_token=session_token,
             region=identity_region,
             provider=provider_id,
+            enable_vefaas_iam_fallback=False,
         )
 
         # 4) Register the SSO callback on the user-pool client HERE, with the

--- a/veadk/integrations/ve_identity/identity_client.py
+++ b/veadk/integrations/ve_identity/identity_client.py
@@ -106,7 +106,9 @@ def refresh_credentials(func):
 
         # Step 3: Try VeFaaS IAM if no credentials or no session_token
         # VeFaaS IAM provides complete credentials (ak, sk, session_token)
-        if not (ak and sk) or (ak and sk and not session_token):
+        if self._enable_vefaas_iam_fallback and (
+            not (ak and sk) or (ak and sk and not session_token)
+        ):
             if credentials := _try_get_vefaas_credentials():
                 ak, sk, session_token = credentials
 
@@ -162,6 +164,7 @@ class IdentityClient:
         session_token: Optional[str] = None,
         region: str = "cn-beijing",
         provider: CloudProvider | None = None,
+        enable_vefaas_iam_fallback: bool = True,
     ):
         """Initialize the identity client.
 
@@ -170,12 +173,15 @@ class IdentityClient:
             secret_key: VolcEngine secret key. Defaults to VOLCENGINE_SECRET_KEY env var.
             session_token: VolcEngine session token. Defaults to VOLCENGINE_SESSION_TOKEN env var.
             region: The VolcEngine region. Defaults to "cn-beijing".
+            enable_vefaas_iam_fallback: Whether API calls may refresh credentials
+                from the VeFaaS IAM file. Defaults to True.
 
         Raises:
             KeyError: If required environment variables are not set.
         """
         self.region = region
         self.provider = provider or cloud_provider_from_env()
+        self._enable_vefaas_iam_fallback = enable_vefaas_iam_fallback
 
         # Store initial credentials for fallback
         if self.provider == "byteplus":


### PR DESCRIPTION
## Summary
- add an opt-out for VeFaaS IAM credential fallback on IdentityClient
- disable the fallback only for Studio deploy identity operations that already receive explicit cloud credentials
- preserve the existing fallback behavior by default for all other services

## Testing
- pre-commit run --files veadk/integrations/ve_identity/identity_client.py veadk/cli/cli_frontend.py tests/cli/test_studio_deploy_target.py
- pytest -q tests/cli/test_studio_deploy_target.py tests/test_ve_identity_auth_config.py tests/test_ve_identity_function_tool.py tests/test_ve_identity_mcp_tool.py tests/test_ve_identity_mcp_toolset.py (89 passed)