### PR TITLE
fix(studio): streamline agent creation navigation

### DIFF
--- a/frontend/src/create/CustomCreate.tsx
+++ b/frontend/src/create/CustomCreate.tsx
@@ -2820,8 +2820,8 @@ type DebugPhase = "idle" | "starting" | "ready" | "sending" | "error";
 
 type WorkspaceMode =
   | "build"
-  | "optimize"
   | "validate"
+  | "optimize"
   | "environment"
   | "publish";
 interface DebugMessage {
@@ -3552,16 +3552,16 @@ const WORKSPACE_MODES: Array<{
   label: string;
 }> = [
   { id: "build", label: "架构" },
-  { id: "optimize", label: "优化" },
   { id: "validate", label: "调试" },
+  { id: "optimize", label: "优化" },
   { id: "environment", label: "环境" },
   { id: "publish", label: "发布" },
 ];
 
 const WORKSPACE_TITLES: Record<WorkspaceMode, string> = {
   build: "个性化您的智能体架构",
-  optimize: "为您的智能体选择优化项",
   validate: "调试您的智能体",
+  optimize: "为您的智能体选择优化项",
   environment: "配置云上环境",
   publish: "准备好部署您的智能体",
 };
@@ -4704,12 +4704,12 @@ export function CustomCreate({
       await materializePublishRelease();
       return;
     }
-    if (nextMode === "optimize") {
-      await openOptimization();
-      return;
-    }
     if (nextMode === "validate") {
       openValidation();
+      return;
+    }
+    if (nextMode === "optimize") {
+      await openOptimization();
       return;
     }
     if (nextMode === "environment") {
@@ -5665,16 +5665,6 @@ export function CustomCreate({
           </div>
         )}
 
-        {workspaceMode === "optimize" && (
-          <HarnessOptimizationWorkspace
-            profile={harnessOptimizationProfile}
-            optimizations={harnessOptimizations}
-            unavailableMessage={harnessProviderNotice}
-            onProfileChange={updateHarnessOptimizationProfile}
-            onOptimizationChange={updateHarnessOptimization}
-          />
-        )}
-
         {workspaceMode === "validate" && (
           <div className="cw-validation-workspace">
             <div className="cw-validation-content">
@@ -5701,6 +5691,16 @@ export function CustomCreate({
               />
             </div>
           </div>
+        )}
+
+        {workspaceMode === "optimize" && (
+          <HarnessOptimizationWorkspace
+            profile={harnessOptimizationProfile}
+            optimizations={harnessOptimizations}
+            unavailableMessage={harnessProviderNotice}
+            onProfileChange={updateHarnessOptimizationProfile}
+            onOptimizationChange={updateHarnessOptimization}
+          />
         )}
 
         {workspaceMode === "environment" && (

--- a/frontend/src/ui/Sidebar.tsx
+++ b/frontend/src/ui/Sidebar.tsx
@@ -312,7 +312,8 @@ export function Sidebar({
   userInfo,
   onLogout,
 }: SidebarProps) {
-  // The legacy full-page creator remains outside the main navigation.
+  // Agent creation remains outside the main navigation.
+  void onQuickCreate;
   void onAddAgent;
   // Per-module feature gates; a missing flag defaults to shown.
   const show = (k: keyof NonNullable<typeof features>) => features?.[k] !== false;
@@ -423,17 +424,6 @@ export function Sidebar({
           <AgentFaceIcon />
           <span className="sidebar-nav-label">智能体</span>
         </button>
-        {access.capabilities.createAgents && show("addAgent") ? (
-          <button
-            className="new-chat new-chat--add-agent"
-            onClick={onQuickCreate}
-            aria-label="添加智能体"
-            title="添加智能体"
-          >
-            <Plus className="icon" />
-            <span className="sidebar-nav-label">添加智能体</span>
-          </button>
-        ) : null}
         <button
           className={`new-chat new-chat--library${
             activePage === "library" ? " is-active" : ""

--- a/frontend/tests/harnessSidecarOptions.test.mjs
+++ b/frontend/tests/harnessSidecarOptions.test.mjs
@@ -202,20 +202,24 @@ test("derives Model Proxy dependencies from the selected optimization catalog", 
   ]);
 });
 
-test("places the Harness optimization page second, before debugging", () => {
+test("places the Harness optimization page immediately before environment setup", () => {
   assert.match(
     customCreateSource,
-    /type WorkspaceMode =[\s\S]*?\| "optimize"[\s\S]*?\| "validate"[\s\S]*?\| "publish";/,
+    /type WorkspaceMode =[\s\S]*?\| "validate"[\s\S]*?\| "optimize"[\s\S]*?\| "environment"[\s\S]*?\| "publish";/,
   );
   assert.match(
     customCreateSource,
-    /\{ id: "build", label: "架构" \},\s*\{ id: "optimize", label: "优化" \},\s*\{ id: "validate", label: "调试" \},\s*\{ id: "environment", label: "环境" \},\s*\{ id: "publish", label: "发布" \}/,
+    /\{ id: "build", label: "架构" \},\s*\{ id: "validate", label: "调试" \},\s*\{ id: "optimize", label: "优化" \},\s*\{ id: "environment", label: "环境" \},\s*\{ id: "publish", label: "发布" \}/,
   );
   assert.match(customCreateSource, /optimize:\s*"为您的智能体选择优化项"/);
   assert.doesNotMatch(customCreateSource, /为您的智能体选择一些优化项/);
   assert.ok(
+    customCreateSource.indexOf('{workspaceMode === "validate"') <
+      customCreateSource.indexOf('{workspaceMode === "optimize"'),
+  );
+  assert.ok(
     customCreateSource.indexOf('{workspaceMode === "optimize"') <
-      customCreateSource.indexOf('{workspaceMode === "validate"'),
+      customCreateSource.indexOf('{workspaceMode === "environment"'),
   );
   assert.match(
     customCreateSource,

--- a/frontend/tests/myAgents.test.mjs
+++ b/frontend/tests/myAgents.test.mjs
@@ -45,15 +45,9 @@ test("shows only the Agent navigation in the sidebar", () => {
   assert.match(appSource, /myAgents && !showManageAgents \? \([\s\S]*?<MyAgents/);
 });
 
-test("opens Agent creation directly without visiting the Runtime-backed library", () => {
-  assert.match(
-    sidebarSource,
-    /access\.capabilities\.createAgents && show\("addAgent"\)[\s\S]*?onClick=\{onQuickCreate\}[\s\S]*?aria-label="添加智能体"/,
-  );
-  assert.match(
-    appSource,
-    /onQuickCreate=\{\(\) => requestIntelligentNavigation\(\(\) => \{[\s\S]*?setCreateView\(null\)[\s\S]*?setAddMenu\(true\)/,
-  );
+test("keeps Agent creation out of the sidebar navigation", () => {
+  assert.doesNotMatch(sidebarSource, /new-chat--add-agent/);
+  assert.doesNotMatch(sidebarSource, /aria-label="添加智能体"/);
 });
 
 test("shows the requested title, search, and agent type pills", () => {

--- a/frontend/tests/studioAccess.test.mjs
+++ b/frontend/tests/studioAccess.test.mjs
@@ -35,9 +35,10 @@ test("Studio entry telemetry uses anonymous UI config metadata", () => {
 });
 
 test("Agent workspace creation and update actions obey Studio access", () => {
-  assert.match(sidebarSource, /access\.capabilities\.createAgents && show\("addAgent"\)/);
+  assert.doesNotMatch(sidebarSource, /access\.capabilities\.createAgents && show\("addAgent"\)/);
   assert.doesNotMatch(sidebarSource, /access\.capabilities\.manageAgents && show\("manageAgents"\)/);
   assert.doesNotMatch(sidebarSource, /onManageAgents/);
+  assert.match(appSource, /<MyAgents[\s\S]*?canCreate=\{canCreateAgents\}/);
   assert.match(appSource, /const visibleCreateView = canCreateAgents \? createView : null/);
   assert.match(appSource, /const showManageAgents = manageAgents/);
   assert.match(appSource, /if \(!access\.capabilities\.manageAgents\) setManageAgents\(false\)/);


### PR DESCRIPTION
## Summary
- remove the 添加智能体 action from the Studio sidebar
- reorder the Agent creation lifecycle to 架构 → 调试 → 优化 → 环境 → 发布
- update navigation and access regression tests

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run build`
- `uv run pre-commit run --files frontend/src/create/CustomCreate.tsx frontend/src/ui/Sidebar.tsx frontend/tests/harnessSidecarOptions.test.mjs frontend/tests/myAgents.test.mjs frontend/tests/studioAccess.test.mjs`