### PR TITLE
fix: deduplicate Ark inputs and streaming telemetry

### DIFF
--- a/tests/models/test_ark_llm_input_conversion.py
+++ b/tests/models/test_ark_llm_input_conversion.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.genai import types
+
+from veadk.models.ark_llm import _content_to_input_item
+
+
+def test_model_thought_and_final_text_are_aggregated_once():
+    content = types.Content(
+        role="model",
+        parts=[
+            types.Part(text="thinking", thought=True),
+            types.Part(text="final answer"),
+        ],
+    )
+
+    assert _content_to_input_item(content) == [
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {"type": "input_text", "text": "thinking"},
+                {"type": "input_text", "text": "final answer"},
+            ],
+        }
+    ]
+
+
+def test_model_function_call_precedes_single_aggregated_text_message():
+    content = types.Content(
+        role="model",
+        parts=[
+            types.Part(text="first"),
+            types.Part(
+                function_call=types.FunctionCall(
+                    id="call-1",
+                    name="lookup",
+                    args={"query": "veadk"},
+                )
+            ),
+            types.Part(text="second"),
+        ],
+    )
+
+    assert _content_to_input_item(content) == [
+        {
+            "arguments": '{"query": "veadk"}',
+            "call_id": "call-1",
+            "name": "lookup",
+            "type": "function_call",
+        },
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {"type": "input_text", "text": "first"},
+                {"type": "input_text", "text": "second"},
+            ],
+        },
+    ]
+
+
+def test_model_file_data_is_preserved_in_single_message():
+    content = types.Content(
+        role="model",
+        parts=[
+            types.Part(
+                file_data=types.FileData(
+                    file_uri="file_id://file-1",
+                    mime_type="application/pdf",
+                )
+            )
+        ],
+    )
+
+    assert _content_to_input_item(content) == [
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "input_file",
+                    "file_id": "file-1",
+                }
+            ],
+        }
+    ]
+
+
+def test_model_inline_data_is_preserved_in_single_message():
+    content = types.Content(
+        role="model",
+        parts=[
+            types.Part(
+                inline_data=types.Blob(
+                    data=b"image-bytes",
+                    mime_type="image/png",
+                )
+            )
+        ],
+    )
+
+    assert _content_to_input_item(content) == [
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "input_image",
+                    "image_url": "data:image/png;base64,aW1hZ2UtYnl0ZXM=",
+                    "detail": "auto",
+                }
+            ],
+        }
+    ]

--- a/tests/test_llm_attributes_extractors.py
+++ b/tests/test_llm_attributes_extractors.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock, call
 
 from google.adk.models.llm_request import LlmRequest
 from google.adk.tools.function_tool import FunctionTool
+from opentelemetry.sdk.trace import TracerProvider
 
 from veadk.tracing.telemetry.attributes.extractors.llm_attributes_extractors import (
     llm_gen_ai_request_functions,
@@ -128,8 +129,113 @@ def test_falsy_attribute_values_are_written_to_span():
 
 def test_none_values_in_attribute_mappings_are_not_written_to_span():
     span = Mock()
-    response = ExtractorResponse(content=[{"present": 0, "missing": None}])
+    response = ExtractorResponse(
+        content=[
+            {
+                "zero": 0,
+                "false": False,
+                "empty": "",
+                "text": "present",
+                "missing": None,
+            }
+        ]
+    )
 
     ExtractorResponse.update_span(span, "unused", response)
 
-    span.set_attribute.assert_called_once_with("present", 0)
+    assert span.set_attribute.call_args_list == [
+        call("zero", 0),
+        call("false", False),
+        call("empty", ""),
+        call("text", "present"),
+    ]
+
+
+def test_none_values_in_event_mapping_are_not_written_to_span():
+    span = Mock()
+    response = ExtractorResponse(
+        type="event",
+        content={
+            "zero": 0,
+            "false": False,
+            "empty": "",
+            "text": "present",
+            "missing": None,
+        },
+    )
+
+    ExtractorResponse.update_span(span, "event.name", response)
+
+    span.add_event.assert_called_once_with(
+        "event.name",
+        {"zero": 0, "false": False, "empty": "", "text": "present"},
+    )
+
+
+def test_none_values_in_event_mapping_list_are_not_written_to_span():
+    span = Mock()
+    response = ExtractorResponse(
+        type="event",
+        content=[
+            {"zero": 0, "missing": None},
+            {"false": False, "empty": "", "text": "present"},
+        ],
+    )
+
+    ExtractorResponse.update_span(span, "event.name", response)
+
+    assert span.add_event.call_args_list == [
+        call("event.name", {"zero": 0}),
+        call("event.name", {"false": False, "empty": "", "text": "present"}),
+    ]
+
+
+def test_none_values_in_event_list_mappings_are_not_written_to_span():
+    span = Mock()
+    response = ExtractorResponse(
+        type="event_list",
+        content=[
+            {
+                "event.one": {
+                    "zero": 0,
+                    "false": False,
+                    "empty": "",
+                    "missing": None,
+                }
+            },
+            {"event.two": {"text": "present", "missing": None}},
+        ],
+    )
+
+    ExtractorResponse.update_span(span, "unused", response)
+
+    assert span.add_event.call_args_list == [
+        call("event.one", {"zero": 0, "false": False, "empty": ""}),
+        call("event.two", {"text": "present"}),
+    ]
+
+
+def test_none_values_are_filtered_before_reaching_real_otel_span():
+    provider = TracerProvider()
+    span = provider.get_tracer(__name__).start_span("extractor-response")
+
+    ExtractorResponse.update_span(
+        span,
+        "event.one",
+        ExtractorResponse(type="event", content={"zero": 0, "missing": None}),
+    )
+    ExtractorResponse.update_span(
+        span,
+        "unused",
+        ExtractorResponse(
+            type="event_list",
+            content=[{"event.two": {"false": False, "missing": None}}],
+        ),
+    )
+
+    assert [(event.name, dict(event.attributes)) for event in span.events] == [
+        ("event.one", {"zero": 0}),
+        ("event.two", {"false": False}),
+    ]
+    span.end()
+    provider.shutdown()

--- a/tests/test_tracing_content.py
+++ b/tests/test_tracing_content.py
@@ -143,6 +143,10 @@ def _event_names(span):
     return [event.name for event in span.events]
 
 
+def _event_count(span, name: str) -> int:
+    return _event_names(span).count(name)
+
+
 def test_trace_call_llm_records_content_by_default(monkeypatch):
     monkeypatch.delenv("OBSERVABILITY_OPENTELEMETRY_TRACE_CONTENT", raising=False)
 
@@ -162,6 +166,73 @@ def test_trace_call_llm_records_content_by_default(monkeypatch):
         assert "gen_ai.choice" in _event_names(span)
 
 
+def test_trace_call_llm_records_request_events_once_per_span(monkeypatch):
+    monkeypatch.delenv("OBSERVABILITY_OPENTELEMETRY_TRACE_CONTENT", raising=False)
+
+    with _start_test_span("call_llm") as span:
+        for _ in range(2):
+            telemetry.trace_call_llm(
+                _FakeInvocationContext(),
+                "event-id",
+                _FakeLlmRequest(),
+                _FakeLlmResponse(),
+            )
+
+        assert _event_count(span, "gen_ai.system.message") == 1
+        assert _event_count(span, "gen_ai.user.message") == 1
+        assert _event_count(span, "gen_ai.choice") == 2
+
+
+def test_trace_call_llm_request_sentinel_does_not_require_system_event(monkeypatch):
+    monkeypatch.delenv("OBSERVABILITY_OPENTELEMETRY_TRACE_CONTENT", raising=False)
+    monkeypatch.setattr(
+        telemetry,
+        "get_attributes",
+        lambda kind: {
+            "gen_ai.messages": lambda params: telemetry.ExtractorResponse(
+                type="event_list",
+                content=[{"gen_ai.user.message": {"role": "user"}}],
+            ),
+            "gen_ai.choice": lambda params: telemetry.ExtractorResponse(
+                type="event", content={"role": "assistant"}
+            ),
+        },
+    )
+
+    with _start_test_span("call_llm") as span:
+        for _ in range(2):
+            telemetry.trace_call_llm(
+                _FakeInvocationContext(),
+                "event-id",
+                _FakeLlmRequest(),
+                _FakeLlmResponse(),
+            )
+
+        assert _event_count(span, "gen_ai.system.message") == 0
+        assert _event_count(span, "gen_ai.user.message") == 1
+        assert _event_count(span, "gen_ai.choice") == 2
+
+
+def test_trace_call_llm_records_request_events_for_each_span(monkeypatch):
+    monkeypatch.delenv("OBSERVABILITY_OPENTELEMETRY_TRACE_CONTENT", raising=False)
+
+    spans = []
+    for name in ("call_llm.first", "call_llm.second"):
+        with _start_test_span(name) as span:
+            spans.append(span)
+            telemetry.trace_call_llm(
+                _FakeInvocationContext(),
+                "event-id",
+                _FakeLlmRequest(),
+                _FakeLlmResponse(),
+            )
+
+    for span in spans:
+        assert _event_count(span, "gen_ai.system.message") == 1
+        assert _event_count(span, "gen_ai.user.message") == 1
+        assert _event_count(span, "gen_ai.choice") == 1
+
+
 def test_trace_call_llm_prefers_explicit_adk_span(monkeypatch):
     """ADK 1.24+ calls the hook while a nested inference span is current."""
     monkeypatch.delenv("OBSERVABILITY_OPENTELEMETRY_TRACE_CONTENT", raising=False)
@@ -170,16 +241,21 @@ def test_trace_call_llm_prefers_explicit_adk_span(monkeypatch):
     tracer = provider.get_tracer(__name__)
     with tracer.start_as_current_span("call_llm") as call_llm_span:
         with tracer.start_as_current_span("generate_content") as inference_span:
-            telemetry.trace_call_llm(
-                _FakeInvocationContext(),
-                "event-id",
-                _FakeLlmRequest(),
-                _FakeLlmResponse(),
-                call_llm_span,
-            )
+            for _ in range(2):
+                telemetry.trace_call_llm(
+                    _FakeInvocationContext(),
+                    "event-id",
+                    _FakeLlmRequest(),
+                    _FakeLlmResponse(),
+                    call_llm_span,
+                )
 
     assert call_llm_span.attributes["gen_ai.request.model"] == "test-model"
+    assert _event_count(call_llm_span, "gen_ai.system.message") == 1
+    assert _event_count(call_llm_span, "gen_ai.user.message") == 1
+    assert _event_count(call_llm_span, "gen_ai.choice") == 2
     assert "gen_ai.request.model" not in inference_span.attributes
+    assert not inference_span.events
 
 
 def test_content_tracing_uses_veadk_config_when_env_missing(monkeypatch):
@@ -193,12 +269,13 @@ def test_trace_call_llm_skips_content_when_env_false(monkeypatch):
     monkeypatch.setenv("OBSERVABILITY_OPENTELEMETRY_TRACE_CONTENT", "false")
 
     with _start_test_span("call_llm") as span:
-        telemetry.trace_call_llm(
-            _FakeInvocationContext(),
-            "event-id",
-            _FakeLlmRequest(),
-            _FakeLlmResponse(),
-        )
+        for _ in range(2):
+            telemetry.trace_call_llm(
+                _FakeInvocationContext(),
+                "event-id",
+                _FakeLlmRequest(),
+                _FakeLlmResponse(),
+            )
 
         assert span.attributes["gen_ai.request.model"] == "test-model"
         assert span.attributes["gen_ai.usage.total_tokens"] == 18

--- a/veadk/models/ark_llm.py
+++ b/veadk/models/ark_llm.py
@@ -296,9 +296,8 @@ def _content_to_input_item(
                         type="function_call",
                     )
                 )
-            elif part.text or part.inline_data:
-                if input_content:
-                    input_list.append(input_content)
+        if input_content:
+            input_list.append(input_content)
     return input_list
 
 

--- a/veadk/tracing/telemetry/attributes/extractors/types.py
+++ b/veadk/tracing/telemetry/attributes/extractors/types.py
@@ -24,6 +24,11 @@ from opentelemetry.sdk.trace import _Span
 from opentelemetry.trace.span import Span
 
 
+def _remove_none_attributes(attributes: dict[str, Any]) -> dict[str, Any]:
+    """Remove None attribute values before sending them to OpenTelemetry."""
+    return {key: value for key, value in attributes.items() if value is not None}
+
+
 @dataclass
 class ExtractorResponse:
     """Response container for telemetry attribute extractors.
@@ -91,24 +96,33 @@ class ExtractorResponse:
             if isinstance(res, list):
                 for _res in res:
                     if isinstance(_res, dict):
-                        for k, v in _res.items():
-                            if v is not None:
-                                span.set_attribute(k, v)
+                        for k, v in _remove_none_attributes(_res).items():
+                            span.set_attribute(k, v)
             else:
                 span.set_attribute(attr_name, res)  # type: ignore
         elif response.type == "event":
             if isinstance(response.content, dict):
-                span.add_event(attr_name, response.content)
+                span.add_event(attr_name, _remove_none_attributes(response.content))
             elif isinstance(response.content, list):
                 for event in response.content:
-                    span.add_event(attr_name, event)  # type: ignore
+                    event_attributes = (
+                        _remove_none_attributes(event)
+                        if isinstance(event, dict)
+                        else event
+                    )
+                    span.add_event(attr_name, event_attributes)  # type: ignore
         elif response.type == "event_list":
             if isinstance(response.content, list):
                 for event in response.content:
                     if isinstance(event, dict):
                         # we ensure this dict only have one key-value pair
                         key, value = next(iter(event.items()))
-                        span.add_event(key, value)
+                        event_attributes = (
+                            _remove_none_attributes(value)
+                            if isinstance(value, dict)
+                            else value
+                        )
+                        span.add_event(key, event_attributes)
                     else:
                         # Unsupported response type, discard it.
                         pass

--- a/veadk/tracing/telemetry/telemetry.py
+++ b/veadk/tracing/telemetry/telemetry.py
@@ -36,6 +36,8 @@ from veadk.utils.misc import safe_json_serialize
 
 logger = get_logger(__name__)
 
+_LLM_REQUEST_EVENTS_RECORDED_ATTR = "_veadk_llm_request_events_recorded"
+
 
 def _upload_call_llm_metrics(
     invocation_context: InvocationContext,
@@ -425,8 +427,19 @@ def trace_call_llm(
     )
 
     for attr_name, attr_extractor in llm_attributes_mapping.items():
+        if attr_name == "gen_ai.messages" and getattr(
+            span, _LLM_REQUEST_EVENTS_RECORDED_ATTR, False
+        ):
+            continue
+
         response: ExtractorResponse = attr_extractor(params)
         ExtractorResponse.update_span(span, attr_name, response)
+
+        # ADK invokes this hook once for every streamed response chunk. Request
+        # events belong to the call_llm span, so emit them only on the first
+        # chunk while continuing to record response choices for every chunk.
+        if attr_name == "gen_ai.messages":
+            setattr(span, _LLM_REQUEST_EVENTS_RECORDED_ATTR, True)
 
     _upload_call_llm_metrics(invocation_context, event_id, llm_request, llm_response)
 


### PR DESCRIPTION
## Summary

- append aggregated Ark assistant content exactly once while preserving function calls and file/inline inputs
- record request message events once per `call_llm` span while keeping streamed response choices per chunk
- filter `None` values from OpenTelemetry attribute, event, and event-list mappings without dropping valid falsy values

## Validation

- `pre-commit run --show-diff-on-failure --color=never --all-files`
- `pytest -n 16` — 2286 passed, 5 skipped
- provider-boundary end-to-end checks for Volcengine and BytePlus
- real OpenTelemetry SDK span checks for streamed events and nullable attributes