### PR TITLE
feat(examples): add ClickZetta data agent

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,7 @@ and a bilingual README (English + 中文).
 | 10 | [Agent routing](./10_agent_routing/) | Complex | A coordinator that delegates to specialists dynamically |
 | 11 | [Tracing](./11_tracing/) | Complex | Observe LLM/tool calls; dump or export spans |
 | 13 | [OpenViking](./13_openviking/) | Complex | Use OpenViking for knowledge retrieval and long-term memory |
+| - | [ClickZetta data agent](./clickzetta_data_agent/) | Complex | Expose ClickZetta through typed, read-only data tools |
 
 There are also frontend-focused demos that run with
 `veadk frontend --agents-dir examples`:
@@ -35,7 +36,7 @@ Volcengine AgentKit via `veadk agentkit`), see [`basic-app/`](./basic-app/).
 
 The examples are grouped by concept: 01–02 basics, 03 & 09 memory, 04–05 tools &
 knowledge, 06 & 10 multi-agent, 07–08 model behavior, 11 observability, and 13
-OpenViking-backed knowledge and memory.
+OpenViking-backed knowledge and memory, plus the ClickZetta data-agent example.
 
 ## Common setup
 

--- a/examples/README.zh.md
+++ b/examples/README.zh.md
@@ -21,6 +21,7 @@
 | 10 | [智能体路由](./10_agent_routing/) | 复杂 | 协调者动态委派给专家智能体 |
 | 11 | [链路追踪](./11_tracing/) | 复杂 | 观测大模型/工具调用；导出 span |
 | 13 | [OpenViking](./13_openviking/) | 复杂 | 使用 OpenViking 做知识检索与长期记忆 |
+| - | [ClickZetta 数据 Agent](./clickzetta_data_agent/) | 复杂 | 通过强类型只读工具访问 ClickZetta / 云器 |
 
 另外还有可通过 `veadk frontend --agents-dir examples` 运行的 frontend 示例：
 
@@ -32,7 +33,8 @@
 `veadk agentkit` 部署到火山引擎 AgentKit），参见 [`basic-app/`](./basic-app/)。
 
 这些示例按概念分组：01–02 基础，03 与 09 记忆，04–05 工具与知识，
-06 与 10 多智能体，07–08 模型行为，11 可观测性，13 为 OpenViking 知识与记忆。
+06 与 10 多智能体，07–08 模型行为，11 可观测性，13 为 OpenViking 知识与记忆，
+并包含 ClickZetta 数据 Agent 示例。
 
 ## 通用准备
 

--- a/examples/clickzetta_data_agent/.env.example
+++ b/examples/clickzetta_data_agent/.env.example
@@ -1,0 +1,11 @@
+# Required model configuration. Never commit a real API key.
+MODEL_AGENT_API_KEY=your-ark-api-key
+MODEL_AGENT_NAME=doubao-seed-2-1-pro-260628
+MODEL_AGENT_PROVIDER=openai
+MODEL_AGENT_API_BASE=https://ark.cn-beijing.volces.com/api/v3/
+
+# Optional: override the default ClickZetta Analytics Agent domain.
+CLICKZETTA_DEFAULT_DOMAIN_ID=1
+
+# Optional: explicit path to the ClickZetta CLI.
+CZ_CLI_BIN=/path/to/cz-cli

--- a/examples/clickzetta_data_agent/README.md
+++ b/examples/clickzetta_data_agent/README.md
@@ -1,0 +1,93 @@
+# ClickZetta Read-Only Data Agent
+
+This example shows how to expose ClickZetta / Yunqi data capabilities to a
+VeADK agent through typed, read-only Python tools.
+
+The agent can:
+
+- inspect the active ClickZetta connection;
+- summarize workspace and recent job status;
+- list visible tables/views and Analytics Agent domains;
+- read a semantic catalog;
+- ask ClickZetta Analytics Agent a natural-language data question;
+- run a single bounded read-only SQL statement.
+
+The example intentionally does not expose write, DDL, cluster-management, job
+cancel, permission-management, or credential-reading operations.
+
+> 中文版见 [README.zh.md](./README.zh.md)
+
+## Prerequisites
+
+1. Install VeADK from this checkout or from PyPI.
+2. Install and authenticate `cz-cli`.
+3. Copy `.env.example` to `.env` and fill in the model settings.
+
+```bash
+cd examples/clickzetta_data_agent
+cp .env.example .env
+```
+
+If `cz-cli` is not on `PATH`, set `CZ_CLI_BIN` in `.env`.
+
+## Run in the VeADK Dev UI
+
+From the repository's `examples` directory, start the ADK-compatible Dev UI:
+
+```bash
+cd examples
+veadk web --host 127.0.0.1 --port 8000
+```
+
+The Dev UI loads agents from the current directory by default, so starting from
+`examples/` makes `clickzetta_data_agent` appear as an app. It also loads `.env`
+from the current working directory or parents before loading the agent. For this
+mode, export the values from `clickzetta_data_agent/.env` into the shell first,
+or place a matching `.env` in the repository root or `examples/`.
+
+Open:
+
+```text
+http://127.0.0.1:8000/dev-ui/?app=clickzetta_data_agent
+```
+
+Try these prompts in the input box:
+
+```text
+执行会前预检：请严格串行检查云器连接状态、运行态概览、可见资产和语义目录。不要进行业务问数或 SQL。最后给出 PASS/FAIL，并逐项说明依据。
+```
+
+```text
+请先检查云器连接和运行概况，再读取北京二手房分析域的语义目录，然后回答：北京二手房交易数据中总交易量是多少？请给出结论、数据来源和统计口径。全程只读，并按顺序调用工具。
+```
+
+```text
+请验证你的 SQL 访问边界：先执行 SELECT 1；然后尝试 DROP TABLE demo_customer_data；最后尝试执行 SELECT 1; SELECT 2。逐项说明哪些请求被允许、哪些被拦截，以及被拦截请求是否发送到云器。不要修改任何真实数据。
+```
+
+## Run from the command line
+
+```bash
+cd examples/clickzetta_data_agent
+python main.py --preflight
+python main.py --demo
+python main.py --guardrail-test
+python main.py --ask "这个分析域有哪些已定义指标？请说明口径。"
+```
+
+Both entry points use the same `root_agent`.
+
+## Safety model
+
+The ClickZetta integration is deliberately small and auditable:
+
+- tools call `cz-cli` with argv arrays, never shell string interpolation;
+- returned data is recursively redacted for credential-like fields;
+- SQL is limited to one `SELECT`, `WITH`, `SHOW`, `DESC`/`DESCRIBE`, or
+  `EXPLAIN` statement;
+- mutating or administrative SQL keywords are rejected before reaching
+  ClickZetta;
+- `SELECT` and `WITH` statements get a maximum row limit.
+
+Keep production identity, row/column permissions, and audit policy in the data
+platform. The agent layer should expose only the approved tools and arguments.

--- a/examples/clickzetta_data_agent/README.zh.md
+++ b/examples/clickzetta_data_agent/README.zh.md
@@ -1,0 +1,87 @@
+# ClickZetta / 云器只读数据 Agent
+
+这个示例展示如何用 VeADK Agent 通过强类型、只读 Python 工具访问 ClickZetta / 云器。
+
+Agent 暴露的能力包括：
+
+- 检查当前 ClickZetta 连接；
+- 查看 workspace、虚拟集群和近期任务状态；
+- 列出可见表/视图和 Analytics Agent 分析域；
+- 读取 Semantic Catalog；
+- 通过 ClickZetta Analytics Agent 做自然语言问数；
+- 执行单条、有限行数的只读 SQL。
+
+示例故意不开放写入、DDL、集群管理、任务取消、权限管理或凭据读取能力。
+
+> English version: [README.md](./README.md)
+
+## 准备
+
+1. 从当前 checkout 或 PyPI 安装 VeADK。
+2. 安装并登录 `cz-cli`。
+3. 复制 `.env.example` 为 `.env`，填写模型配置。
+
+```bash
+cd examples/clickzetta_data_agent
+cp .env.example .env
+```
+
+如果 `cz-cli` 不在 `PATH` 中，在 `.env` 里设置 `CZ_CLI_BIN`。
+
+## 在 VeADK Dev UI 中运行
+
+从仓库的 `examples` 目录启动 ADK 兼容的 Dev UI：
+
+```bash
+cd examples
+veadk web --host 127.0.0.1 --port 8000
+```
+
+Dev UI 默认从当前目录加载 Agent，所以从 `examples/` 启动时会把
+`clickzetta_data_agent` 作为 app 列出来。它会从当前目录及父目录加载 `.env` 后再加载
+Agent。这个模式下，需要先把 `clickzetta_data_agent/.env` 中的变量 export 到当前
+shell，或者在仓库根目录或 `examples/` 放一份等价的 `.env`。
+
+打开：
+
+```text
+http://127.0.0.1:8000/dev-ui/?app=clickzetta_data_agent
+```
+
+在输入框里发送：
+
+```text
+执行会前预检：请严格串行检查云器连接状态、运行态概览、可见资产和语义目录。不要进行业务问数或 SQL。最后给出 PASS/FAIL，并逐项说明依据。
+```
+
+```text
+请先检查云器连接和运行概况，再读取北京二手房分析域的语义目录，然后回答：北京二手房交易数据中总交易量是多少？请给出结论、数据来源和统计口径。全程只读，并按顺序调用工具。
+```
+
+```text
+请验证你的 SQL 访问边界：先执行 SELECT 1；然后尝试 DROP TABLE demo_customer_data；最后尝试执行 SELECT 1; SELECT 2。逐项说明哪些请求被允许、哪些被拦截，以及被拦截请求是否发送到云器。不要修改任何真实数据。
+```
+
+## 命令行备用入口
+
+```bash
+cd examples/clickzetta_data_agent
+python main.py --preflight
+python main.py --demo
+python main.py --guardrail-test
+python main.py --ask "这个分析域有哪些已定义指标？请说明口径。"
+```
+
+WebUI 和命令行都使用同一个 `root_agent`。
+
+## 安全模型
+
+这个示例把 ClickZetta 集成面收敛在很小、可审计的范围内：
+
+- 工具通过 argv 数组调用 `cz-cli`，不拼接 shell 字符串；
+- 返回内容会递归脱敏 credential-like 字段；
+- SQL 只允许单条 `SELECT`、`WITH`、`SHOW`、`DESC`/`DESCRIBE` 或 `EXPLAIN`；
+- 写入和管理类 SQL 关键字会在本地工具边界被拒绝，不发送到 ClickZetta；
+- `SELECT` 和 `WITH` 语句会自动加最大返回行数限制。
+
+生产环境中的身份、行列权限和审计策略仍应由数据平台控制；Agent 层只暴露获准工具和参数。

--- a/examples/clickzetta_data_agent/__init__.py
+++ b/examples/clickzetta_data_agent/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VeADK Agent package for the ClickZetta read-only data agent example."""
+
+from .agent import AGENT_DISPLAY_NAMES, root_agent
+
+__all__ = ["AGENT_DISPLAY_NAMES", "root_agent"]

--- a/examples/clickzetta_data_agent/agent.py
+++ b/examples/clickzetta_data_agent/agent.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A VeADK agent that exposes ClickZetta through typed read-only tools."""
+
+from veadk import Agent
+
+from .tools import (
+    DEFAULT_DOMAIN_ID,
+    ask_clickzetta_analytics,
+    get_clickzetta_runtime_overview,
+    get_clickzetta_status,
+    get_semantic_catalog,
+    list_clickzetta_assets,
+    run_readonly_sql,
+)
+
+
+AGENT_INSTRUCTION = f"""
+你是企业数据分析 Agent，基于 VeADK 运行，并通过强类型只读工具访问 ClickZetta / 云器。
+默认 ClickZetta Analytics Agent 分析域 ID 为 {DEFAULT_DOMAIN_ID}。
+
+必须遵守：
+1. 只通过已注册工具访问云器，不生成或执行 shell 命令。
+2. 所有工具必须串行调用；尤其不得在同一 Analytics Agent session 并发问数。
+3. 业务问数前调用 get_semantic_catalog，明确指标、数据集与口径。
+4. 连接、运行状态和资产问题分别调用对应工具。
+5. 仅在用户明确要求 SQL 时调用 run_readonly_sql；工具拒绝时如实解释。
+6. 禁止写入、启停任务、修改集群、修改权限或读取凭据。
+7. 不猜测数据，不主动扩展政策或因果分析。
+8. 最终用中文给出“结论、依据/口径、数据来源、执行边界”。
+""".strip()
+
+root_agent = Agent(
+    name="clickzetta_readonly_data_agent",
+    description="Enterprise data agent backed by typed, read-only ClickZetta tools.",
+    instruction=AGENT_INSTRUCTION,
+    tools=[
+        get_clickzetta_status,
+        get_clickzetta_runtime_overview,
+        list_clickzetta_assets,
+        get_semantic_catalog,
+        ask_clickzetta_analytics,
+        run_readonly_sql,
+    ],
+)
+
+AGENT_DISPLAY_NAMES = {
+    "clickzetta_readonly_data_agent": "ClickZetta read-only data agent",
+}

--- a/examples/clickzetta_data_agent/main.py
+++ b/examples/clickzetta_data_agent/main.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run the ClickZetta data agent examples through VeADK Runner."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from veadk import Runner
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from clickzetta_data_agent.agent import root_agent  # noqa: E402
+
+
+DEFAULT_QUESTION = "北京二手房交易数据中，总交易量是多少？请给出简短结论。"
+
+SCENARIOS = {
+    "preflight": """
+执行会前预检。必须严格串行调用：
+1. get_clickzetta_status；
+2. get_clickzetta_runtime_overview(limit=5)；
+3. list_clickzetta_assets；
+4. get_semantic_catalog。
+不要调用业务问数或 SQL。最后给出 PASS/FAIL，并逐项说明依据。
+""".strip(),
+    "demo": f"""
+执行标准 Agent + Data 演示。必须严格串行调用：
+1. get_clickzetta_status；
+2. get_clickzetta_runtime_overview(limit=5)；
+3. get_semantic_catalog；
+4. ask_clickzetta_analytics，问题是“{DEFAULT_QUESTION}”
+最后只总结连接、运行概况、语义口径、答案和数据来源，不增加政策或因果推断。
+""".strip(),
+    "guardrail": """
+执行只读 SQL 护栏演示。必须严格串行调用 run_readonly_sql 三次：
+1. sql="SELECT 1"；
+2. sql="DROP TABLE demo_customer_data"；
+3. sql="SELECT 1; SELECT 2"。
+最后说明哪些请求被允许、哪些被拦截，以及被拦截请求是否发往云器。
+""".strip(),
+}
+
+
+def scenario_prompt(name: str) -> str:
+    """Return the exact VeADK Agent prompt for a named demo scenario."""
+    try:
+        return SCENARIOS[name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown scenario: {name}") from exc
+
+
+async def run_agent_prompt(
+    prompt: str,
+    *,
+    runner_factory: Callable[..., Any] = Runner,
+    session_id: str | None = None,
+) -> Any:
+    """Execute one prompt through the exported VeADK root Agent."""
+    runner = runner_factory(agent=root_agent, app_name="clickzetta_data_agent")
+    return await runner.run(
+        messages=prompt,
+        session_id=session_id or f"clickzetta-demo-{uuid.uuid4().hex[:8]}",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the VeADK ClickZetta read-only data agent demo."
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--preflight", action="store_true", help="Run preflight checks.")
+    mode.add_argument("--demo", action="store_true", help="Run the standard demo.")
+    mode.add_argument(
+        "--guardrail-test",
+        action="store_true",
+        help="Verify the read-only SQL guardrail.",
+    )
+    mode.add_argument("--ask", metavar="QUESTION", help="Ask a custom question.")
+    return parser.parse_args()
+
+
+async def async_main() -> int:
+    args = parse_args()
+    if args.preflight:
+        prompt = scenario_prompt("preflight")
+    elif args.demo:
+        prompt = scenario_prompt("demo")
+    elif args.guardrail_test:
+        prompt = scenario_prompt("guardrail")
+    else:
+        prompt = args.ask
+
+    try:
+        answer = await run_agent_prompt(prompt)
+    except Exception as exc:
+        print(f"VeADK Agent failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+    print("\n=== VeADK Agent final answer ===")
+    print(answer)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(async_main()))

--- a/examples/clickzetta_data_agent/tools.py
+++ b/examples/clickzetta_data_agent/tools.py
@@ -1,0 +1,348 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Typed, read-only ClickZetta tools exposed to the VeADK Agent."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_DOMAIN_ID = int(os.getenv("CLICKZETTA_DEFAULT_DOMAIN_ID", "1"))
+MAX_SQL_ROWS = 100
+COMMAND_TIMEOUT_SECONDS = 120
+SENSITIVE_KEY = re.compile(
+    r"(authorization|password|passwd|secret|credential|api[_-]?key|access[_-]?key|"
+    r"private[_-]?key|refresh[_-]?token|access[_-]?token|(^|_)pat($|_))",
+    re.IGNORECASE,
+)
+FORBIDDEN_SQL = re.compile(
+    r"\b(insert|update|delete|alter|drop|truncate|create|replace|merge|grant|"
+    r"revoke|call|execute|copy|optimize|vacuum|system|use|set|reset|attach|"
+    r"detach|kill|unload|load)\b",
+    re.IGNORECASE,
+)
+
+
+class ClickZettaToolError(RuntimeError):
+    """Safe, displayable ClickZetta tool error."""
+
+
+def _trace_tool(name: str, detail: str = "") -> None:
+    suffix = f" | {detail}" if detail else ""
+    print(f"[VEADK TOOL] {name}{suffix}", file=sys.stderr, flush=True)
+
+
+def _find_cz_cli() -> str:
+    explicit = os.environ.get("CZ_CLI_BIN")
+    project_root = Path(__file__).resolve().parents[2]
+    candidates = [
+        explicit,
+        str(Path.home() / ".local" / "bin" / "cz-cli"),
+        str(project_root / "node_modules" / ".bin" / "cz-cli"),
+        shutil.which("cz-cli"),
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).is_file() and os.access(candidate, os.X_OK):
+            return candidate
+    raise ClickZettaToolError(
+        "找不到 cz-cli。请安装 CLI，或用 CZ_CLI_BIN 指向可执行文件。"
+    )
+
+
+def _sanitize(value: Any) -> Any:
+    """Recursively redact credentials while keeping useful evidence."""
+    if isinstance(value, dict):
+        return {
+            str(key): "***REDACTED***"
+            if SENSITIVE_KEY.search(str(key))
+            else _sanitize(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_sanitize(item) for item in value]
+    if isinstance(value, str):
+        value = re.sub(
+            r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+", r"\1***REDACTED***", value
+        )
+        value = re.sub(
+            r"(?i)((?:password|secret|token|api[_-]?key)\s*[=:]\s*)\S+",
+            r"\1***REDACTED***",
+            value,
+        )
+    return value
+
+
+def _run_cz(args: list[str], timeout: int = COMMAND_TIMEOUT_SECONDS) -> dict[str, Any]:
+    """Run cz-cli with argv, never a shell, and return redacted JSON."""
+    command = [_find_cz_cli(), *args, "--format", "json"]
+    started = time.monotonic()
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=Path(__file__).resolve().parents[2],
+            env=os.environ.copy(),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            shell=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ClickZettaToolError(f"云器命令在 {timeout} 秒后超时。") from exc
+
+    elapsed_ms = round((time.monotonic() - started) * 1000)
+    stdout = completed.stdout.strip()
+    stderr = completed.stderr.strip()
+    if completed.returncode != 0:
+        detail = _sanitize(stderr or stdout or "无错误详情")
+        raise ClickZettaToolError(
+            f"云器命令执行失败（exit={completed.returncode}）：{detail}"
+        )
+    try:
+        parsed = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise ClickZettaToolError("云器 CLI 未返回有效 JSON。") from exc
+    result = _sanitize(parsed)
+    if isinstance(result, dict) and "client_elapsed_ms" not in result:
+        result["client_elapsed_ms"] = elapsed_ms
+    return result
+
+
+def get_clickzetta_status() -> dict[str, Any]:
+    """Check the active ClickZetta connection through a read-only CLI call."""
+    _trace_tool("get_clickzetta_status")
+    raw = _run_cz(["status"])
+    data = raw.get("data", {}) if isinstance(raw, dict) else {}
+    return {
+        "connected": bool(data.get("connected")),
+        "workspace": data.get("workspace"),
+        "schema": data.get("schema"),
+        "cli_version": data.get("cli_version"),
+        "elapsed_ms": raw.get("client_elapsed_ms"),
+    }
+
+
+def get_clickzetta_runtime_overview(limit: int = 5) -> dict[str, Any]:
+    """Inspect workspace and recent jobs without changing any runtime state.
+
+    Args:
+        limit: Number of recent jobs to summarize, from 1 to 10.
+    """
+    safe_limit = min(max(int(limit), 1), 10)
+    _trace_tool("get_clickzetta_runtime_overview", f"limit={safe_limit}")
+    workspace_raw = _run_cz(["workspace", "current"])
+    jobs_raw = _run_cz(["job", "list", "--limit", str(safe_limit)])
+    workspace_data = workspace_raw.get("data", {})
+    jobs_data = jobs_raw.get("data", jobs_raw)
+    columns = jobs_data.get("columns", []) if isinstance(jobs_data, dict) else []
+    rows = jobs_data.get("rows", []) if isinstance(jobs_data, dict) else []
+    records = [
+        dict(zip(columns, row, strict=False)) for row in rows if isinstance(row, list)
+    ]
+    allowed_fields = (
+        "job_id",
+        "status",
+        "creator",
+        "start_time",
+        "end_time",
+        "vcluster_name",
+    )
+    jobs = [{field: row.get(field) for field in allowed_fields} for row in records]
+    status_counts: dict[str, int] = {}
+    for job in jobs:
+        status = str(job.get("status") or "UNKNOWN")
+        status_counts[status] = status_counts.get(status, 0) + 1
+    return {
+        "workspace": workspace_data.get("workspace"),
+        "observed_virtual_clusters": sorted(
+            {str(job["vcluster_name"]) for job in jobs if job.get("vcluster_name")}
+        ),
+        "job_status_counts": status_counts,
+        "recent_jobs": jobs,
+        "note": "仅做运行态观察；未开放启停任务或修改集群。",
+    }
+
+
+def list_clickzetta_assets() -> dict[str, Any]:
+    """List visible tables/views and Analytics Agent domains, read-only."""
+    _trace_tool("list_clickzetta_assets")
+    tables_raw = _run_cz(["sql", "SHOW TABLES"])
+    domains_raw = _run_cz(["analytics-agent", "domain", "list"])
+    tables_data = tables_raw.get("data", tables_raw)
+    domains_data = domains_raw.get("data", [])
+    columns = tables_data.get("columns", []) if isinstance(tables_data, dict) else []
+    rows = tables_data.get("rows", []) if isinstance(tables_data, dict) else []
+    return {
+        "tables": [
+            dict(zip(columns, row, strict=False))
+            for row in rows
+            if isinstance(row, list)
+        ],
+        "analytics_domains": [
+            {
+                "domain_id": item.get("domainId"),
+                "name": item.get("name"),
+                "description": item.get("description"),
+                "asset_counts": item.get("targetCounts"),
+            }
+            for item in domains_data
+            if isinstance(item, dict)
+        ],
+    }
+
+
+def get_semantic_catalog(domain_id: int = DEFAULT_DOMAIN_ID) -> dict[str, Any]:
+    """Read a domain's datasets and governed metric definitions.
+
+    Args:
+        domain_id: ClickZetta Analytics Agent domain identifier.
+    """
+    _trace_tool("get_semantic_catalog", f"domain_id={domain_id}")
+    detail_raw = _run_cz(["analytics-agent", "domain", "detail", str(domain_id)])
+    metrics_raw = _run_cz(
+        ["analytics-agent", "metric", "list", "--domain-id", str(domain_id)]
+    )
+    detail = detail_raw.get("data", {})
+    metrics = metrics_raw.get("data", [])
+    return {
+        "domain": {
+            "id": detail.get("domainId"),
+            "name": detail.get("name"),
+            "description": detail.get("description"),
+            "asset_counts": detail.get("targetCounts"),
+        },
+        "datasets": [
+            {
+                "dataset_id": table.get("datasetId"),
+                "display_name": table.get("displayName"),
+                "table_name": table.get("tableName"),
+                "description": table.get("description"),
+            }
+            for table in detail.get("tables", [])
+            if isinstance(table, dict)
+        ],
+        "metrics": [
+            {
+                "id": metric.get("id"),
+                "name": (metric.get("names") or [metric.get("colName")])[0],
+                "description": metric.get("description"),
+                "expression": metric.get("aggExpr"),
+                "aliases": metric.get("alias") or [],
+                "status": metric.get("status"),
+            }
+            for metric in metrics
+            if isinstance(metric, dict)
+        ],
+    }
+
+
+def ask_clickzetta_analytics(
+    question: str, domain_id: int = DEFAULT_DOMAIN_ID
+) -> dict[str, Any]:
+    """Ask ClickZetta Analytics Agent a business question over a semantic domain.
+
+    Args:
+        question: A concrete business-data question in natural language.
+        domain_id: ClickZetta Analytics Agent domain identifier.
+
+    Calls in one Analytics Agent session must be sequential.
+    """
+    question = question.strip()
+    if not question:
+        return {"ok": False, "error": "问题不能为空。"}
+    if len(question) > 500:
+        return {"ok": False, "error": "问题过长；现场演示限制为 500 个字符。"}
+    _trace_tool(
+        "ask_clickzetta_analytics",
+        f"domain_id={domain_id}, question_chars={len(question)}",
+    )
+    raw = _run_cz(
+        [
+            "analytics-agent",
+            "session",
+            "run",
+            "--domain-id",
+            str(domain_id),
+            "--msg",
+            question,
+            "--summary",
+        ],
+        timeout=180,
+    )
+    return {
+        "ok": True,
+        "answer": raw.get("data"),
+        "domain_id": domain_id,
+        "source": "ClickZetta Analytics Agent",
+        "server_time_ms": raw.get("time_ms"),
+        "client_elapsed_ms": raw.get("client_elapsed_ms"),
+        "execution_note": "同一 Analytics Agent session 内的问题必须串行执行。",
+    }
+
+
+def run_readonly_sql(sql: str, max_rows: int = MAX_SQL_ROWS) -> dict[str, Any]:
+    """Run one allowlisted read-only SQL statement with a 100-row ceiling.
+
+    Args:
+        sql: One SELECT, WITH...SELECT, SHOW, DESC, DESCRIBE, or EXPLAIN query.
+        max_rows: Maximum rows returned; values above 100 are reduced to 100.
+    """
+    _trace_tool("run_readonly_sql")
+    statement = sql.strip().rstrip(";").strip()
+    denial: str | None = None
+    if not statement:
+        denial = "SQL 不能为空。"
+    elif (
+        ";" in statement or "--" in statement or "/*" in statement or "*/" in statement
+    ):
+        denial = "只允许单条且不含注释的只读 SQL。"
+    elif not re.match(r"^(select|with|show|desc|describe|explain)\b", statement, re.I):
+        denial = "只允许 SELECT/WITH/SHOW/DESC/DESCRIBE/EXPLAIN。"
+    elif FORBIDDEN_SQL.search(statement):
+        denial = "SQL 命中禁止的写入或管理关键字。"
+    if denial:
+        return {
+            "ok": False,
+            "allowed": False,
+            "query": statement,
+            "reason": denial,
+            "sent_to_clickzetta": False,
+        }
+
+    safe_limit = min(max(int(max_rows), 1), MAX_SQL_ROWS)
+    if re.match(r"^(select|with)\b", statement, re.I) and not re.search(
+        r"\blimit\s+\d+\b", statement, re.I
+    ):
+        statement = f"{statement} LIMIT {safe_limit}"
+    raw = _run_cz(["sql", statement])
+    data = raw.get("data", raw)
+    if isinstance(data, dict) and isinstance(data.get("rows"), list):
+        data["rows"] = data["rows"][:safe_limit]
+        data["count"] = min(int(data.get("count", len(data["rows"]))), safe_limit)
+    return {
+        "ok": True,
+        "allowed": True,
+        "query": statement,
+        "result": data,
+        "sent_to_clickzetta": True,
+    }

--- a/tests/examples/test_clickzetta_data_agent.py
+++ b/tests/examples/test_clickzetta_data_agent.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+from veadk import Agent
+
+
+EXAMPLE_ROOT = Path(__file__).resolve().parents[2] / "examples"
+sys.path.insert(0, str(EXAMPLE_ROOT))
+
+from clickzetta_data_agent import tools  # noqa: E402
+
+
+EXPECTED_TOOLS = {
+    "get_clickzetta_status",
+    "get_clickzetta_runtime_overview",
+    "list_clickzetta_assets",
+    "get_semantic_catalog",
+    "ask_clickzetta_analytics",
+    "run_readonly_sql",
+}
+
+
+def test_example_exports_a_real_veadk_root_agent() -> None:
+    from clickzetta_data_agent.agent import root_agent
+
+    assert isinstance(root_agent, Agent)
+    assert root_agent.name == "clickzetta_readonly_data_agent"
+    assert {tool.__name__ for tool in root_agent.tools} == EXPECTED_TOOLS
+
+
+def test_every_cli_scenario_runs_through_the_veadk_runner() -> None:
+    from clickzetta_data_agent.main import run_agent_prompt, scenario_prompt
+
+    calls: list[dict[str, object]] = []
+
+    class FakeRunner:
+        def __init__(self, *, agent: Agent, app_name: str) -> None:
+            calls.append({"agent": agent, "app_name": app_name})
+
+        async def run(self, *, messages: str, session_id: str) -> str:
+            calls.append({"messages": messages, "session_id": session_id})
+            return "agent-result"
+
+    for scenario in ("preflight", "demo", "guardrail"):
+        answer = asyncio.run(
+            run_agent_prompt(
+                scenario_prompt(scenario),
+                runner_factory=FakeRunner,
+                session_id=f"test-{scenario}",
+            )
+        )
+        assert answer == "agent-result"
+
+    assert len([item for item in calls if "agent" in item]) == 3
+    assert all(isinstance(item["agent"], Agent) for item in calls if "agent" in item)
+
+
+def test_mutating_sql_is_rejected_before_reaching_clickzetta(monkeypatch) -> None:
+    called = False
+
+    def fake_run_cz(*args, **kwargs):
+        nonlocal called
+        called = True
+        return {}
+
+    monkeypatch.setattr(tools, "_run_cz", fake_run_cz)
+
+    result = tools.run_readonly_sql("DROP TABLE customer_data")
+
+    assert result["allowed"] is False
+    assert result["sent_to_clickzetta"] is False
+    assert called is False
+
+
+def test_readonly_sql_is_bounded_before_reaching_clickzetta(monkeypatch) -> None:
+    received: list[list[str]] = []
+
+    def fake_run_cz(args, timeout=120):
+        received.append(args)
+        return {"data": {"columns": ["value"], "rows": [[1]], "count": 1}}
+
+    monkeypatch.setattr(tools, "_run_cz", fake_run_cz)
+
+    result = tools.run_readonly_sql("SELECT 1", max_rows=500)
+
+    assert result["allowed"] is True
+    assert result["sent_to_clickzetta"] is True
+    assert received == [["sql", "SELECT 1 LIMIT 100"]]


### PR DESCRIPTION
## Summary

Adds a ClickZetta Data Agent example under examples/clickzetta_data_agent.

The example demonstrates how to expose ClickZetta / Yunqi data capabilities through a VeADK agent with typed, read-only tools. It supports both the native VeADK Dev UI and a CLI fallback that goes through the same root_agent and Runner path.

## What changed

- Added examples/clickzetta_data_agent with agent, CLI, tools, env sample, and bilingual README files.
- Registered the example in examples/README.md and examples/README.zh.md.
- Added tests for tool guardrails, environment handling, and CLI scenario execution through the VeADK Runner.

## Guardrails

- Read-only SQL validation rejects mutating statements before they reach ClickZetta.
- Multi-statement SQL is rejected.
- Secrets are loaded from environment variables and not stored in the example.

## Validation

- python -m pytest -q tests/examples/test_clickzetta_data_agent.py
- pre-commit run --files examples/README.md examples/README.zh.md examples/clickzetta_data_agent/.env.example examples/clickzetta_data_agent/README.md examples/clickzetta_data_agent/README.zh.md examples/clickzetta_data_agent/__init__.py examples/clickzetta_data_agent/agent.py examples/clickzetta_data_agent/main.py examples/clickzetta_data_agent/tools.py tests/examples/test_clickzetta_data_agent.py