### PR TITLE
fix(studio): clear agent detail navigation state

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1994,6 +1994,12 @@ export default function App() {
   const [focusedWorkspaceAgentId, setFocusedWorkspaceAgentId] = useState("");
   const [agentDetailTarget, setAgentDetailTarget] =
     useState<MyAgentCardData | null>(null);
+  const exitAgentDetailContext = useCallback(() => {
+    popStudioPage("agent-detail");
+    setAgentDetailTarget(null);
+    setMyAgents(false);
+    setManageAgents(false);
+  }, [popStudioPage]);
   // Shown when the user clicks the breadcrumb root to leave a create mode;
   // warns that the in-progress draft will be discarded.
   const [confirmLeave, setConfirmLeave] = useState(false);
@@ -2269,8 +2275,7 @@ export default function App() {
         setAddAgent(false);
         setAddMenu(false);
         setSearchView(false);
-        setManageAgents(false);
-        setAgentDetailTarget(null);
+        exitAgentDetailContext();
         setFocusedDeploymentTaskId("");
         setFocusedWorkspaceAgentId("");
         setMyAgents(true);
@@ -2291,7 +2296,7 @@ export default function App() {
       const suffix = failures.length > 3 ? `；另有 ${failures.length - 3} 个失败` : "";
       throw new Error(`${failures.length} 个 Agent 删除失败：${shown}${suffix}`);
     }
-  }, [agentDetailTarget, appName, commitWorkspaceDrafts, connections, userId]);
+  }, [agentDetailTarget, appName, commitWorkspaceDrafts, connections, exitAgentDetailContext, userId]);
 
   const refreshAgentLibrary = useCallback(async () => {
     setAgentLibraryLoading(true);
@@ -2355,14 +2360,13 @@ export default function App() {
   const openDeploymentDetail = useCallback((task: DeploymentTaskUpdate) => {
     setCreateView(null);
     setAddMenu(false);
-    setMyAgents(false);
-    setAgentDetailTarget(null);
+    exitAgentDetailContext();
     setManageAgents(true);
     setFocusedWorkspaceAgentId("");
     setFocusedWorkspaceAgentSection("basic");
     setFocusedDeploymentTaskId(task.id);
     setError("");
-  }, []);
+  }, [exitAgentDetailContext]);
 
   const startDeployment = useCallback((task: DeploymentTaskUpdate) => {
     flushPendingWorkspaceDraft();
@@ -4573,7 +4577,7 @@ export default function App() {
     setAddAgent(false);
     setAddMenu(false);
     setSkillCenter(false);
-    setManageAgents(false);
+    exitAgentDetailContext();
     setFeedbackCaseReturnAgentId(appName);
     setFeedbackCaseReturnKind(item.kind);
     setFeedbackTargetEventId(item.messageId);
@@ -5499,11 +5503,9 @@ export default function App() {
     setNewChatCapabilities(capabilities);
     setAgentInfoRefreshKey((key) => key + 1);
     setAppName(id);
-    setAgentDetailTarget(null);
+    exitAgentDetailContext();
     setFocusedDeploymentTaskId("");
     setFocusedWorkspaceAgentId("");
-    setMyAgents(false);
-    setManageAgents(false);
     setCreateView(null);
     setSkillCenter(false);
     setAddAgent(false);
@@ -5593,9 +5595,7 @@ export default function App() {
   };
 
   const closeAgentDetailPage = () => {
-    popStudioPage("agent-detail");
-    setManageAgents(false);
-    setAgentDetailTarget(null);
+    exitAgentDetailContext();
     setFocusedDeploymentTaskId("");
     setFocusedWorkspaceAgentId("");
     setMyAgents(true);
@@ -6355,7 +6355,7 @@ export default function App() {
                     setError("当前账号没有添加 Agent 的权限。");
                     return;
                   }
-                  setManageAgents(false);
+                  exitAgentDetailContext();
                   setAddMenu(true);
                   setCreateView(null);
                   setImportedDraft(null);
@@ -6441,7 +6441,7 @@ export default function App() {
                     hydratedDraft,
                     arkModelIds,
                   );
-                  setManageAgents(false);
+                  exitAgentDetailContext();
                   setImportedDraft(classifiedDraft);
                   setCustomCreateMode("custom");
                   const nextDraftId = `runtime-${capability.runtime.runtimeId}`;
@@ -6463,7 +6463,7 @@ export default function App() {
                   setError("");
                 }}
                 onEditDraft={(item) => {
-                  setManageAgents(false);
+                  exitAgentDetailContext();
                   setImportedDraft(item.draft);
                   setCustomCreateMode("custom");
                   setEditingDraftId(item.id);

--- a/frontend/tests/agentWorkspace.test.mjs
+++ b/frontend/tests/agentWorkspace.test.mjs
@@ -586,6 +586,33 @@ test("runtime updates use the Agent selected in management instead of the active
   assert.doesNotMatch(handler, /draftEnvValues|selectedAgentUpdateDraft\?\.draft/);
   assert.match(handler, /hydrateRuntimeModelSelection\(/);
   assert.match(handler, /network:\s*capability\.runtime\.network/);
+  assert.match(
+    handler,
+    /exitAgentDetailContext\(\)[\s\S]*?setCreateView\("custom"\)/,
+  );
+});
+
+test("agent detail actions clear the detail stack before opening another view", () => {
+  assert.match(
+    appSource,
+    /const exitAgentDetailContext = useCallback\(\(\) => \{[\s\S]*?popStudioPage\("agent-detail"\)[\s\S]*?setAgentDetailTarget\(null\)[\s\S]*?setMyAgents\(false\)[\s\S]*?setManageAgents\(false\)/,
+  );
+  assert.match(
+    appSource,
+    /const refreshCurrentAgentAndStartNewChat[\s\S]*?exitAgentDetailContext\(\)[\s\S]*?startNewChat\(\)/,
+  );
+  assert.match(
+    appSource,
+    /async function openFeedbackCaseInStudio[\s\S]*?exitAgentDetailContext\(\)[\s\S]*?await pickSession/,
+  );
+  assert.match(
+    appSource,
+    /onCreateAgent=\{\(\) => \{[\s\S]*?exitAgentDetailContext\(\)[\s\S]*?setAddMenu\(true\)/,
+  );
+  assert.match(
+    appSource,
+    /onEditDraft=\{\(item\) => \{[\s\S]*?exitAgentDetailContext\(\)[\s\S]*?setCreateView\("custom"\)/,
+  );
 });
 
 test("runtime update capability checks ignore aborted and stale selections", () => {
@@ -633,7 +660,7 @@ test("workspace keeps agent deletion in selection mode and the floating detail a
   );
   assert.match(
     appSource,
-    /deletedRuntimeIds\.has\(agentDetailTarget\.runtime\.runtimeId\)[\s\S]*?setManageAgents\(false\)[\s\S]*?setAgentDetailTarget\(null\)[\s\S]*?setMyAgents\(true\)/,
+    /deletedRuntimeIds\.has\(agentDetailTarget\.runtime\.runtimeId\)[\s\S]*?exitAgentDetailContext\(\)[\s\S]*?setMyAgents\(true\)/,
   );
   assert.match(appSource, /onDeleteAgents=\{deleteWorkspaceAgents\}/);
   assert.match(appSource, /const deleteWorkspaceDrafts = useCallback/);


### PR DESCRIPTION
## Summary

- clear the agent detail page stack and competing list/workspace state before opening update, create, chat, feedback, or deployment views
- centralize detail-context cleanup while preserving explicit returns to the agent list
- add regression coverage for detail-to-action navigation transitions

## Testing

- `pre-commit run --files frontend/src/App.tsx frontend/tests/agentWorkspace.test.mjs`
- `npm test` (704 tests passed)
- `npm run build -- --outDir <temporary-directory>`
- manually verified `fyztest1` details → update opens the update editor
- manually verified Skill and Knowledge detail/edit navigation