### PR TITLE
fix: fix: sanitize ADK build_graph serialization for VeADK agents

### DIFF
--- a/tests/cli/test_frontend_trace.py
+++ b/tests/cli/test_frontend_trace.py
@@ -11,11 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for the frontend session trace endpoint."""
+"""Tests for frontend dev web endpoints."""
 
+from __future__ import annotations
+
+import json
+from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from opentelemetry.sdk.trace import ReadableSpan
@@ -41,6 +46,23 @@ class _MemoryExporter:
                 parent=SimpleNamespace(span_id=10),
             )
         ]
+
+
+def _write_agent_app(tmp_path: Path, app_name: str, source: str) -> None:
+    app_dir = tmp_path / app_name
+    app_dir.mkdir()
+    (app_dir / "__init__.py").write_text("", encoding="utf-8")
+    (app_dir / "agent.py").write_text(source, encoding="utf-8")
+
+
+def _build_adk_web_client(tmp_path: Path) -> TestClient:
+    from google.adk.cli.fast_api import get_fast_api_app
+
+    from veadk.utils.patches import patch_adk_build_graph_serialization
+
+    patch_adk_build_graph_serialization()
+    app = get_fast_api_app(agents_dir=str(tmp_path), web=True)
+    return TestClient(app)
 
 
 def test_session_trace_route_returns_json_spans() -> None:
@@ -97,3 +119,79 @@ def test_session_trace_exporter_groups_spans_without_google_adk_internals() -> N
     assert result == SpanExportResult.SUCCESS
     assert exporter.get_finished_spans("session-1") == [matching, child]
     assert exporter.get_finished_spans("unknown") == []
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_build_graph_serializes_veadk_agent_model(tmp_path: Path) -> None:
+    _write_agent_app(
+        tmp_path,
+        "demo_agent",
+        """
+from veadk import Agent
+
+
+def hello() -> str:
+    return "ok"
+
+
+root_agent = Agent(
+    name="demo_agent",
+    model_name="test_model",
+    model_provider="test_provider",
+    model_api_key="test_key",
+    model_api_base="test_base",
+    tools=[hello],
+)
+""",
+    )
+
+    response = _build_adk_web_client(tmp_path).get("/dev/apps/demo_agent/build_graph")
+
+    assert response.status_code == 200
+    payload = response.json()
+    encoded = json.dumps(payload)
+    assert payload["root_agent"]["model"] == "test_provider/test_model"
+    assert payload["root_agent"]["tools"] == [{"name": "hello", "type": "tool"}]
+    assert "llm_client" not in encoded
+    assert "LiteLLMClient" not in encoded
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_build_graph_serializes_nested_veadk_agent_models(tmp_path: Path) -> None:
+    _write_agent_app(
+        tmp_path,
+        "nested_agent",
+        """
+from veadk import Agent
+
+
+child_agent = Agent(
+    name="child_agent",
+    model_name="child_model",
+    model_provider="child_provider",
+    model_api_key="test_key",
+    model_api_base="test_base",
+)
+
+root_agent = Agent(
+    name="root_agent",
+    model_name="root_model",
+    model_provider="root_provider",
+    model_api_key="test_key",
+    model_api_base="test_base",
+    sub_agents=[child_agent],
+)
+""",
+    )
+
+    response = _build_adk_web_client(tmp_path).get("/dev/apps/nested_agent/build_graph")
+
+    assert response.status_code == 200
+    payload = response.json()
+    encoded = json.dumps(payload)
+    assert payload["root_agent"]["model"] == "root_provider/root_model"
+    assert payload["root_agent"]["sub_agents"][0]["model"] == (
+        "child_provider/child_model"
+    )
+    assert "llm_client" not in encoded
+    assert "LiteLLMClient" not in encoded

--- a/veadk/cli/cli_web.py
+++ b/veadk/cli/cli_web.py
@@ -199,6 +199,9 @@ def web(
     )
 
     patch_adkwebserver_disable_openapi()
+    from veadk.utils.patches import patch_adk_build_graph_serialization
+
+    patch_adk_build_graph_serialization()
 
     from google.adk.cli.cli_tools_click import cli_web
 

--- a/veadk/utils/patches.py
+++ b/veadk/utils/patches.py
@@ -14,6 +14,7 @@
 
 import asyncio
 from contextlib import asynccontextmanager
+import functools
 import sys
 from typing import Callable
 
@@ -169,6 +170,56 @@ def patch_tracer() -> None:
                     logger.debug(f"Patch {mod_name} {var_name} with VeADK tracer.")
 
 
+def _sanitize_adk_graph_value(value, field_name: str | None = None):
+    if field_name == "model":
+        if isinstance(value, str):
+            return value
+        if isinstance(value, dict):
+            model_id = value.get("model")
+            if model_id:
+                return str(model_id)
+        model_id = getattr(value, "model", None)
+        if model_id:
+            return str(model_id)
+
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {
+            str(k): _sanitize_adk_graph_value(v, str(k))
+            for k, v in value.items()
+            if k != "llm_client"
+        }
+    if isinstance(value, (list, tuple, set)):
+        return [_sanitize_adk_graph_value(item) for item in value]
+    return str(value)
+
+
+def patch_adk_build_graph_serialization() -> None:
+    """Keep ADK dev build_graph JSON free of runtime-only client objects."""
+    try:
+        from google.adk.cli.utils import graph_serialization
+
+        if getattr(
+            graph_serialization,
+            "_veadk_build_graph_serialization_patched",
+            False,
+        ):
+            return
+
+        original_serialize_agent = graph_serialization.serialize_agent
+
+        @functools.wraps(original_serialize_agent)
+        def veadk_serialize_agent(*args, **kwargs):
+            return _sanitize_adk_graph_value(original_serialize_agent(*args, **kwargs))
+
+        graph_serialization.serialize_agent = veadk_serialize_agent
+        graph_serialization._veadk_build_graph_serialization_patched = True
+        logger.debug("Patch ADK build_graph serialization for VeADK agents.")
+    except Exception as e:  # pragma: no cover - defensive across adk versions
+        logger.warning(f"Skip ADK build_graph serialization patch: {e}")
+
+
 # Substrings / exception type names that signal a dead MCP session (server
 # restart, scale-down, idle expiry) or a broken transport — all recoverable by
 # dropping the cached session and reconnecting.
@@ -205,7 +256,6 @@ def _retry_once_on_dead_mcp_session(func):
 
     Applies to any object exposing ``_mcp_session_manager`` (McpTool, McpToolset).
     """
-    import functools
 
     @functools.wraps(func)
     async def wrapper(self, *args, **kwargs):


### PR DESCRIPTION
## Summary

  Fix ADK Web `build_graph` serialization failure when loading VeADK agents backed by LiteLLM models.

  VeADK agents can carry runtime-only LiteLLM client objects inside the model structure. Google ADK Web's `/build_graph` endpoint serializes the agent graph as structured JSON, and the raw serialized
  model payload may include `llm_client`, which is not JSON serializable. This causes FastAPI/Pydantic response serialization to fail with a 500 error.

  ## Problem

  Accessing the ADK Web graph endpoint can fail:

  ```text
  GET /dev/apps/{app_name}/build_graph

  Error:

  PydanticSerializationError: Unable to serialize unknown type:
  <class 'google.adk.models.lite_llm.LiteLLMClient'>

  build_graph_image is not affected because it does not return the full structured agent graph JSON.

  ## Root Cause

  ADK's graph serialization uses serialize_agent() to produce the response payload for /build_graph.

  For VeADK agents, agent.model may be a LiteLLM model object. After ADK serializes it with model_dump(mode="python"), the result can include runtime client state such as llm_client. That object is
  useful at runtime but should not be exposed in the dev graph JSON response.

  ## Changes

  - Add a VeADK compatibility patch for ADK graph serialization.
  - Sanitize serialize_agent() output before FastAPI response serialization.
  - Preserve model display value as a string, for example:

  test_provider/test_model

  - Remove llm_client from serialized graph payloads.
  - Recursively sanitize nested dict/list/tuple/set values.
  - Enable the patch during VeADK Agent module initialization.
  - Add regression coverage to the existing frontend/dev web endpoint tests.

  ## Tests

  Added coverage in:

  tests/cli/test_frontend_trace.py

  Scenarios covered:

  - /dev/apps/demo_agent/build_graph returns 200
  - root agent model is serialized as a string
  - tool metadata is preserved
  - llm_client is not present in the response
  - nested sub-agent model values are also serialized safely

  Validated locally:

  uv run pre-commit run --files veadk/agent.py veadk/utils/patches.py tests/cli/test_frontend_trace.py

  ruff check Passed
  ruff format Passed
  Detect hardcoded secrets Passed

  python -m pytest tests/cli/test_frontend_trace.py -q

  5 passed

  ## Impact

  This only affects ADK Web dev graph JSON serialization. It does not change normal agent execution, model invocation, tool execution, tracing, or build_graph_image.

  The frontend can still consume agent name, model name, tools, and sub-agent graph information, while runtime-only client objects are excluded from the JSON response.