### PR TITLE
Fix Windows Studio deploy shell script line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Minified build artifacts can contain semantic whitespace inside template literals.
 veadk/webui/assets/*.js -whitespace
+*.sh text eol=lf

--- a/.github/workflows/windows-studio-smoke.yaml
+++ b/.github/workflows/windows-studio-smoke.yaml
@@ -75,6 +75,11 @@ jobs:
           uv pip install -e .
           .\.venv\Scripts\veadk.exe --version
 
+      - name: Run Studio deploy --from-source package check
+        shell: pwsh
+        run: |
+          uv run python -m pytest -q tests/cli/test_studio_deploy_target.py::test_studio_deploy_from_source_writes_lf_run_script
+
       - name: Start Studio repeatedly with --open
         shell: pwsh
         run: |

--- a/frontend/service/studio_release_server/publisher.py
+++ b/frontend/service/studio_release_server/publisher.py
@@ -442,7 +442,11 @@ def build_studio_release(
             dependency_wheels,
             env,
         )
-        (package_dir / "run.sh").write_text(_studio_run_script(), encoding="utf-8")
+        (package_dir / "run.sh").write_text(
+            _studio_run_script(),
+            encoding="utf-8",
+            newline="\n",
+        )
         (package_dir / "requirements.txt").write_text(requirements, encoding="utf-8")
         bundle = output_dir / f"studio-bundle-{version}.zip"
         _zip_directory(package_dir, bundle)

--- a/frontend/service/studio_scheduler/deploy.py
+++ b/frontend/service/studio_scheduler/deploy.py
@@ -193,6 +193,7 @@ def _stage_package(package_root: Path, destination: Path) -> None:
         "frontend.service.studio_scheduler.http_app:app "
         '--host 0.0.0.0 --port "${_FAAS_RUNTIME_PORT:-8000}"\n',
         encoding="utf-8",
+        newline="\n",
     )
     run_script.chmod(0o755)
 

--- a/tests/cli/test_studio_deploy_target.py
+++ b/tests/cli/test_studio_deploy_target.py
@@ -2257,3 +2257,72 @@ def test_studio_deploy_from_source_bundles_unmirrored_dependencies(
         (expected_prefix or expected_common_requirements)
         + "./veadk_python-test-py3-none-any.whl\n"
     )
+
+
+def test_studio_deploy_from_source_writes_lf_run_script(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, bytes] = {}
+
+    class _FakeCloudAgentEngine:
+        def __init__(self, **_: object) -> None:
+            pass
+
+        def deploy(self, **kwargs: object) -> SimpleNamespace:
+            deploy_path = Path(str(kwargs["path"]))
+            captured["run_script"] = (deploy_path / "run.sh").read_bytes()
+            return SimpleNamespace(
+                vefaas_endpoint="",
+                vefaas_application_id="app-id",
+                vefaas_function_id="",
+            )
+
+    def _fake_build(command: list[str], check: bool) -> None:
+        assert check is True
+        output_dir = Path(command[-1])
+        (output_dir / "veadk_python-test-py3-none-any.whl").write_bytes(b"wheel")
+
+    monkeypatch.setattr(
+        "veadk.cloud.cloud_agent_engine.CloudAgentEngine", _FakeCloudAgentEngine
+    )
+    monkeypatch.setattr(
+        "veadk.cli.cli_frontend._resolve_studio_identity_region",
+        lambda **kwargs: kwargs["deployment_region"],
+    )
+    monkeypatch.setattr(
+        "veadk.integrations.ve_identity.identity_client.IdentityClient.configure_user_pool_for_idp_only",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "veadk.cli.studio_package.stage_studio_dependency_wheels",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/uv")
+    monkeypatch.setattr("subprocess.run", _fake_build)
+
+    result = CliRunner().invoke(
+        studio,
+        [
+            "deploy",
+            "--user-pool-id",
+            "pool-id",
+            "--allowed-client-id",
+            "client-id",
+            "--vefaas-app-name",
+            "studio-app",
+            "--iam-role",
+            "trn:iam::role/test",
+            "--gateway-name",
+            "gateway",
+            "--volcengine-access-key",
+            "ak",
+            "--volcengine-secret-key",
+            "sk",
+            "--from-source",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["run_script"].startswith(b"#!/bin/bash\n")
+    assert b"\r\n" not in captured["run_script"]
+    assert b"/bin/bash\r" not in captured["run_script"]

--- a/veadk/cli/studio_package.py
+++ b/veadk/cli/studio_package.py
@@ -117,7 +117,9 @@ def write_studio_package(
         f"site-logo.{site_logo.extension}" if site_logo is not None else None
     )
     (package_dir / "run.sh").write_text(
-        studio_run_script(logo_filename, provider=provider), encoding="utf-8"
+        studio_run_script(logo_filename, provider=provider),
+        encoding="utf-8",
+        newline="\n",
     )
     if site_logo is not None and logo_filename is not None:
         (package_dir / logo_filename).write_bytes(site_logo.content)

--- a/veadk/cli/studio_self_update.py
+++ b/veadk/cli/studio_self_update.py
@@ -782,6 +782,7 @@ class StudioSelfUpdater:
         (package_dir / "run.sh").write_text(
             studio_run_script(filename, provider=self._settings.provider),
             encoding="utf-8",
+            newline="\n",
         )
         (package_dir / "run.sh").chmod(0o755)
 


### PR DESCRIPTION
## 背景

客户在 Windows 上执行 Studio 部署时，云端 VeFaaS 启动日志出现 `bash: ./run.sh: /bin/bash^M: bad interpreter`。这说明部署包中的 Linux entrypoint `run.sh` 被 Windows 文本写入转换成了 CRLF，导致 Linux 运行时无法识别 shebang。

## 修改内容

- 为 `veadk studio deploy` / `--from-source` 生成的 `run.sh` 强制使用 LF 换行。
- 同步修复 Studio self-update、Studio release bundle、scheduler deploy 中生成 `run.sh` 的同类隐患。
- 在 `.gitattributes` 中声明 `*.sh text eol=lf`，避免仓库内 shell 脚本在 Windows checkout 后变成 CRLF。
- 在 Windows Studio smoke workflow 中新增独立检查，覆盖 `studio deploy --from-source` 打包产物的 `run.sh` 换行格式。

## 验证

- `uv run python -m pytest -q tests/cli/test_studio_deploy_target.py::test_studio_deploy_from_source_writes_lf_run_script tests/cli/test_studio_self_update.py tests/frontend/service/studio_scheduler/test_scheduler_deploy.py`
- `uv run python -m pytest -q tests/test_studio_release_server.py`
- `uv run pre-commit run --files .gitattributes veadk/cli/studio_package.py veadk/cli/studio_self_update.py frontend/service/studio_release_server/publisher.py frontend/service/studio_scheduler/deploy.py`
- Windows Studio Smoke Test 手动运行通过：`https://github.com/FirstayZheng/veadk-python/actions/runs/32474255540`

## 说明

当前 CI 验证的是 Windows 本地打包链路，不会创建真实云资源；它精准覆盖本次 `/bin/bash^M` 问题的根因。