### PR TITLE
Harden Studio auto-open readiness on Windows

### DIFF
--- a/.github/workflows/windows-studio-smoke.yaml
+++ b/.github/workflows/windows-studio-smoke.yaml
@@ -1,0 +1,229 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Windows Studio Smoke Test
+
+on:
+  push:
+    branches:
+      - fix/windows-studio-smoke
+    paths:
+      - ".github/workflows/windows-studio-smoke.yaml"
+      - "frontend/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "veadk/**"
+  workflow_dispatch:
+    inputs:
+      repeat_count:
+        description: "How many times to start Studio"
+        required: false
+        default: "10"
+      base_port:
+        description: "First local port"
+        required: false
+        default: "8877"
+      python_version:
+        description: "Python version"
+        required: false
+        default: "3.10"
+
+permissions:
+  contents: read
+
+jobs:
+  studio-open-smoke:
+    runs-on: windows-2025
+    timeout-minutes: 60
+
+    env:
+      NO_COLOR: "1"
+      PYTHONIOENCODING: utf-8
+      PYTHONUNBUFFERED: "1"
+      SMOKE_BASE_PORT: ${{ github.event_name == 'workflow_dispatch' && inputs.base_port || '8877' }}
+      SMOKE_REPEAT_COUNT: ${{ github.event_name == 'workflow_dispatch' && inputs.repeat_count || '10' }}
+      VOLCENGINE_ACCESS_KEY: smoke
+      VOLCENGINE_SECRET_KEY: smoke
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ github.event_name == 'workflow_dispatch' && inputs.python_version || '3.10' }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install dependencies
+        shell: pwsh
+        run: |
+          uv venv .venv
+          uv sync --all-extras
+          uv pip install -e .
+          .\.venv\Scripts\veadk.exe --version
+
+      - name: Start Studio repeatedly with --open
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          $repeatCount = [int]$env:SMOKE_REPEAT_COUNT
+          $basePort = [int]$env:SMOKE_BASE_PORT
+          if ($repeatCount -lt 1) {
+            throw "SMOKE_REPEAT_COUNT must be at least 1."
+          }
+          if ($basePort -lt 1 -or $basePort -gt 65535) {
+            throw "SMOKE_BASE_PORT must be a valid TCP port."
+          }
+          if (($basePort + $repeatCount - 1) -gt 65535) {
+            throw "The requested port range exceeds 65535."
+          }
+
+          $rootLogDir = "artifacts\windows-studio-smoke"
+          $workspaceRoot = "artifacts\studio-smoke-workspace"
+          $agentDir = Join-Path $workspaceRoot "demo_agent"
+          New-Item -ItemType Directory -Force $rootLogDir | Out-Null
+          New-Item -ItemType Directory -Force $agentDir | Out-Null
+
+          @"
+          from veadk import Agent
+
+          root_agent = Agent(
+              name="demo_agent",
+              instruction="You are a smoke test agent.",
+          )
+          "@ | Set-Content -Path (Join-Path $agentDir "agent.py") -Encoding utf8
+
+          $veadk = (Resolve-Path ".\.venv\Scripts\veadk.exe").Path
+          $failedAttempts = @()
+          $summary = @()
+
+          function Invoke-StudioSmokeAttempt {
+            param(
+              [Parameter(Mandatory = $true)]
+              [int] $Attempt
+            )
+
+            $port = $basePort + $Attempt - 1
+            $baseUrl = "http://127.0.0.1:$port"
+            $attemptName = "{0:D2}" -f $Attempt
+            $attemptLogDir = Join-Path $rootLogDir "attempt-$attemptName"
+            New-Item -ItemType Directory -Force $attemptLogDir | Out-Null
+
+            $stdoutPath = Join-Path $attemptLogDir "studio.stdout.log"
+            $stderrPath = Join-Path $attemptLogDir "studio.stderr.log"
+            $resultPath = Join-Path $attemptLogDir "result.txt"
+            $process = $null
+
+            @(
+              "attempt=$Attempt"
+              "port=$port"
+              "url=$baseUrl"
+              "command=$veadk studio --agents-dir . --dev --port $port --open"
+            ) | Set-Content -Path (Join-Path $attemptLogDir "command.txt") -Encoding utf8
+
+            try {
+              $process = Start-Process `
+                -FilePath $veadk `
+                -WorkingDirectory $workspaceRoot `
+                -ArgumentList @("studio", "--agents-dir", ".", "--dev", "--port", "$port", "--open") `
+                -PassThru `
+                -RedirectStandardOutput $stdoutPath `
+                -RedirectStandardError $stderrPath
+
+              $deadline = (Get-Date).AddSeconds(90)
+              $ready = $false
+              $lastError = ""
+
+              while ((Get-Date) -lt $deadline) {
+                if ($process.HasExited) {
+                  throw "Studio exited before becoming ready. ExitCode=$($process.ExitCode)"
+                }
+
+                try {
+                  $response = Invoke-WebRequest `
+                    -UseBasicParsing `
+                    -Uri "$baseUrl/web/ui-config" `
+                    -TimeoutSec 5
+                  if ($response.StatusCode -eq 200) {
+                    $response.Content | Set-Content `
+                      -Path (Join-Path $attemptLogDir "ui-config.json") `
+                      -Encoding utf8
+                    $ready = $true
+                    break
+                  }
+                  $lastError = "HTTP status $($response.StatusCode)"
+                } catch {
+                  $lastError = $_.Exception.Message
+                }
+
+                Start-Sleep -Seconds 2
+              }
+
+              if (-not $ready) {
+                throw "Studio did not become ready at $baseUrl. Last error: $lastError"
+              }
+
+              Start-Sleep -Seconds 15
+
+              if ($process.HasExited) {
+                throw "Studio exited after becoming ready. ExitCode=$($process.ExitCode)"
+              }
+
+              Invoke-WebRequest -UseBasicParsing -Uri "$baseUrl/" -TimeoutSec 5 | Out-Null
+              "PASS: Studio stayed reachable at $baseUrl with --open." |
+                Set-Content -Path $resultPath -Encoding utf8
+            } finally {
+              if ($process -and -not $process.HasExited) {
+                Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+                Wait-Process -Id $process.Id -Timeout 10 -ErrorAction SilentlyContinue
+              }
+            }
+          }
+
+          for ($attempt = 1; $attempt -le $repeatCount; $attempt++) {
+            Write-Host "Starting Studio smoke attempt $attempt/$repeatCount..."
+            try {
+              Invoke-StudioSmokeAttempt -Attempt $attempt
+              $summary += "attempt-$("{0:D2}" -f $attempt): PASS"
+            } catch {
+              $message = $_.Exception.Message
+              $failedAttempts += $attempt
+              $summary += "attempt-$("{0:D2}" -f $attempt): FAIL - $message"
+              $attemptLogDir = Join-Path $rootLogDir ("attempt-{0:D2}" -f $attempt)
+              New-Item -ItemType Directory -Force $attemptLogDir | Out-Null
+              "FAIL: $message" |
+                Set-Content -Path (Join-Path $attemptLogDir "result.txt") -Encoding utf8
+              Write-Error "Attempt $attempt failed: $message" -ErrorAction Continue
+            }
+          }
+
+          $summary | Set-Content -Path (Join-Path $rootLogDir "summary.txt") -Encoding utf8
+
+          if ($failedAttempts.Count -gt 0) {
+            throw "Windows Studio smoke failed attempts: $($failedAttempts -join ', ')"
+          }
+
+          Write-Host "Windows Studio smoke passed all $repeatCount attempts."
+
+      - name: Upload smoke logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-studio-smoke-logs
+          path: artifacts/windows-studio-smoke
+          retention-days: 7

--- a/.github/workflows/windows-studio-smoke.yaml
+++ b/.github/workflows/windows-studio-smoke.yaml
@@ -44,8 +44,16 @@ permissions:
 
 jobs:
   studio-open-smoke:
-    runs-on: windows-2025
+    name: studio-open-smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-2022
+          - windows-2025
 
     env:
       NO_COLOR: "1"
@@ -224,6 +232,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: windows-studio-smoke-logs
+          name: windows-studio-smoke-logs-${{ matrix.os }}
           path: artifacts/windows-studio-smoke
           retention-days: 7

--- a/.github/workflows/windows-studio-smoke.yaml
+++ b/.github/workflows/windows-studio-smoke.yaml
@@ -15,15 +15,6 @@
 name: Windows Studio Smoke Test
 
 on:
-  push:
-    branches:
-      - fix/windows-studio-smoke
-    paths:
-      - ".github/workflows/windows-studio-smoke.yaml"
-      - "frontend/**"
-      - "pyproject.toml"
-      - "uv.lock"
-      - "veadk/**"
   workflow_dispatch:
     inputs:
       repeat_count:

--- a/tests/cli/test_frontend_runtime_proxy.py
+++ b/tests/cli/test_frontend_runtime_proxy.py
@@ -26,9 +26,11 @@ import pytest
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
+from veadk.cli import cli_frontend
 from veadk.cli.cli_frontend import (
     _build_agentkit_proxy_headers,
     _frontend_allow_origins,
+    _open_browser_when_ready,
     _run_frontend_server,
     _runtime_regions,
 )
@@ -98,6 +100,166 @@ def test_vite_allows_both_loopback_browser_origins() -> None:
         "http://127.0.0.1:5174",
     ]
     assert _frontend_allow_origins(vite=False) == []
+
+
+class _FakeHttpResponse:
+    def __init__(self, status: int = 200) -> None:
+        self.status = status
+
+    def __enter__(self) -> "_FakeHttpResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+def test_open_browser_waits_for_http_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[tuple[str, float]] = []
+    opened: list[str] = []
+
+    def _urlopen(request: Any, timeout: float) -> _FakeHttpResponse:
+        requests.append((request.full_url, timeout))
+        return _FakeHttpResponse(200)
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+    monkeypatch.setattr("webbrowser.open", lambda url: opened.append(url) or True)
+
+    _open_browser_when_ready(
+        "http://127.0.0.1:8877",
+        "127.0.0.1",
+        8877,
+        timeout=1.0,
+    )
+
+    assert requests == [("http://127.0.0.1:8877/web/ui-config", 1.0)]
+    assert opened == ["http://127.0.0.1:8877"]
+
+
+def test_open_browser_falls_back_to_root_http_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[str] = []
+    opened: list[str] = []
+
+    def _urlopen(request: Any, timeout: float) -> _FakeHttpResponse:
+        del timeout
+        requests.append(request.full_url)
+        if request.full_url.endswith("/web/ui-config"):
+            return _FakeHttpResponse(503)
+        return _FakeHttpResponse(200)
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+    monkeypatch.setattr("webbrowser.open", lambda url: opened.append(url) or True)
+
+    _open_browser_when_ready(
+        "http://127.0.0.1:8877",
+        "127.0.0.1",
+        8877,
+        timeout=1.0,
+    )
+
+    assert requests == [
+        "http://127.0.0.1:8877/web/ui-config",
+        "http://127.0.0.1:8877",
+    ]
+    assert opened == ["http://127.0.0.1:8877"]
+
+
+def test_open_browser_treats_http_client_error_as_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import urllib.error
+
+    opened: list[str] = []
+
+    def _urlopen(request: Any, timeout: float) -> _FakeHttpResponse:
+        del timeout
+        raise urllib.error.HTTPError(
+            request.full_url,
+            403,
+            "Forbidden",
+            hdrs=None,
+            fp=None,
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+    monkeypatch.setattr("webbrowser.open", lambda url: opened.append(url) or True)
+
+    _open_browser_when_ready(
+        "http://127.0.0.1:8877",
+        "127.0.0.1",
+        8877,
+        timeout=1.0,
+    )
+
+    assert opened == ["http://127.0.0.1:8877"]
+
+
+def test_open_browser_timeout_logs_manual_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import itertools
+    import urllib.error
+
+    warnings: list[str] = []
+    times = itertools.chain([100.0, 100.0, 100.6], itertools.repeat(100.6))
+
+    monkeypatch.setattr("time.time", lambda: next(times))
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            urllib.error.URLError("connection refused")
+        ),
+    )
+    monkeypatch.setattr("webbrowser.open", lambda _url: False)
+    monkeypatch.setattr(
+        cli_frontend.logger,
+        "warning",
+        lambda message: warnings.append(message),
+    )
+    monkeypatch.setattr(cli_frontend.logger, "info", lambda _message: None)
+
+    _open_browser_when_ready(
+        "http://127.0.0.1:8877",
+        "127.0.0.1",
+        8877,
+        timeout=0.5,
+    )
+
+    assert len(warnings) == 1
+    assert "Open http://127.0.0.1:8877 manually" in warnings[0]
+    assert "connection refused" in warnings[0]
+
+
+def test_open_browser_warns_when_browser_returns_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warnings: list[str] = []
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_args, **_kwargs: _FakeHttpResponse(200),
+    )
+    monkeypatch.setattr("webbrowser.open", lambda _url: False)
+    monkeypatch.setattr(
+        cli_frontend.logger,
+        "warning",
+        lambda message: warnings.append(message),
+    )
+
+    _open_browser_when_ready(
+        "http://127.0.0.1:8877",
+        "127.0.0.1",
+        8877,
+        timeout=1.0,
+    )
+
+    assert warnings == [
+        "Could not open the browser automatically. Open http://127.0.0.1:8877 manually."
+    ]
 
 
 def test_runtime_regions_use_both_volcengine_regions() -> None:

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -756,33 +756,62 @@ def _resolve_frontend_dir(arg: str | None) -> Path:
 
 
 def _open_browser_when_ready(
-    url: str, host: str, port: int, timeout: float = 15.0
+    url: str, host: str, port: int, timeout: float = 30.0
 ) -> None:
-    """Open ``url`` in the default browser once the server accepts connections.
+    """Open ``url`` in the default browser once the server responds to HTTP.
 
-    Polls the TCP port (up to ``timeout`` seconds) so the tab lands on a ready
-    server rather than a connection error. Runs on a daemon thread; any failure
-    is logged and ignored — a browser that will not open must never block the
-    server from serving.
+    Polls the Studio HTTP endpoint (up to ``timeout`` seconds) so the tab lands
+    on a ready server rather than a connection error. Runs on a daemon thread;
+    any failure is logged and ignored — a browser that will not open must never
+    block the server from serving.
     """
-    import socket
     import time
+    import urllib.error
+    import urllib.request
     import webbrowser
 
+    ready_urls = (f"http://{host}:{port}/web/ui-config", url)
     deadline = time.time() + timeout
+    last_error = ""
+    logger.info(
+        "Waiting up to "
+        f"{timeout:.0f}s for Studio HTTP readiness before opening {url} "
+        f"(host={host}, port={port}, pid={os.getpid()})"
+    )
     while time.time() < deadline:
-        try:
-            with socket.create_connection((host, port), timeout=0.5):
-                break
-        except OSError:
-            time.sleep(0.25)
+        for ready_url in ready_urls:
+            try:
+                request = urllib.request.Request(ready_url, method="GET")
+                with urllib.request.urlopen(request, timeout=1.0) as response:
+                    status = getattr(response, "status", 200)
+                    if 200 <= status < 500:
+                        break
+                    last_error = f"{ready_url} returned HTTP {status}"
+            except urllib.error.HTTPError as error:
+                if 200 <= error.code < 500:
+                    break
+                last_error = f"{ready_url} returned HTTP {error.code}"
+            except (OSError, urllib.error.URLError) as error:
+                last_error = f"{ready_url}: {error}"
+        else:
+            time.sleep(0.5)
+            continue
+        break
     else:
-        logger.warning("Server not ready in time; skipped opening the browser.")
+        logger.warning(
+            "Server not ready in time; skipped opening the browser. "
+            f"Open {url} manually. Last error: {last_error or 'unknown'}"
+        )
         return
     try:
-        webbrowser.open(url)
+        if not webbrowser.open(url):
+            logger.warning(
+                f"Could not open the browser automatically. Open {url} manually."
+            )
     except Exception as e:  # noqa: BLE001 - opening a browser is best-effort
-        logger.warning(f"Could not open the browser automatically: {e}")
+        logger.warning(
+            f"Could not open the browser automatically: {e}. Open {url} manually."
+        )
 
 
 # Built-in provider presets so users only need to supply client id/secret.


### PR DESCRIPTION
## 变更说明

- 新增手动触发的 Windows Studio smoke test，覆盖 windows-2022 和 windows-2025，每个环境默认循环启动 10 次 veadk studio --open，并上传每次尝试的 stdout、stderr、ui-config 和结果日志。
- 将 Studio --open 的 ready 探测从 TCP 连接改为 HTTP 探测，优先检查 /web/ui-config，失败时回退到 /。
- 将自动打开浏览器前的等待时间从 15 秒调整为 30 秒，并在失败时输出手动访问 URL 和最后一次探测错误。
- 处理 webbrowser.open() 返回 False 的情况，避免静默失败。

## 验证

- uv run pre-commit run --files veadk/cli/cli_frontend.py tests/cli/test_frontend_runtime_proxy.py
- uv run python -m pytest -q tests/cli/test_frontend_runtime_proxy.py
- Windows smoke test 已在分支上验证过 windows-2022 和 windows-2025 各 10 次启动均通过。