### PR TITLE
fix(studio): preserve DeepSeek Harness API semantics

### DIFF
--- a/tests/cli/test_frontend_agent_proxy.py
+++ b/tests/cli/test_frontend_agent_proxy.py
@@ -65,16 +65,17 @@ def test_hermes_surface_rewrite_removes_private_gateway_query() -> None:
     assert "hermes-secret" not in rewritten
 
 
-def test_deepseek_harness_rewrite_routes_root_assets_and_api_through_surface() -> None:
+def test_deepseek_harness_rewrite_routes_root_assets_through_surface() -> None:
     prefix = "/web/deepseek-harness/sessions/session-1/surface/token-1"
     body = (
-        b'<script src="/deepseek-harness-auth-query.js?Authorization=secret">'
+        b'<html><head><script src="/deepseek-harness-auth-query.js?Authorization=secret">'
         b"</script>"
         b'<script>const slash = "/"; const api = "/api/status";'
         b'const ws = new WebSocket("/api/events");'
         b'window.__DSH_BASE_PATH__ = "/deepseek-harness";</script>'
         b'<script src="/assets/app.js"></script>'
         b'<link href="/plugins/plugin-a/index.css" rel="stylesheet">'
+        b"</head></html>"
     )
 
     rewritten = _rewrite_body(
@@ -86,13 +87,33 @@ def test_deepseek_harness_rewrite_routes_root_assets_and_api_through_surface() -
 
     assert 'const slash = "/"' in rewritten
     assert f'src="{prefix}/deepseek-harness-auth-query.js"' in rewritten
-    assert f'const api = "{prefix}/api/status"' in rewritten
-    assert f'new WebSocket("{prefix}/api/events")' in rewritten
+    assert 'const api = "/api/status"' in rewritten
+    assert 'new WebSocket("/api/events")' in rewritten
     assert f'window.__DSH_BASE_PATH__ = "{prefix}/deepseek-harness"' in rewritten
     assert f'src="{prefix}/assets/app.js"' in rewritten
     assert f'href="{prefix}/plugins/plugin-a/index.css"' in rewritten
+    assert f'const surfacePrefix = "{prefix}"' in rewritten
+    assert "url.pathname = surfacePrefix + url.pathname" in rewritten
     assert "Authorization" not in rewritten
     assert "secret" not in rewritten
+
+
+def test_deepseek_harness_rewrite_preserves_api_transport_semantics() -> None:
+    prefix = "/web/deepseek-harness/sessions/session-1/surface/token-1"
+    body = (
+        b'const API_PATH = "/api";'
+        b'connection.rpc.call("/api", endpoint, { args });'
+        b"const response = await this.postJson(`/api/${method}`, message);"
+    )
+
+    rewritten = _rewrite_body(
+        body,
+        "text/javascript; charset=utf-8",
+        prefix,
+        "deepseek-harness",
+    ).decode()
+
+    assert rewritten == body.decode()
 
 
 def test_agent_surface_proxy_keeps_endpoint_auth_server_side(
@@ -212,10 +233,7 @@ def test_deepseek_harness_proxy_keeps_endpoint_auth_server_side(
         "?faasInstanceName=instance-1&Authorization=server-secret"
     )
     assert requested_urls == [expected_url]
-    expected_fetch = (
-        'fetch("/web/deepseek-harness/sessions/session-1/surface/token-1/api/status")'
-    )
-    assert expected_fetch in response.text
+    assert 'fetch("/api/status")' in response.text
     assert "server-secret" not in response.text
 
 

--- a/veadk/cli/frontend_agent_proxy.py
+++ b/veadk/cli/frontend_agent_proxy.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import html
+import json
 import re
 from collections.abc import Callable
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
@@ -45,12 +46,11 @@ _OPENCLAW_RESET_TAG = (
     b"if(key.startsWith('openclaw.control.settings.v1'))localStorage.removeItem(key)"
     b"}}catch{}</script>"
 )
-_DEEPSEEK_HARNESS_PATHS = (
+_DEEPSEEK_HARNESS_STATIC_PATHS = (
     "/deepseek-harness-auth-query.js",
     "/deepseek-harness",
     "/plugins",
     "/assets",
-    "/api",
 )
 _BLOCKED_RESPONSE_HEADERS = {
     "connection",
@@ -94,7 +94,7 @@ def _rewrite_body(
     if kind in {"hermes", "deepseek-harness"}:
         body = _strip_hermes_gateway_query(body)
     if kind == "deepseek-harness":
-        return _rewrite_deepseek_harness_body(body, prefix)
+        return _rewrite_deepseek_harness_body(body, content_type, prefix)
     source = f"/{kind}".encode()
     replacement = f"{prefix}/{kind}".encode()
     for quote in (b'"', b"'", b"`"):
@@ -114,10 +114,61 @@ def _rewrite_root_path(body: bytes, source_path: str, replacement_path: str) -> 
     return body
 
 
-def _rewrite_deepseek_harness_body(body: bytes, prefix: str) -> bytes:
-    """Route DSH root assets and APIs through the opaque Studio surface proxy."""
-    for path in _DEEPSEEK_HARNESS_PATHS:
+def _javascript_string(value: str) -> bytes:
+    """Return an HTML-safe JavaScript string literal."""
+    literal = json.dumps(value, ensure_ascii=True)
+    return (
+        literal.replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .encode()
+    )
+
+
+def _deepseek_harness_surface_bootstrap(prefix: str) -> bytes:
+    """Build the browser shim that rebases DSH API traffic at request time."""
+    return b"".join(
+        (
+            b"<script>(()=>{",
+            b"const surfacePrefix = ",
+            _javascript_string(prefix),
+            b";const pageUrl=new URL(window.location.href);",
+            b"const sameEndpoint=url=>url.hostname===pageUrl.hostname&&",
+            b"url.port===pageUrl.port&&(url.protocol===pageUrl.protocol||",
+            b"pageUrl.protocol==='https:'&&url.protocol==='wss:'||",
+            b"pageUrl.protocol==='http:'&&url.protocol==='ws:');",
+            b"const rebase=input=>{try{",
+            b"const source=input instanceof Request?input.url:input;",
+            b"const url=new URL(source,window.location.href);",
+            b"if(sameEndpoint(url)&&(url.pathname==='/api'||",
+            b"url.pathname.startsWith('/api/')||url.pathname.startsWith('/api.')))",
+            b"{url.pathname = surfacePrefix + url.pathname;}",
+            b"if(input instanceof Request)return new Request(url.toString(),input);",
+            b"return url;}catch{return input;}};",
+            b"const originalFetch=window.fetch.bind(window);",
+            b"window.fetch=(input,init)=>originalFetch(rebase(input),init);",
+            b"const OriginalWebSocket=window.WebSocket;",
+            b"window.WebSocket=function(url,protocols){const next=rebase(url);",
+            b"return protocols===undefined?new OriginalWebSocket(next):",
+            b"new OriginalWebSocket(next,protocols);};",
+            b"Object.setPrototypeOf(window.WebSocket,OriginalWebSocket);",
+            b"window.WebSocket.prototype=OriginalWebSocket.prototype;",
+            b"})();</script>",
+        )
+    )
+
+
+def _rewrite_deepseek_harness_body(
+    body: bytes,
+    content_type: str,
+    prefix: str,
+) -> bytes:
+    """Route DSH root assets and runtime API traffic through its Studio surface."""
+    for path in _DEEPSEEK_HARNESS_STATIC_PATHS:
         body = _rewrite_root_path(body, path, f"{prefix}{path}")
+    if "text/html" in content_type:
+        bootstrap = _deepseek_harness_surface_bootstrap(prefix)
+        body = body.replace(b"<head>", b"<head>" + bootstrap, 1)
     return body
 
 


### PR DESCRIPTION
## Summary

- preserve DeepSeek Harness `/api` RPC targets in JavaScript bundles
- inject an HTML bootstrap that rebases runtime `fetch` and `WebSocket` API traffic through the opaque Studio surface path
- keep DeepSeek Harness endpoint authentication server-side and continue rewriting root static asset paths

## Problem

Studio previously rewrote every quoted `/api` occurrence in DeepSeek Harness responses. That changed the logical RPC target used by `pluginInventory/list`, causing `invalid RPC target`. Model-provider requests could also fall through to the Studio SPA and return HTML, which surfaced as `Unexpected token '<'` when parsed as JSON.

## Verification

- `pre-commit run --all-files`
- `pytest -q tests/cli/test_frontend_agent_proxy.py tests/cli/test_frontend_sandbox.py tests/cli/test_frontend_sandbox_options.py` (84 passed)
- exercised the proxy against DeepSeek Harness `0.1.0-rc.6`; `llm.providers` and `pluginInventory/list` returned HTTP 200 JSON
