### PR TITLE
fix(studio): enforce Google ADK floor for managed Sidecar

### DIFF
--- a/tests/cli/test_managed_sidecar_source.py
+++ b/tests/cli/test_managed_sidecar_source.py
@@ -46,14 +46,14 @@ def _package(root: Path) -> Path:
     return package
 
 
-def test_rewrite_uses_source_snapshot_and_pins_public_sdk() -> None:
+def test_rewrite_uses_source_snapshot_and_pins_runtime_dependencies() -> None:
     rewritten = rewrite_managed_sidecar_requirements(
         "\n".join(
             (
                 "veadk-python[harness-sidecar]>=1.1.1",
                 "agentkit_sdk_python>=0.8.0,<0.9.0",
                 "agentkit-harness-sidecar-integration==0.1.0",
-                "google-adk>=1.34.0",
+                "google_adk==1.23.0",
                 "mcp==1.20.0",
                 "",
             )
@@ -65,9 +65,10 @@ def test_rewrite_uses_source_snapshot_and_pins_public_sdk() -> None:
     assert "agentkit-harness-sidecar-integration" not in rewritten
     assert rewritten.splitlines()[1] == "agentkit-sdk-python==0.8.1"
     assert rewritten.splitlines().count("agentkit-sdk-python==0.8.1") == 1
-    assert "google-adk>=1.34.0" in rewritten
     assert rewritten.splitlines().count("mcp==1.26.0") == 1
     assert "mcp==1.20.0" not in rewritten
+    assert rewritten.splitlines().count("google-adk>=1.34.0") == 1
+    assert "google_adk==1.23.0" not in rewritten
 
 
 def test_rewrite_preserves_comments_and_rejects_missing_veadk() -> None:
@@ -118,6 +119,8 @@ def test_stage_copies_only_safe_runtime_source_and_rewrites_requirements(
     requirements = (project / "requirements.txt").read_text(encoding="utf-8")
     assert requirements.splitlines().count("agentkit-sdk-python==0.8.1") == 1
     assert requirements.splitlines().count("mcp==1.26.0") == 1
+    assert requirements.splitlines().count("google-adk>=1.34.0") == 1
+    assert "\ngoogle-adk\n" not in f"\n{requirements}"
     assert "veadk-python[" not in requirements
 
 

--- a/veadk/cli/managed_sidecar_source.py
+++ b/veadk/cli/managed_sidecar_source.py
@@ -26,11 +26,13 @@ _REQUIREMENT_NAME_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)")
 _REMOVED_DISTRIBUTIONS = {
     "agentkit-sdk-python",
     "agentkit-harness-sidecar-integration",
+    "google-adk",
     "mcp",
     "veadk-python",
 }
 _MANAGED_SDK_REQUIREMENT = "agentkit-sdk-python==0.8.1"
 _MANAGED_MCP_REQUIREMENT = "mcp==1.26.0"
+_MANAGED_ADK_REQUIREMENT = "google-adk>=1.34.0"
 _IGNORED_PARTS = {".git", "__pycache__", "webui"}
 _IGNORED_SUFFIXES = {".pyc", ".pyo"}
 _BLOCKED_SUFFIXES = {".key", ".p12", ".pem", ".pfx"}
@@ -68,7 +70,7 @@ def _canonical_requirement_name(line: str) -> str | None:
 
 
 def rewrite_managed_sidecar_requirements(requirements: str) -> str:
-    """Use in-snapshot VeADK and install the approved public SDK explicitly."""
+    """Use in-snapshot VeADK and install approved runtime dependencies."""
 
     lines: list[str] = []
     veadk_removed = False
@@ -84,6 +86,7 @@ def rewrite_managed_sidecar_requirements(requirements: str) -> str:
         "# veadk-python is provided by the Studio-managed public source snapshot.",
         _MANAGED_SDK_REQUIREMENT,
         _MANAGED_MCP_REQUIREMENT,
+        _MANAGED_ADK_REQUIREMENT,
         *lines,
     ]
     return "\n".join(lines).rstrip() + "\n"


### PR DESCRIPTION
## Summary

- Replace inherited bare or outdated `google-adk` requirements when staging managed Harness Sidecar builds.
- Enforce `google-adk>=1.34.0` so the current VeADK source can import `SkillToolset`.
- Keep ordinary non-Sidecar installation and runtime paths unchanged.

## Root cause

The managed base image already contains an older Google ADK version. A bare `google-adk` requirement was therefore considered satisfied, so the application build did not upgrade it. The Runtime then failed during startup because `google.adk.tools.skill_toolset` was unavailable.

## Verification

- `tests/cli/test_managed_sidecar_source.py`: 7 passed
- `tests/cli/test_studio_rbac.py`: 84 passed
- Ruff check/format, hardcoded-secret pre-commit, and `git diff --check` passed
- Built wheel verified to contain and use the `google-adk>=1.34.0` rewrite logic
