### PR TITLE
feat(studio): add opt-in local identity login

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -469,7 +469,11 @@ After automatic provisioning, the success summary lists every Sandbox type and
 Tool ID, the private Studio TOS address, and the resolved Identity user pool and
 client IDs. It also links to the matching Volcengine or BytePlus Identity
 console. Password sign-in remains disabled by default for security; configure
-an SSO identity provider before inviting users to the deployed Studio.
+an SSO identity provider before inviting users to the deployed Studio. Pass
+`--allow-dangerous-login` to explicitly enable local password, passwordless,
+sign-up, recovery, and unconfirmed-user login flows on a Studio-managed user
+pool. When `--user-pool-id` is provided, deployment preserves that existing
+user pool's login settings regardless of this flag.
 
 Studio checks `latest.json` every three minutes and lists newer releases with
 their changelog and Git SHA. An accepted update verifies the selected complete

--- a/tests/cli/test_studio_deploy_target.py
+++ b/tests/cli/test_studio_deploy_target.py
@@ -352,7 +352,14 @@ def test_studio_identity_resources_reject_client_without_pool() -> None:
 
 
 @pytest.mark.parametrize(
-    ("provider_args", "expected_region", "expected_provider", "dev_args"),
+    (
+        "provider_args",
+        "expected_region",
+        "expected_provider",
+        "dev_args",
+        "login_args",
+        "expected_login_mode",
+    ),
     [
         (
             [
@@ -366,6 +373,8 @@ def test_studio_identity_resources_reject_client_without_pool() -> None:
             "cn-beijing",
             "volcengine",
             ["--sandbox-dev-tool-id", "dev-tool"],
+            [],
+            "idp_only",
         ),
         (
             [
@@ -379,6 +388,8 @@ def test_studio_identity_resources_reject_client_without_pool() -> None:
             "cn-shanghai",
             "volcengine",
             ["--sandbox-dev-tool-id", "dev-tool"],
+            [],
+            "idp_only",
         ),
         (
             [
@@ -392,6 +403,23 @@ def test_studio_identity_resources_reject_client_without_pool() -> None:
             "ap-southeast-1",
             "byteplus",
             ["--sandbox-dev-tool-id", "dev-tool"],
+            [],
+            "idp_only",
+        ),
+        (
+            [
+                "--region",
+                "cn-beijing",
+                "--volcengine-access-key",
+                "ak",
+                "--volcengine-secret-key",
+                "sk",
+            ],
+            "cn-beijing",
+            "volcengine",
+            ["--sandbox-dev-tool-id", "dev-tool"],
+            ["--allow-dangerous-login"],
+            "local_login",
         ),
     ],
 )
@@ -401,6 +429,8 @@ def test_studio_deploy_auto_identity_is_injected_and_printed(
     expected_region: str,
     expected_provider: str,
     dev_args: list[str],
+    login_args: list[str],
+    expected_login_mode: str,
 ) -> None:
     captured: dict[str, object] = {}
     environments: dict[str, str] = {}
@@ -428,7 +458,10 @@ def test_studio_deploy_auto_identity_is_injected_and_printed(
             captured["callback"] = kwargs
 
         def configure_user_pool_for_idp_only(self, user_pool_uid: str) -> None:
-            captured["configured_user_pool"] = user_pool_uid
+            captured["configured_user_pool"] = ("idp_only", user_pool_uid)
+
+        def configure_user_pool_for_local_login(self, user_pool_uid: str) -> None:
+            captured["configured_user_pool"] = ("local_login", user_pool_uid)
 
     monkeypatch.setattr("veadk.config.veadk_environments", environments)
     monkeypatch.setattr(
@@ -461,6 +494,7 @@ def test_studio_deploy_auto_identity_is_injected_and_printed(
             "hermes-tool",
             *provider_args,
             *dev_args,
+            *login_args,
         ],
     )
 
@@ -478,8 +512,13 @@ def test_studio_deploy_auto_identity_is_injected_and_printed(
     assert "user pool id: pool-created" in result.output
     assert "user pool domain: identity.example.com" in result.output
     assert "client id: client-created" in result.output
-    assert captured["configured_user_pool"] == "pool-created"
-    assert "Configured the user pool for IdP-only sign-in." in result.output
+    assert captured["configured_user_pool"] == (expected_login_mode, "pool-created")
+    assert ("Configured the user pool for IdP-only sign-in." in result.output) == (
+        expected_login_mode == "idp_only"
+    )
+    assert ("WARNING: Enabled dangerous local account flows" in result.output) == (
+        expected_login_mode == "local_login"
+    )
     tos_domain = "bytepluses.com" if expected_provider == "byteplus" else "volces.com"
     identity_console = (
         "https://console.byteplus.com/identity"
@@ -497,8 +536,12 @@ def test_studio_deploy_auto_identity_is_injected_and_printed(
         in result.output
     )
     assert f"Identity console: {identity_console}" in result.output
-    assert "Password sign-in is disabled by default for security." in result.output
-    assert "Configure an SSO identity provider before inviting users." in result.output
+    assert (
+        "Password sign-in is disabled by default for security." in result.output
+    ) == (expected_login_mode == "idp_only")
+    assert ("Local account login flows are enabled." in result.output) == (
+        expected_login_mode == "local_login"
+    )
     callback_client = captured["callback_client"]
     assert isinstance(callback_client, dict)
     assert callback_client["enable_vefaas_iam_fallback"] is False
@@ -958,6 +1001,7 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
             "sk",
             "--volcengine-session-token",
             "sts-token",
+            "--allow-dangerous-login",
             *target_args,
         ],
     )
@@ -1019,6 +1063,8 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
     assert isinstance(callback, dict)
     assert callback["dismiss_login_page_enabled"] is False
     assert callback["skip_consent_enabled"] is True
+    assert "configured_user_pool" not in captured
+    assert "Preserved the existing Identity user pool login settings." in result.output
 
 
 def test_studio_deploy_persists_studio_context_environment(
@@ -2113,6 +2159,28 @@ def test_configure_user_pool_for_idp_only_disables_local_account_flows() -> None
         "SignUpAutoVerificationEnabled": False,
         "SmsPasswordlessSignInEnabled": False,
         "UnconfirmedUserSignInEnabled": False,
+        "UserPoolUid": "pool-id",
+    }
+
+
+def test_configure_user_pool_for_local_login_enables_local_account_flows() -> None:
+    identity_client = IdentityClient(
+        access_key="test_access_key",
+        secret_key="test_secret_key",
+    )
+    identity_client._api_client = Mock()
+
+    identity_client.configure_user_pool_for_local_login("pool-id")
+
+    update_request = identity_client._api_client.update_user_pool.call_args.args[0]
+    assert sanitize_for_serialization(update_request) == {
+        "EmailPasswordlessSignInEnabled": True,
+        "PasswordSignInEnabled": True,
+        "SelfAccountRecoveryEnabled": True,
+        "SelfSignUpEnabled": True,
+        "SignUpAutoVerificationEnabled": True,
+        "SmsPasswordlessSignInEnabled": True,
+        "UnconfirmedUserSignInEnabled": True,
         "UserPoolUid": "pool-id",
     }
 

--- a/tests/cli/test_studio_rbac.py
+++ b/tests/cli/test_studio_rbac.py
@@ -1960,6 +1960,7 @@ def test_studio_deploy_exposes_role_options() -> None:
     assert result.exit_code == 0
     assert "--admin" in result.output
     assert "--developer" in result.output
+    assert "--allow-dangerous-login" in result.output
     assert "Omit both role options to grant every user admin access" in " ".join(
         result.output.split()
     )

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -10520,6 +10520,14 @@ def _resolve_studio_cloud_credentials(
     help="Client secret, if it cannot be read back from the client UID.",
 )
 @click.option(
+    "--allow-dangerous-login",
+    is_flag=True,
+    default=False,
+    help="Enable local password, passwordless, sign-up, recovery, and "
+    "unconfirmed-user login flows on a Studio-managed Identity user pool. "
+    "Ignored when --user-pool-id is provided.",
+)
+@click.option(
     "--vefaas-app-name",
     required=True,
     help="VeFaaS application/function name (4-64 chars, letters/digits/-, no underscore).",
@@ -10698,6 +10706,7 @@ def frontend_deploy(
     user_pool_id: str | None,
     allowed_client_id: str | None,
     client_secret: str,
+    allow_dangerous_login: bool,
     vefaas_app_name: str,
     provider: str,
     region: str | None,
@@ -10787,6 +10796,7 @@ def frontend_deploy(
         if session_token:
             os.environ["BYTEPLUS_SESSION_TOKEN"] = session_token
 
+    manage_user_pool_settings = not bool((user_pool_id or "").strip())
     auto_identity_resources = not (user_pool_id and allowed_client_id)
     auto_storage = not str(
         veadk_environments.get("VEADK_STUDIO_TOS_BUCKET") or ""
@@ -11444,10 +11454,20 @@ def frontend_deploy(
             f"worker_timer={scheduler_worker_timer_id}"
         )
 
-        # 6) Disable local account flows so Studio can only be entered through
-        #    the configured identity provider.
-        identity_client.configure_user_pool_for_idp_only(user_pool_id)
-        click.echo("Configured the user pool for IdP-only sign-in.")
+        # 6) Only configure login flows on a Studio-managed user pool. Explicit
+        #    --user-pool-id values are customer-managed and must be preserved.
+        if manage_user_pool_settings:
+            if allow_dangerous_login:
+                identity_client.configure_user_pool_for_local_login(user_pool_id)
+                click.echo(
+                    "WARNING: Enabled dangerous local account flows on the "
+                    "Studio-managed user pool."
+                )
+            else:
+                identity_client.configure_user_pool_for_idp_only(user_pool_id)
+                click.echo("Configured the user pool for IdP-only sign-in.")
+        else:
+            click.echo("Preserved the existing Identity user pool login settings.")
 
         click.echo("")
         click.echo(f"✅ Frontend deployed: {url}")
@@ -11471,8 +11491,13 @@ def frontend_deploy(
             click.echo(f"   user pool id: {user_pool_id}")
             click.echo(f"   client id: {allowed_client_id}")
             click.echo(f"   Identity console: {identity_console}")
-            click.echo("   Password sign-in is disabled by default for security.")
-            click.echo("   Configure an SSO identity provider before inviting users.")
+            if manage_user_pool_settings and allow_dangerous_login:
+                click.echo("   Local account login flows are enabled.")
+            elif manage_user_pool_settings:
+                click.echo("   Password sign-in is disabled by default for security.")
+                click.echo(
+                    "   Configure an SSO identity provider before inviting users."
+                )
         click.echo("   (open the URL — you'll be redirected through SSO login)")
     finally:
         shutil.rmtree(tmp, ignore_errors=True)

--- a/veadk/integrations/ve_identity/identity_client.py
+++ b/veadk/integrations/ve_identity/identity_client.py
@@ -819,6 +819,23 @@ class IdentityClient:
         self._api_client.update_user_pool(request)
 
     @refresh_credentials
+    def configure_user_pool_for_local_login(self, user_pool_uid: str) -> None:
+        """Enable local sign-up, recovery, and sign-in for a user pool."""
+        from volcenginesdkid import UpdateUserPoolRequest
+
+        request = UpdateUserPoolRequest(
+            email_passwordless_sign_in_enabled=True,
+            password_sign_in_enabled=True,
+            self_account_recovery_enabled=True,
+            self_sign_up_enabled=True,
+            sign_up_auto_verification_enabled=True,
+            sms_passwordless_sign_in_enabled=True,
+            unconfirmed_user_sign_in_enabled=True,
+            user_pool_uid=user_pool_uid,
+        )
+        self._api_client.update_user_pool(request)
+
+    @refresh_credentials
     def list_user_pools(self, *, page_size: int = 100) -> list[dict[str, str]]:
         """List all user pools available to the current account."""
         from volcenginesdkid import ListUserPoolsRequest, ListUserPoolsResponse


### PR DESCRIPTION
## Summary

- add `--allow-dangerous-login` to enable all seven local account flows on Studio-managed Identity user pools
- preserve login settings on explicitly supplied user pools, regardless of the flag
- document the behavior and cover default, opt-in, and existing-pool paths

## Verification

- `uv run pre-commit run --files frontend/README.md tests/cli/test_studio_deploy_target.py tests/cli/test_studio_rbac.py veadk/cli/cli_frontend.py veadk/integrations/ve_identity/identity_client.py`
- `uv run pytest tests/cli/test_studio_deploy_target.py tests/cli/test_studio_rbac.py tests/cli/test_studio_deploy_serverless_iam.py tests/cli/test_frontend_branding.py` (153 passed)
- deployed managed and explicit-user-pool variants to Volcengine and BytePlus
- verified all seven local login switches enabled only for managed pools with the flag
- verified existing pool settings stayed unchanged and completed real SSO callbacks in both clouds