### PR TITLE
fix(studio): 支持 GetRuntime 隐藏场景下的 Runtime 连接

### DIFF
--- a/tests/cli/test_frontend_runtime_proxy.py
+++ b/tests/cli/test_frontend_runtime_proxy.py
@@ -378,26 +378,35 @@ def test_runtime_route_channel_connects_after_runtime_probe(
     )
     app = _create_frontend_app(monkeypatch, tmp_path)
 
+    runtime = SimpleNamespace(
+        runtime_id="runtime-1",
+        project_name="default",
+        network_configurations=[
+            SimpleNamespace(
+                endpoint="https://runtime.example",
+                network_type="public",
+            )
+        ],
+        authorizer_configuration=SimpleNamespace(
+            key_auth=SimpleNamespace(api_key="runtime-api-key"),
+            custom_jwt_authorizer=None,
+        ),
+        tags=[],
+    )
+
     class _FakeRuntimeClient:
         def __init__(self, **kwargs: Any) -> None:
             del kwargs
 
         def get_runtime(self, request: Any) -> SimpleNamespace:
             del request
+            raise RuntimeError("InvalidAgentKitRuntime.NotFound: hidden")
+
+        def list_runtimes(self, request: Any) -> SimpleNamespace:
+            del request
             return SimpleNamespace(
-                runtime_id="runtime-1",
-                project_name="default",
-                network_configurations=[
-                    SimpleNamespace(
-                        endpoint="https://runtime.example",
-                        network_type="public",
-                    )
-                ],
-                authorizer_configuration=SimpleNamespace(
-                    key_auth=SimpleNamespace(api_key="runtime-api-key"),
-                    custom_jwt_authorizer=None,
-                ),
-                tags=[],
+                agent_kit_runtimes=[runtime],
+                next_token=None,
             )
 
     monkeypatch.setattr(
@@ -419,6 +428,67 @@ def test_runtime_route_channel_connects_after_runtime_probe(
         "endpoint": "https://runtime.example",
         "authorization": "Bearer runtime-api-key",
     }
+
+
+def test_runtime_tool_capabilities_use_list_fallback_when_get_is_hidden(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app = _create_frontend_app(monkeypatch, tmp_path)
+    runtime = SimpleNamespace(
+        runtime_id="runtime-1",
+        network_configurations=[
+            SimpleNamespace(
+                endpoint="https://runtime.example",
+                network_type="public",
+            )
+        ],
+        authorizer_configuration=SimpleNamespace(
+            key_auth=SimpleNamespace(api_key="runtime-api-key"),
+            custom_jwt_authorizer=None,
+        ),
+        tags=[],
+    )
+
+    class _FakeRuntimeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            del kwargs
+
+        def get_runtime(self, request: Any) -> SimpleNamespace:
+            del request
+            raise RuntimeError("InvalidAgentKitRuntime.NotFound: hidden")
+
+        def list_runtimes(self, request: Any) -> SimpleNamespace:
+            del request
+            return SimpleNamespace(
+                agent_kit_runtimes=[runtime],
+                next_token=None,
+            )
+
+    monkeypatch.setattr(
+        "agentkit.sdk.runtime.client.AgentkitRuntimeClient",
+        _FakeRuntimeClient,
+    )
+
+    async def fake_runtime_supports_bff_tools(**kwargs: Any) -> bool:
+        assert kwargs == {
+            "endpoint": "https://runtime.example",
+            "authorization": "Bearer runtime-api-key",
+        }
+        return True
+
+    monkeypatch.setattr(
+        "frontend.server.studio_tools.runtime_supports_bff_tools",
+        fake_runtime_supports_bff_tools,
+    )
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/web/runtime-tool-channel/runtime-1/capabilities?region=cn-beijing"
+        )
+
+    assert response.status_code == 200
+    assert response.json()["supported"] is True
 
 
 def test_runtime_proxy_uses_plain_run_sse_when_runtime_lacks_bff_tool_host(
@@ -1748,6 +1818,150 @@ def test_runtime_proxy_retry_policy(
             if network_type == "private"
             else "runtime_proxy_connect_error"
         )
+
+
+@pytest.mark.parametrize(
+    "error_code",
+    ["InvalidResource.NotFound", "InvalidAgentKitRuntime.NotFound"],
+)
+def test_runtime_proxy_classifies_runtime_lookup_not_found_without_raw_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    error_code: str,
+) -> None:
+    app = _create_frontend_app(monkeypatch, tmp_path)
+
+    class _FakeRuntimeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            del kwargs
+
+        def get_runtime(self, request: Any) -> SimpleNamespace:
+            del request
+            raise RuntimeError(f"{error_code}: protected-upstream-detail")
+
+        def list_runtimes(self, request: Any) -> SimpleNamespace:
+            del request
+            return SimpleNamespace(
+                agent_kit_runtimes=[],
+                next_token=None,
+            )
+
+    monkeypatch.setattr(
+        "agentkit.sdk.runtime.client.AgentkitRuntimeClient",
+        _FakeRuntimeClient,
+    )
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/web/runtime-proxy/runtime-1/list-apps?_runtime_region=cn-shanghai"
+        )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "runtime_not_found"}
+    assert "protected-upstream-detail" not in response.text
+
+
+def test_runtime_proxy_uses_exact_list_item_when_role_get_runtime_is_hidden(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app = _create_frontend_app(monkeypatch, tmp_path)
+    list_requests: list[Any] = []
+
+    class _FakeRuntimeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            assert kwargs["region"] == "cn-shanghai"
+
+        def get_runtime(self, request: Any) -> SimpleNamespace:
+            del request
+            raise RuntimeError(
+                "InvalidAgentKitRuntime.NotFound: protected-upstream-detail"
+            )
+
+        def list_runtimes(self, request: Any) -> SimpleNamespace:
+            list_requests.append(request)
+            return SimpleNamespace(
+                agent_kit_runtimes=[
+                    SimpleNamespace(
+                        runtime_id="runtime-1",
+                        name="runtime-name",
+                        status="Ready",
+                        current_version_number=2,
+                        network_configurations=[
+                            SimpleNamespace(
+                                endpoint="https://runtime.example",
+                                network_type="public",
+                            )
+                        ],
+                        authorizer_configuration=SimpleNamespace(
+                            key_auth=SimpleNamespace(api_key="runtime-api-key"),
+                            custom_jwt_authorizer=None,
+                        ),
+                        tags=[],
+                    )
+                ],
+                next_token=None,
+            )
+
+    monkeypatch.setattr(
+        "agentkit.sdk.runtime.client.AgentkitRuntimeClient",
+        _FakeRuntimeClient,
+    )
+
+    class _FakeUpstreamResponse:
+        status_code = 200
+        headers: ClassVar[dict[str, str]] = {"content-type": "application/json"}
+
+        async def aiter_raw(self):
+            yield b'["demo_agent"]'
+
+        async def aclose(self) -> None:
+            pass
+
+    class _FakeAsyncClient:
+        def __init__(self, **kwargs: Any) -> None:
+            del kwargs
+
+        def build_request(
+            self,
+            method: str,
+            url: str,
+            *,
+            params: dict[str, str],
+            headers: dict[str, str],
+            content: bytes,
+        ) -> object:
+            assert method == "GET"
+            assert url == "https://runtime.example/list-apps"
+            assert params == {}
+            assert headers["Authorization"] == "Bearer runtime-api-key"
+            assert content == b""
+            return object()
+
+        async def send(
+            self,
+            request: object,
+            *,
+            stream: bool,
+        ) -> _FakeUpstreamResponse:
+            del request
+            assert stream is True
+            return _FakeUpstreamResponse()
+
+        async def aclose(self) -> None:
+            pass
+
+    monkeypatch.setattr("httpx.AsyncClient", _FakeAsyncClient)
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/web/runtime-proxy/runtime-1/list-apps"
+            "?_runtime_region=cn-shanghai&probe_retry=connect"
+        )
+
+    assert response.status_code == 200
+    assert response.json() == ["demo_agent"]
+    assert len(list_requests) == 1
 
 
 def test_runtime_proxy_resolves_studio_media_before_forwarding(

--- a/tests/cli/test_studio_rbac.py
+++ b/tests/cli/test_studio_rbac.py
@@ -2849,6 +2849,43 @@ def test_runtime_detail_proxy_and_delete_enforce_role_and_owner(
     assert deleted == ["runtime-developer", "runtime-other"]
 
 
+def test_runtime_proxy_list_fallback_still_enforces_runtime_owner(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from agentkit.sdk.runtime.client import AgentkitRuntimeClient
+
+    runtime = _runtime_with_public_endpoint(_runtime("runtime-other", "someone-else"))
+
+    def get_runtime(_self: Any, _request: Any) -> SimpleNamespace:
+        raise RuntimeError("InvalidAgentKitRuntime.NotFound: protected-detail")
+
+    def list_runtimes(_self: Any, _request: Any) -> SimpleNamespace:
+        return SimpleNamespace(
+            agent_kit_runtimes=[runtime],
+            next_token=None,
+        )
+
+    monkeypatch.setattr(AgentkitRuntimeClient, "get_runtime", get_runtime)
+    monkeypatch.setattr(AgentkitRuntimeClient, "list_runtimes", list_runtimes)
+    app = _create_studio_app(
+        monkeypatch,
+        tmp_path,
+        admins="admin",
+        developers="developer",
+    )
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/web/runtime-proxy/runtime-other/list-apps?region=cn-beijing",
+            headers={"X-VeADK-Local-User": "developer"},
+        )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "runtime_access_denied"
+    assert "protected-detail" not in response.text
+
+
 def test_agent_usage_requires_management_role_and_runtime_ownership(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/veadk/cli/agentkit_sandbox_region.py
+++ b/veadk/cli/agentkit_sandbox_region.py
@@ -24,7 +24,10 @@ from veadk.utils.cloud_provider import (
 
 _SANDBOX_REGIONS = ("cn-beijing", "cn-shanghai")
 _BYTEPLUS_SANDBOX_REGIONS = ("ap-southeast-1",)
-_RESOURCE_NOT_FOUND_CODE = "InvalidResource.NotFound"
+_RESOURCE_NOT_FOUND_CODES = (
+    "InvalidResource.NotFound",
+    "InvalidAgentKitRuntime.NotFound",
+)
 
 
 def sandbox_region_candidates(
@@ -66,4 +69,5 @@ def resolve_sandbox_client_region(region: str | None, *, provider: str) -> str:
 
 
 def is_agentkit_resource_not_found(error: object) -> bool:
-    return _RESOURCE_NOT_FOUND_CODE.lower() in str(error or "").lower()
+    message = str(error or "").lower()
+    return any(code.lower() in message for code in _RESOURCE_NOT_FOUND_CODES)

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -7294,6 +7294,47 @@ def _run_frontend_server(
         )
         return client.get_runtime(_rt.GetRuntimeRequest(runtime_id=runtime_id))
 
+    def _list_runtime_for_connection(
+        runtime_id: str,
+        region: str,
+    ) -> Any | None:
+        """Resolve an exact visible Runtime for connection-only access.
+
+        A VeFaaS service role can list an authorized Runtime while GetRuntime
+        hides the same resource behind NotFound. List entries still contain the
+        endpoint, authorizer, and ownership tags needed by data-plane routes.
+        Keep this fallback bounded and connection-only; mutation and full-detail
+        routes continue to require GetRuntime.
+        """
+        from agentkit.sdk.runtime import types as _rt
+        from agentkit.sdk.runtime.client import AgentkitRuntimeClient
+
+        ak, sk, token = _resolve_ve_credentials()
+        client = AgentkitRuntimeClient(
+            access_key=ak,
+            secret_key=sk,
+            session_token=token or "",
+            region=region,
+        )
+        matches: list[Any] = []
+        next_token = ""
+        for _ in range(20):
+            kwargs: dict[str, Any] = {"page_size": 100}
+            if next_token:
+                kwargs["next_token"] = next_token
+            response = client.list_runtimes(_rt.ListRuntimesRequest(**kwargs))
+            matches.extend(
+                runtime
+                for runtime in (response.agent_kit_runtimes or [])
+                if str(getattr(runtime, "runtime_id", "") or "") == runtime_id
+            )
+            if len(matches) > 1:
+                raise RuntimeError("duplicate Runtime identity in ListRuntimes")
+            next_token = str(getattr(response, "next_token", "") or "")
+            if not next_token:
+                break
+        return matches[0] if matches else None
+
     def _authorized_runtime(
         request: Request,
         runtime_id: str,
@@ -7317,6 +7358,43 @@ def _run_frontend_server(
             )
         if managed_only and tags.get("veadk:managed") != "true":
             raise HTTPException(status_code=404, detail="Runtime not found")
+        return runtime
+
+    def _authorized_runtime_for_connection(
+        request: Request,
+        runtime_id: str,
+        region: str,
+    ) -> Any:
+        try:
+            return _authorized_runtime(
+                request,
+                runtime_id,
+                region,
+                coded_access_error=True,
+            )
+        except HTTPException:
+            raise
+        except Exception as error:
+            if not is_agentkit_resource_not_found(error):
+                raise
+            runtime = _list_runtime_for_connection(runtime_id, region)
+            if runtime is None:
+                raise
+
+        principal = _current_principal(request)
+        role = _request_role(request)
+        tags = _runtime_tags(runtime)
+        if role != StudioRole.ADMIN and not runtime_belongs_to(tags, principal):
+            raise HTTPException(
+                status_code=404,
+                detail="runtime_access_denied",
+            )
+        logger.info(
+            "runtime connection metadata resolved through exact ListRuntimes "
+            "fallback runtime_id=%s region=%s",
+            runtime_id,
+            region,
+        )
         return runtime
 
     from frontend.server.cronjobs import (
@@ -8073,11 +8151,10 @@ def _run_frontend_server(
 
         region = _coerce_cloud_region(request.query_params.get("region"))
         try:
-            runtime = _authorized_runtime(
+            runtime = _authorized_runtime_for_connection(
                 request,
                 runtime_id,
                 region,
-                coded_access_error=True,
             )
             endpoint, apikey, auth_type, _ = _resolve_runtime_conn(
                 runtime_id,
@@ -8121,11 +8198,10 @@ def _run_frontend_server(
 
         region = _coerce_cloud_region(request.query_params.get("region"))
         try:
-            runtime = _authorized_runtime(
+            runtime = _authorized_runtime_for_connection(
                 request,
                 runtime_id,
                 region,
-                coded_access_error=True,
             )
             endpoint, apikey, auth_type, _ = _resolve_runtime_conn(
                 runtime_id,
@@ -8352,11 +8428,10 @@ def _run_frontend_server(
             proxy_region or request.query_params.get("region")
         )
         try:
-            runtime = _authorized_runtime(
+            runtime = _authorized_runtime_for_connection(
                 request,
                 runtime_id,
                 region,
-                coded_access_error=True,
             )
             endpoint, apikey, auth_type, endpoint_network_type = _resolve_runtime_conn(
                 runtime_id,
@@ -8365,9 +8440,27 @@ def _run_frontend_server(
             )
         except HTTPException:
             raise
-        except Exception as e:
-            logger.error(f"resolve runtime conn failed: {e}", exc_info=True)
-            raise HTTPException(status_code=502, detail=str(e))
+        except Exception as error:
+            if is_agentkit_resource_not_found(error):
+                logger.info(
+                    "runtime lookup not found runtime_id=%s region=%s",
+                    runtime_id,
+                    region,
+                )
+                raise HTTPException(
+                    status_code=404,
+                    detail="runtime_not_found",
+                ) from error
+            logger.error(
+                "resolve runtime conn failed runtime_id=%s region=%s",
+                runtime_id,
+                region,
+                exc_info=True,
+            )
+            raise HTTPException(
+                status_code=502,
+                detail="runtime_lookup_failed",
+            ) from error
 
         # Drop Studio-only query params; keep any real API query params.
         studio_query_params = {"probe_retry", "_method", "_runtime_region"}


### PR DESCRIPTION
## 背景

VeFaaS 服务角色可能可以通过 `ListRuntimes` 看到已授权的 Runtime，但 `GetRuntime` 会以 `InvalidAgentKitRuntime.NotFound` 隐藏同一资源，导致 Studio 的 Runtime Proxy、Tool Channel 和 Route Channel 无法建立连接。

## 改动

- 仅当 `GetRuntime` 明确返回 NotFound 时，在同地域分页调用 `ListRuntimes`，并按 Runtime ID 精确匹配。
- 使用 List 条目后重新执行现有 ownership 校验；详情、更新、删除等管理路径仍严格依赖 `GetRuntime`。
- 同时识别 `InvalidResource.NotFound` 与 `InvalidAgentKitRuntime.NotFound`。
- Runtime Proxy 对真实缺失返回稳定的 `runtime_not_found`，其他查询失败返回 `runtime_lookup_failed`，不再向浏览器透传上游异常原文。

## 验证

- `pytest -q tests/cli/test_frontend_runtime_proxy.py tests/cli/test_studio_rbac.py`：131 passed
- scoped pre-commit：Ruff check、Ruff format、hardcoded-secret scan 全部通过
- `git diff --check` 通过