### PR TITLE
fix(studio): ignore macOS metadata in skill archives

### DIFF
--- a/frontend/server/skills/archive.py
+++ b/frontend/server/skills/archive.py
@@ -80,6 +80,8 @@ def validate_skill_archive(content: bytes) -> SkillArchive:
             if not infos:
                 raise SkillArchiveError("SKILL_ARCHIVE_EMPTY", "Skill ZIP 不能为空。")
             files: dict[str, zipfile.ZipInfo] = {}
+            seen: set[str] = set()
+            file_count = 0
             total = 0
             for info in infos:
                 raw = info.filename
@@ -97,11 +99,12 @@ def validate_skill_archive(content: bytes) -> SkillArchive:
                         f"Skill ZIP 包含不安全路径：{raw}",
                     )
                 folded = normalized.casefold()
-                if folded in {item.casefold() for item in files}:
+                if folded in seen:
                     raise SkillArchiveError(
                         "SKILL_ARCHIVE_DUPLICATE_PATH",
                         f"Skill ZIP 包含重复路径：{raw}",
                     )
+                seen.add(folded)
                 mode = info.external_attr >> 16
                 file_type = stat.S_IFMT(mode)
                 if file_type == stat.S_IFLNK:
@@ -116,9 +119,9 @@ def validate_skill_archive(content: bytes) -> SkillArchive:
                     )
                 if info.is_dir():
                     continue
-                files[normalized] = info
+                file_count += 1
                 total += info.file_size
-                if len(files) > MAX_FILES:
+                if file_count > MAX_FILES:
                     raise SkillArchiveError(
                         "SKILL_ARCHIVE_FILE_COUNT",
                         "Skill 文件数不能超过 100 个。",
@@ -136,6 +139,9 @@ def validate_skill_archive(content: bytes) -> SkillArchive:
                         f"文件压缩率异常：{raw}",
                         status_code=413,
                     )
+                if path.parts[0] == "__MACOSX":
+                    continue
+                files[normalized] = info
             if not files:
                 raise SkillArchiveError("SKILL_ARCHIVE_EMPTY", "Skill ZIP 不能为空。")
             wrapper = ""

--- a/frontend/server/skills/devenv.py
+++ b/frontend/server/skills/devenv.py
@@ -552,6 +552,7 @@ def validate_skill_archive(content: bytes) -> SkillArchive:
             file_paths: list[PurePosixPath] = []
             files: list[dict[str, object]] = []
             total = 0
+            file_count = 0
             archive_files: dict[str, zipfile.ZipInfo] = {}
             for info in infos:
                 raw_name = info.filename
@@ -585,9 +586,13 @@ def validate_skill_archive(content: bytes) -> SkillArchive:
                     )
                 if info.is_dir():
                     continue
-                file_paths.append(path)
-                archive_files[normalized] = info
+                file_count += 1
                 total += info.file_size
+                if file_count > _MAX_FILES:
+                    raise SkillWorkbenchError(
+                        "SKILL_ARCHIVE_FILE_COUNT",
+                        "Skill 文件数必须在 1 到 100 之间",
+                    )
                 if total > _MAX_EXPANDED_BYTES:
                     raise SkillWorkbenchError(
                         "SKILL_ARCHIVE_EXPANDED_TOO_LARGE",
@@ -600,9 +605,13 @@ def validate_skill_archive(content: bytes) -> SkillArchive:
                         "Skill ZIP 压缩率异常",
                         status_code=413,
                     )
-            if not file_paths or len(file_paths) > _MAX_FILES:
+                if path.parts[0] == "__MACOSX":
+                    continue
+                file_paths.append(path)
+                archive_files[normalized] = info
+            if not file_paths:
                 raise SkillWorkbenchError(
-                    "SKILL_ARCHIVE_FILE_COUNT", "Skill 文件数必须在 1 到 100 之间"
+                    "SKILL_ARCHIVE_EMPTY", "Skill ZIP 不能为空", status_code=422
                 )
 
             wrapper = ""

--- a/tests/frontend/test_skills_server.py
+++ b/tests/frontend/test_skills_server.py
@@ -17,11 +17,10 @@ from __future__ import annotations
 import base64
 import io
 import json
-import sys
 import stat
+import sys
 import zipfile
-from types import ModuleType
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -30,6 +29,9 @@ from frontend.server.skills.devenv import (
     CreateSkillTaskBody,
     SkillWorkbenchError,
     SkillWorkbenchService,
+)
+from frontend.server.skills.devenv import (
+    validate_skill_archive as validate_workbench_skill_archive,
 )
 from frontend.server.skills.models import (
     CreateSkillSpaceBody,
@@ -80,6 +82,66 @@ def test_skill_archive_accepts_root_or_one_wrapper(files: dict[str, bytes]) -> N
     assert result.name == "example-skill"
     assert result.description == "A focused test Skill"
     assert result.files[0]["path"] == "SKILL.md"
+
+
+@pytest.mark.parametrize(
+    "validator", [validate_skill_archive, validate_workbench_skill_archive]
+)
+def test_skill_archive_ignores_top_level_macos_metadata(validator) -> None:
+    result = validator(
+        archive(
+            {
+                "example-skill/SKILL.md": SKILL_MD.encode(),
+                "__MACOSX/._example-skill": b"\x00\x05AppleDouble",
+                "__MACOSX/example-skill/._SKILL.md": b"\x00\x05AppleDouble",
+            }
+        )
+    )
+
+    assert result.name == "example-skill"
+    assert result.files == [{"path": "SKILL.md", "size": len(SKILL_MD.encode())}]
+
+
+@pytest.mark.parametrize(
+    "validator", [validate_skill_archive, validate_workbench_skill_archive]
+)
+def test_skill_archive_rejects_macos_metadata_only(validator) -> None:
+    with pytest.raises((SkillArchiveError, SkillWorkbenchError)) as raised:
+        validator(archive({"__MACOSX/._example-skill": b"\x00\x05AppleDouble"}))
+
+    assert raised.value.code == "SKILL_ARCHIVE_EMPTY"
+
+
+@pytest.mark.parametrize(
+    "validator", [validate_skill_archive, validate_workbench_skill_archive]
+)
+def test_skill_archive_still_rejects_an_unrelated_second_root(validator) -> None:
+    with pytest.raises((SkillArchiveError, SkillWorkbenchError)) as raised:
+        validator(
+            archive(
+                {
+                    "example-skill/SKILL.md": SKILL_MD.encode(),
+                    "other/notes.txt": b"not metadata",
+                }
+            )
+        )
+
+    assert raised.value.code == "SKILL_MD_NOT_AT_ROOT"
+
+
+@pytest.mark.parametrize(
+    "validator", [validate_skill_archive, validate_workbench_skill_archive]
+)
+def test_ignored_macos_metadata_still_gets_security_validation(validator) -> None:
+    content = archive(
+        {"example-skill/SKILL.md": SKILL_MD.encode()},
+        symlink="__MACOSX/unsafe-link",
+    )
+
+    with pytest.raises((SkillArchiveError, SkillWorkbenchError)) as raised:
+        validator(content)
+
+    assert raised.value.code == "SKILL_ARCHIVE_SYMLINK"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- ignore top-level `__MACOSX/` entries when determining Skill archive structure
- retain path, file type, file count, expanded size, and compression safety checks for ignored entries
- keep upload and Skill workbench validation behavior aligned
- add regression coverage for macOS metadata, metadata-only archives, unrelated roots, and unsafe symlinks

## Validation

- `uv run pytest tests/frontend/test_skills_server.py -q` (31 passed)
- `npm test` (698 passed)
- `npm run build`
- `uv run pre-commit run --files frontend/server/skills/archive.py frontend/server/skills/devenv.py tests/frontend/test_skills_server.py`
- verified `jvm-finding-explainer.zip` against both Studio validators