### PR TITLE
fix(studio): handle unmaterialized Codex thread on first read

### DIFF
--- a/tests/cli/test_codex_app_server.py
+++ b/tests/cli/test_codex_app_server.py
@@ -397,6 +397,55 @@ class _DetailedErrorWebSocket(_FakeWebSocket):
         await super().send(raw)
 
 
+class _NotMaterializedThreadWebSocket(_FakeWebSocket):
+    """Simulates a freshly-started thread that has no turns yet."""
+
+    async def send(self, raw: str) -> None:
+        message = json.loads(raw)
+        params = message.get("params") or {}
+        if (
+            message.get("method") == "thread/read"
+            and params.get("includeTurns") is True
+        ):
+            self.messages.append(message)
+            thread_id = params.get("threadId", "unknown")
+            await self.queue.put(
+                json.dumps(
+                    {
+                        "id": message["id"],
+                        "error": {
+                            "code": -32600,
+                            "message": (
+                                f"thread {thread_id} is not materialized yet; "
+                                "includeTurns is unavailable before first user message"
+                            ),
+                        },
+                    }
+                )
+            )
+            return
+        if message.get("method") == "thread/read":
+            # Metadata-only read (no includeTurns) returns thread without turns.
+            self.messages.append(message)
+            await self.queue.put(
+                json.dumps(
+                    {
+                        "id": message["id"],
+                        "result": {
+                            "thread": {
+                                "id": message["params"]["threadId"],
+                                "cwd": "/workspace",
+                            },
+                            "cwd": "/workspace",
+                            "model": "gpt-test",
+                        },
+                    }
+                )
+            )
+            return
+        await super().send(raw)
+
+
 class _SendFailureWebSocket(_FakeWebSocket):
     async def send(self, raw: str) -> None:
         message = json.loads(raw)
@@ -757,6 +806,44 @@ async def test_json_rpc_error_preserves_complete_payload() -> None:
     assert '"code":-32001' in detail
     assert '"message":"quota exceeded"' in detail
     assert '"data":{"reason":"quota_exceeded","retryAfter":30}' in detail
+    await session.close()
+
+
+@pytest.mark.asyncio
+async def test_read_thread_falls_back_when_thread_not_materialized() -> None:
+    """A fresh thread with no user message should not cause a 500 error.
+
+    The Codex app-server rejects includeTurns with -32600 before the first
+    user message. read_thread should retry without includeTurns and return
+    an empty conversation snapshot.
+    """
+    websocket = _NotMaterializedThreadWebSocket()
+    session = CodexAppServerSession(
+        "https://sandbox.example?Authorization=secret",
+        websocket_factory=lambda _url: _ready(websocket),
+    )
+    await session.connect()
+
+    snapshot = await session.read_thread("thread-fresh")
+
+    assert snapshot.thread.id == "thread-fresh"
+    assert snapshot.messages == ()
+    assert snapshot.workspace_locked is False
+    assert snapshot.cwd == "/workspace"
+    assert snapshot.model == "gpt-test"
+
+    # Verify the first request used includeTurns and the fallback did not.
+    read_requests = [
+        message
+        for message in websocket.messages
+        if message.get("method") == "thread/read"
+    ]
+    assert len(read_requests) == 2
+    assert read_requests[0]["params"] == {
+        "threadId": "thread-fresh",
+        "includeTurns": True,
+    }
+    assert read_requests[1]["params"] == {"threadId": "thread-fresh"}
     await session.close()
 
 

--- a/veadk/cli/codex_app_server.py
+++ b/veadk/cli/codex_app_server.py
@@ -81,6 +81,26 @@ def _app_server_error_detail(error: object) -> str:
     return str(error)
 
 
+def _is_thread_not_materialized_error(error: CodexAppServerError) -> bool:
+    """Return True when the app-server reports a thread has no turns yet.
+
+    A freshly-started thread returns JSON-RPC -32600 with the message
+    "thread ... is not materialized yet; includeTurns is unavailable before
+    first user message".
+    """
+    message = str(error)
+    try:
+        payload = json.loads(message)
+    except (json.JSONDecodeError, TypeError):
+        return "not materialized yet" in message
+    if isinstance(payload, dict):
+        if payload.get("code") == -32600 and "not materialized yet" in str(
+            payload.get("message", "")
+        ):
+            return True
+    return "not materialized yet" in message
+
+
 @dataclass(frozen=True)
 class CodexPermissionSettings:
     """Permission settings applied to every Codex thread in one cloud Session."""
@@ -966,10 +986,22 @@ class CodexAppServerSession:
     async def read_thread(self, thread_id: str) -> CodexThreadSnapshot:
         """Read one thread's complete stored history without activating it."""
         thread_id = _required_identifier(thread_id, "Thread ID")
-        result = await self.request(
-            "thread/read",
-            {"threadId": thread_id, "includeTurns": True},
-        )
+        try:
+            result = await self.request(
+                "thread/read",
+                {"threadId": thread_id, "includeTurns": True},
+            )
+        except CodexAppServerError as error:
+            # A freshly-started thread has no user message yet, so the Codex
+            # app-server rejects includeTurns with -32600 ("not materialized
+            # yet"). Fall back to a metadata-only read and return an empty
+            # conversation instead of surfacing a 500 to the browser.
+            if not _is_thread_not_materialized_error(error):
+                raise
+            result = await self.request(
+                "thread/read",
+                {"threadId": thread_id},
+            )
         snapshot = self._thread_snapshot("thread/read", result)
         imported = self._imported_history_by_thread.get(thread_id)
         if imported is None:


### PR DESCRIPTION
## Problem

Creating a new sandbox agent and using it for the first time fails with HTTP 500:

```
thread <id> is not materialized yet; includeTurns is unavailable before first user message
```

This was introduced in two steps:

1. **#862** added `read_thread()` which unconditionally sends `includeTurns: true` to the Codex app-server.
2. **#905** added frontend paths that call `readThread` immediately after `connectSession()` and during busy-state polling — hitting a fresh thread before its first user turn has been materialized.

## Fix

In `CodexAppServerSession.read_thread()`, catch the specific JSON-RPC `-32600` "not materialized yet" error and retry `thread/read` without `includeTurns`. The thread metadata is returned with an empty message list instead of propagating the error as HTTP 500.

This covers all callers: the initial `loadSandboxThreadHistory`, the `syncBackgroundTurn` polling loop, and `resume_thread` (which calls `read_thread` internally).

## Testing

- Added `test_read_thread_falls_back_when_thread_not_materialized` covering the fallback path.
- All 22 `test_codex_app_server` tests pass.
- All 5 `test_frontend_sandbox` thread tests pass.
- `pre-commit` (ruff check/format, secret detection) passes.