### PR TITLE
fix: remove Codex config envs from Code sandbox

### DIFF
--- a/tests/cli/test_frontend_skill_creator.py
+++ b/tests/cli/test_frontend_skill_creator.py
@@ -389,6 +389,8 @@ def test_model_credential_is_bound_directly_to_tool(
     assert envs["MODEL_AGENT_NAME"] == envs["CODEX_MODEL"]
     assert envs["MODEL_AGENT_BASE_URL"] == expected_base_url
     assert envs["AGENTKIT_SANDBOX_MODEL_PROVIDER"] == expected_model_provider
+    assert "CODEX_CONFIG_TOML" not in envs
+    assert "CODEX_MODEL_CATALOG_JSON" not in envs
 
 
 def test_code_env_credential_accepts_a_provider_specific_default_model() -> None:
@@ -485,6 +487,7 @@ def test_candidate_session_never_overrides_tool_model_credential(monkeypatch) ->
     assert {"CODEX_API_KEY", "OPENCODE_API_KEY", "ANTHROPIC_AUTH_TOKEN"}.isdisjoint(
         envs
     )
+    assert {"CODEX_CONFIG_TOML", "CODEX_MODEL_CATALOG_JSON"}.isdisjoint(envs)
 
 
 def test_tool_rejects_untrusted_model_base_url() -> None:

--- a/veadk/cli/frontend_skill_creator.py
+++ b/veadk/cli/frontend_skill_creator.py
@@ -770,7 +770,7 @@ def ensure_skill_creator_model_credential(
         model_base_url=model_base_url,
         model_provider_was_provided=True,
         model_base_url_was_provided=True,
-        include_codex_config=True,
+        include_codex_config=False,
         disable_websearch_apikey=True,
     )
     if not session_envs:
@@ -1118,7 +1118,7 @@ class SkillCreatorService:
             model_base_url=model_base_url,
             model_provider_was_provided=True,
             model_base_url_was_provided=True,
-            include_codex_config=True,
+            include_codex_config=False,
             disable_websearch_apikey=True,
         )
         safe_session_envs = [


### PR DESCRIPTION
## Summary
- stop binding CODEX_CONFIG_TOML and CODEX_MODEL_CATALOG_JSON when updating CodeEnv Tool credentials
- stop injecting those envs when creating CodeEnv candidate sessions
- add regression assertions

## Testing
- uv run pytest tests/cli/test_frontend_skill_creator.py
- uv run pre-commit run --files veadk/cli/frontend_skill_creator.py tests/cli/test_frontend_skill_creator.py