### PR TITLE
fix: relax a2a sdk compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 ]
 dependencies = [
     "pydantic-settings==2.10.1", # Config management
-    "a2a-sdk==0.3.7", # For Google Agent2Agent protocol
+    "a2a-sdk>=0.3.7,<1.0.0", # For Google Agent2Agent protocol
     "deprecated==1.2.18",
     "google-adk>=1.34.0", # For basic agent architecture
     # litellm and sqlalchemy are required by code paths veadk always uses

--- a/tests/cli/test_generated_agent_backend_codegen_extended.py
+++ b/tests/cli/test_generated_agent_backend_codegen_extended.py
@@ -72,7 +72,7 @@ _MINIMAL_FRONTEND_GOLDEN = {
     "agents/demo_agent/__init__.py": "ba3abbb199bbae74dc75151a44ba53a557e5f47d509835950ca756346c5a9582",
     "agents/demo_agent/dynamic_a2a.py": "d136f27d6a77439708c415686a3d167f2ad2fb9a96a5f8a0751916b09d46e364",
     ".env.example": "ec3258da9bef4e74333376d8554c265ccb12a4a1e5d4e1e1b0acdf5c9ae93ab6",
-    "requirements.txt": "220cfbc918879965e134924dd704b76d2282392a371da60492d5405d7b83bf48",
+    "requirements.txt": "d04dddbe531e1d4315ea5ea6349bd9eff73815d9e3b4e996448e6c3db96caf15",
     "README.md": "a34208314cf9061c02662028d7a9dd97448e6b73c1d732cb4aeaa8f70dbbc684",
 }
 
@@ -83,7 +83,7 @@ _FULL_FRONTEND_GOLDEN = {
     "agents/full_agent/__init__.py": "ba3abbb199bbae74dc75151a44ba53a557e5f47d509835950ca756346c5a9582",
     "agents/full_agent/dynamic_a2a.py": "d136f27d6a77439708c415686a3d167f2ad2fb9a96a5f8a0751916b09d46e364",
     ".env.example": "2bfd3afda4e661fbb71588ec5f0d584ce6682363cacc81b0394f8da09f7977e8",
-    "requirements.txt": "17a9afc0b90bf3ba6e8bc3711181b8f0b01918824d554f1b435cf22ef780bff4",
+    "requirements.txt": "35f70f219bbb2c5f0f22cbc0774d9d8e50d9162727579476ca006604ec0da7e2",
     "README.md": "1bf4dc889c7d1076f50784d253b53412ba7c49bcb69a5d948f9092dbbecb18ac",
 }
 

--- a/tests/cli/test_generated_agent_harness_sidecar.py
+++ b/tests/cli/test_generated_agent_harness_sidecar.py
@@ -74,7 +74,7 @@ def test_selected_component_generates_extra_app_plugins_and_close_lifecycle(
     main_py = files["main.py"]
     agent_py = files["agents/sidecar_agent/agent.py"]
     assert "veadk-python[harness-sidecar]" in requirements
-    assert "agentkit-sdk-python==0.8.1" in requirements
+    assert "agentkit-sdk-python==0.8.4" in requirements
     assert "bytedance-agentkit-harness-sidecar" not in requirements
     assert "HarnessExtension.from_env()" in agent_py
     assert "plugins=harness_extension.plugins()" in agent_py

--- a/tests/cli/test_managed_sidecar_source.py
+++ b/tests/cli/test_managed_sidecar_source.py
@@ -60,23 +60,23 @@ def test_rewrite_uses_source_snapshot_and_pins_public_sdk() -> None:
     assert "veadk-python" in rewritten.splitlines()[0]
     assert "veadk-python[" not in rewritten
     assert "agentkit-harness-sidecar-integration" not in rewritten
-    assert rewritten.splitlines()[1] == "agentkit-sdk-python==0.8.1"
-    assert rewritten.splitlines().count("agentkit-sdk-python==0.8.1") == 1
+    assert rewritten.splitlines()[1] == "agentkit-sdk-python==0.8.4"
+    assert rewritten.splitlines().count("agentkit-sdk-python==0.8.4") == 1
     assert "google-adk>=1.34.0" in rewritten
 
 
 def test_rewrite_preserves_comments_and_rejects_missing_veadk() -> None:
     with pytest.raises(ManagedSidecarSourceError, match="requirement_missing"):
         rewrite_managed_sidecar_requirements(
-            "# keep\n@local-reference\nagentkit-sdk-python==0.8.1\n"
+            "# keep\n@local-reference\nagentkit-sdk-python==0.8.4\n"
         )
 
     rewritten = rewrite_managed_sidecar_requirements(
         "# keep\nveadk-python[harness-sidecar]\n"
-        "agentkit-sdk-python>=0.8\nagentkit_sdk_python==0.8.1\n"
+        "agentkit-sdk-python>=0.8\nagentkit_sdk_python==0.8.4\n"
     )
     assert "# keep" in rewritten
-    assert rewritten.splitlines().count("agentkit-sdk-python==0.8.1") == 1
+    assert rewritten.splitlines().count("agentkit-sdk-python==0.8.4") == 1
 
 
 def test_stage_copies_only_safe_runtime_source_and_rewrites_requirements(
@@ -106,7 +106,7 @@ def test_stage_copies_only_safe_runtime_source_and_rewrites_requirements(
     assert not (project / "veadk/__pycache__").exists()
     assert not (project / "veadk/.env.local").exists()
     requirements = (project / "requirements.txt").read_text(encoding="utf-8")
-    assert requirements.splitlines().count("agentkit-sdk-python==0.8.1") == 1
+    assert requirements.splitlines().count("agentkit-sdk-python==0.8.4") == 1
     assert "veadk-python[" not in requirements
 
 

--- a/tests/cli/test_studio_rbac.py
+++ b/tests/cli/test_studio_rbac.py
@@ -3686,7 +3686,7 @@ def test_sidecar_deployment_uses_agentkit_cli_structured_release(
     assert captured["create_only"] is True
     assert captured["managed_source_present"] is True
     assert "veadk-python[" not in captured["requirements"]
-    assert "agentkit-sdk-python==0.8.1" in captured["requirements"]
+    assert "agentkit-sdk-python==0.8.4" in captured["requirements"]
     assert captured["config"]["name"] == runtime_name
     assert captured["config"]["harness_sidecar"]["component_overrides"] == {
         "context_engine": True,

--- a/tests/test_ve_tos.py
+++ b/tests/test_ve_tos.py
@@ -86,6 +86,7 @@ def test_ve_tos_database_region_wins_over_region_env(monkeypatch, fake_tos):
 def test_tos_config_uses_region_env_fallback_and_updates_endpoint(monkeypatch):
     from veadk.configs.database_configs import TOSConfig
 
+    monkeypatch.delenv("AGENTKIT_CLOUD_PROVIDER", raising=False)
     monkeypatch.setenv("CLOUD_PROVIDER", "volces")
     monkeypatch.delenv("DATABASE_TOS_REGION", raising=False)
     monkeypatch.delenv("DATABASE_TOS_ENDPOINT", raising=False)

--- a/veadk/cli/generated_agent_codegen.py
+++ b/veadk/cli/generated_agent_codegen.py
@@ -922,7 +922,7 @@ def render_requirements(extras: set[str], include_feishu_channel: bool) -> str:
     extras_str = f"[{','.join(unique_extras)}]" if unique_extras else ""
     minimum_version = "1.1.1" if "harness-sidecar" in all_extras else "1.0.5"
     pkg = f"veadk-python{extras_str}>={minimum_version}"
-    packages = [pkg, "agentkit-sdk-python==0.8.1", "google-adk", "starlette<1.0.0"]
+    packages = [pkg, "agentkit-sdk-python==0.8.4", "google-adk", "starlette<1.0.0"]
     return "\n".join(packages) + "\n"
 
 

--- a/veadk/cli/managed_sidecar_source.py
+++ b/veadk/cli/managed_sidecar_source.py
@@ -28,7 +28,7 @@ _REMOVED_DISTRIBUTIONS = {
     "agentkit-harness-sidecar-integration",
     "veadk-python",
 }
-_MANAGED_SDK_REQUIREMENT = "agentkit-sdk-python==0.8.1"
+_MANAGED_SDK_REQUIREMENT = "agentkit-sdk-python==0.8.4"
 _IGNORED_PARTS = {".git", "__pycache__"}
 _IGNORED_SUFFIXES = {".pyc", ".pyo"}
 _BLOCKED_SUFFIXES = {".key", ".p12", ".pem", ".pfx"}


### PR DESCRIPTION
## Summary
- relax `a2a-sdk` from `==0.3.7` to `>=0.3.7,<1.0.0` so VeADK can resolve with `agentkit-sdk-python==0.8.4`
- update generated/managed Sidecar requirements to pin `agentkit-sdk-python==0.8.4`
- isolate `AGENTKIT_CLOUD_PROVIDER` in the TOS region fallback test to avoid cross-test environment leakage

## Validation
- `uv run pre-commit run --all-files`
- `uv run pytest tests/a2a tests/test_ve_a2a_middlewares.py tests/test_ve_tos.py -q -n 16`
- `uv run pytest tests/cli/test_managed_sidecar_source.py tests/cli/test_generated_agent_harness_sidecar.py tests/cli/test_studio_rbac.py::test_sidecar_deployment_uses_agentkit_cli_structured_release tests/tools/builtin_tools/test_agentkit.py -q`
- fresh venv resolver check: editable VeADK + `agentkit-sdk-python==0.8.4` resolves `a2a-sdk==0.3.26` and imports `agentkit_identity` plus A2A FastAPI entrypoint

## Notes
- Full local `uv run pytest -n 16` still has environment-related failures unrelated to this change: missing optional `llama_index` and `greenlet` in the local Python 3.13 environment. After updating generated-project golden hashes, no A2A/AgentKit/TOS failures remain in targeted coverage.