### PR TITLE
fix(studio): disable gateway-wide CORS

### DIFF
--- a/tests/cli/test_studio_deploy_target.py
+++ b/tests/cli/test_studio_deploy_target.py
@@ -1284,7 +1284,10 @@ def test_studio_deploy_byteplus_wires_provider_to_cloud_engine_and_package(
     assert identity["provider"] == "byteplus"
     assert identity["region"] == "ap-southeast-1"
     assert identity["enable_vefaas_iam_fallback"] is False
-    assert captured["deploy"]["enable_mcp_session"] is False
+    deploy = captured["deploy"]
+    assert isinstance(deploy, dict)
+    assert deploy["enable_mcp_session"] is False
+    assert deploy["disable_gateway_cors"] is True
     assert "--provider byteplus --auth-mode frontend" in str(captured["run_script"])
     assert str(captured["requirements"]).startswith(
         "./pydantic-2.12.5-py3-none-any.whl\n"

--- a/tests/cli/test_studio_update.py
+++ b/tests/cli/test_studio_update.py
@@ -17,7 +17,7 @@ import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import ANY
+from unittest.mock import ANY, Mock
 
 import httpx
 import pytest
@@ -482,6 +482,7 @@ def test_studio_update_preserves_branding_and_updates_existing_ids(
     assert isinstance(update, dict)
     assert update["application_id"] == "app-id"
     assert update["function_id"] == "function-app-id"
+    assert update["disable_gateway_cors"] is True
     assert update["environment_overrides"] == {
         "AGENTKIT_SANDBOX_REGION": "cn-beijing",
         "VEADK_STUDIO_CRONJOB_SCHEDULER_BASE": "studio-app",
@@ -1231,12 +1232,15 @@ def test_update_application_code_bundle_merges_only_explicit_environment(
     )
     monkeypatch.setattr(service, "_upload_and_mount_code", lambda *_: None)
     monkeypatch.setattr(service, "_release_application", lambda _: "https://same")
+    ensure_route = Mock()
+    monkeypatch.setattr(service, "ensure_application_route_methods", ensure_route)
 
     url = service.update_application_code_bundle(
         application_id="app-id",
         function_id="function-id",
         path=str(tmp_path),
         environment_overrides={"VEADK_SITE_TITLE": "新标题"},
+        disable_gateway_cors=True,
     )
 
     assert url == "https://same"
@@ -1246,6 +1250,7 @@ def test_update_application_code_bundle_merges_only_explicit_environment(
         "EXISTING": "kept",
         "VEADK_SITE_TITLE": "新标题",
     }
+    ensure_route.assert_called_once_with("app-id", disable_cors=True)
 
 
 def test_application_operations_use_deployment_region(

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -15,6 +15,7 @@
 import os
 import tempfile
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -120,7 +121,9 @@ def test_vefaas_passes_session_token_to_apig() -> None:
     )
 
 
-def test_vefaas_application_route_adds_patch_without_losing_configuration() -> None:
+def _vefaas_with_application_route(
+    *, methods: list[str], cors_enabled: bool
+) -> tuple[VeFaaS, Mock]:
     service = object.__new__(VeFaaS)
     service.get_application_route = Mock(
         return_value=("gateway-id", "service-id", "route-id")
@@ -131,7 +134,7 @@ def test_vefaas_application_route_adds_patch_without_losing_configuration() -> N
         enable=True,
         priority=100,
         match_rule=SimpleNamespace(
-            method=["GET", "POST"],
+            method=methods,
             path=SimpleNamespace(match_content="/", match_type="Prefix"),
         ),
         upstream_list=[
@@ -148,7 +151,7 @@ def test_vefaas_application_route_adds_patch_without_losing_configuration() -> N
                 allow_headers=["*"],
                 allow_methods=["GET", "POST"],
                 allow_origins=[SimpleNamespace(match_type="regex", value=".*")],
-                enable=True,
+                enable=cors_enabled,
                 expose_headers=None,
                 max_age=None,
             ),
@@ -159,11 +162,18 @@ def test_vefaas_application_route_adds_patch_without_losing_configuration() -> N
     get_route.return_value.get.return_value = SimpleNamespace(route=route)
     update_route = Mock()
     update_route.return_value.get.return_value = None
-    service.apig_client = SimpleNamespace(
+    cast(Any, service).apig_client = SimpleNamespace(
         apig_20221112_client=SimpleNamespace(
             get_route=get_route,
             update_route=update_route,
         )
+    )
+    return service, update_route
+
+
+def test_vefaas_application_route_adds_patch_without_losing_configuration() -> None:
+    service, update_route = _vefaas_with_application_route(
+        methods=["GET", "POST"], cors_enabled=True
     )
 
     assert service.ensure_application_route_methods("application-id") is True
@@ -176,6 +186,63 @@ def test_vefaas_application_route_adds_patch_without_losing_configuration() -> N
         "POST",
         "PATCH",
     ]
+    assert request.advanced_setting.cors_policy_setting.allow_origins[0].value == ".*"
+    assert request.advanced_setting.cors_policy_setting.allow_credentials is True
+    assert request.advanced_setting.cors_policy_setting.enable is True
+
+
+def test_vefaas_application_route_disables_cors_when_methods_are_present() -> None:
+    service, update_route = _vefaas_with_application_route(
+        methods=["GET", "POST", "PATCH"], cors_enabled=True
+    )
+
+    assert (
+        service.ensure_application_route_methods("application-id", disable_cors=True)
+        is True
+    )
+
+    request = update_route.call_args.args[0]
+    assert request.match_rule.method == ["GET", "POST", "PATCH"]
+    assert request.advanced_setting.cors_policy_setting.allow_origins is None
+    assert request.advanced_setting.cors_policy_setting.allow_credentials is None
+    assert request.advanced_setting.cors_policy_setting.enable is False
+
+
+def test_vefaas_application_route_skips_safe_configuration() -> None:
+    service, update_route = _vefaas_with_application_route(
+        methods=["GET", "POST", "PATCH"], cors_enabled=False
+    )
+
+    assert (
+        service.ensure_application_route_methods("application-id", disable_cors=True)
+        is False
+    )
+    update_route.assert_not_called()
+
+
+def test_vefaas_deploy_can_disable_gateway_cors() -> None:
+    service = object.__new__(VeFaaS)
+    cast(Any, service).apig_client = SimpleNamespace(
+        list_gateways=Mock(return_value=SimpleNamespace(items=[]))
+    )
+    service._create_function = Mock(return_value=("studio-app-fn", "function-id"))
+    service._create_application = Mock(return_value="application-id")
+    service._release_application = Mock(return_value="https://studio.example.com")
+    service.ensure_application_route_methods = Mock()
+
+    service.deploy(
+        "studio-app",
+        ".",
+        gateway_name="gateway",
+        gateway_service_name="service",
+        gateway_upstream_name="upstream",
+        disable_gateway_cors=True,
+    )
+
+    service.ensure_application_route_methods.assert_called_once_with(
+        "application-id",
+        disable_cors=True,
+    )
 
 
 def test_vefaas_code_upload_callback_uses_configured_region() -> None:
@@ -493,6 +560,11 @@ async def test_cloud():
 
                 # Test deploy operation
                 cloud_app = engine.deploy(application_name=app_name, path=temp_dir)
+
+                assert (
+                    mock_vefaas_service.deploy.call_args.kwargs["disable_gateway_cors"]
+                    is False
+                )
 
                 # Verify deployment result contains expected values
                 assert cloud_app.vefaas_application_name == app_name

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -11504,6 +11504,7 @@ def frontend_deploy(
             auth_method="none",
             enable_mcp_session=False,
             keep_failed_deploy=keep_failed_deploy,
+            disable_gateway_cors=True,
         )
         url = (app.vefaas_endpoint or "").rstrip("/")
         redirect_uri = f"{url}/oauth2/callback"
@@ -12464,6 +12465,7 @@ def frontend_update(
                 function_id=target.function_id,
                 path=str(package_dir),
                 environment_overrides=environment_overrides or None,
+                disable_gateway_cors=True,
             )
         except Exception as error:
             if _is_retryable_cloud_read_error(error):

--- a/veadk/cloud/cloud_agent_engine.py
+++ b/veadk/cloud/cloud_agent_engine.py
@@ -253,6 +253,7 @@ class CloudAgentEngine(BaseModel):
         local_test: bool = False,
         enable_mcp_session: bool = True,
         keep_failed_deploy: bool = False,
+        disable_gateway_cors: bool = False,
     ) -> CloudApp:
         """Deploys a local agent project to Volcengine FaaS, creating necessary resources.
 
@@ -269,6 +270,7 @@ class CloudAgentEngine(BaseModel):
             identity_user_pool_name (str, optional): Custom user pool name. Defaults to timestamped.
             identity_client_name (str, optional): Custom client name. Defaults to timestamped.
             local_test (bool): Perform FastAPI server test before deploy. Defaults to False.
+            disable_gateway_cors (bool): Disable route-wide APIG CORS. Defaults to False.
 
         Returns:
             CloudApp: Deployed application with endpoint, name, and ID.
@@ -331,6 +333,7 @@ class CloudAgentEngine(BaseModel):
                 enable_key_auth=enable_key_auth,
                 enable_mcp_session=enable_mcp_session,
                 keep_failed_deploy=keep_failed_deploy,
+                disable_gateway_cors=disable_gateway_cors,
             )
             _ = function_id  # for future use
 

--- a/veadk/integrations/ve_faas/ve_faas.py
+++ b/veadk/integrations/ve_faas/ve_faas.py
@@ -475,6 +475,7 @@ class VeFaaS:
         function_id: str,
         path: str,
         environment_overrides: dict[str, str] | None = None,
+        disable_gateway_cors: bool = False,
     ) -> str:
         """Replace an application's function bundle and release it.
 
@@ -487,6 +488,7 @@ class VeFaaS:
             function_id: Function ID referenced by the Application.
             path: Prepared function bundle directory.
             environment_overrides: Environment values to explicitly replace.
+            disable_gateway_cors: Disable route-wide APIG CORS after release.
 
         Returns:
             The existing Application URL after the new revision is released.
@@ -496,7 +498,13 @@ class VeFaaS:
             path=path,
             environment_overrides=environment_overrides,
         )
-        return self._release_application(application_id)
+        url = self._release_application(application_id)
+        if disable_gateway_cors:
+            self.ensure_application_route_methods(
+                application_id,
+                disable_cors=True,
+            )
+        return url
 
     def submit_application_code_bundle_update(
         self,
@@ -685,8 +693,10 @@ class VeFaaS:
         self,
         app_id: str,
         required_methods: tuple[str, ...] = ("PATCH",),
+        *,
+        disable_cors: bool = False,
     ) -> bool:
-        """Add missing HTTP methods to an application's generated APIG route."""
+        """Reconcile required HTTP methods and optional APIG CORS hardening."""
         from volcenginesdkapig20221112 import (
             AdvancedSettingForUpdateRouteInput,
             AllowOriginForUpdateRouteInput,
@@ -710,16 +720,20 @@ class VeFaaS:
         route = response.route
         methods = list(route.match_rule.method or [])
         missing = [method for method in required_methods if method not in methods]
-        if not missing:
+        advanced_setting = getattr(route, "advanced_setting", None)
+        cors = getattr(advanced_setting, "cors_policy_setting", None)
+        cors_enabled = bool(getattr(cors, "enable", False))
+        if not missing and not (disable_cors and cors_enabled):
             return False
         methods.extend(missing)
 
         path = route.match_rule.path
-        cors = getattr(route.advanced_setting, "cors_policy_setting", None)
         cors_methods = list(getattr(cors, "allow_methods", None) or [])
         cors_methods.extend(method for method in missing if method not in cors_methods)
         cors_update = None
-        if cors is not None:
+        if disable_cors:
+            cors_update = CorsPolicySettingForUpdateRouteInput(enable=False)
+        elif cors is not None:
             cors_update = CorsPolicySettingForUpdateRouteInput(
                 allow_credentials=cors.allow_credentials,
                 allow_headers=cors.allow_headers,
@@ -735,7 +749,7 @@ class VeFaaS:
                 expose_headers=cors.expose_headers,
                 max_age=cors.max_age,
             )
-        timeout = getattr(route.advanced_setting, "timeout_setting", None)
+        timeout = getattr(advanced_setting, "timeout_setting", None)
         timeout_update = (
             TimeoutSettingForUpdateRouteInput(
                 enable=timeout.enable,
@@ -856,6 +870,7 @@ class VeFaaS:
         enable_key_auth: bool = False,
         enable_mcp_session: bool = True,
         keep_failed_deploy: bool = False,
+        disable_gateway_cors: bool = False,
     ) -> tuple[str, str, str]:
         """Deploy an agent project to VeFaaS service.
 
@@ -866,6 +881,7 @@ class VeFaaS:
             gateway_service_name (str, optional): Gateway service name. Defaults to "".
             gateway_upstream_name (str, optional): Gateway upstream name. Defaults to "".
             enable_key_auth (bool, optional): Enable key auth. Defaults to False.
+            disable_gateway_cors (bool, optional): Disable route-wide APIG CORS.
 
         Returns:
             tuple[str, str, str]: (url, app_id, function_id)
@@ -922,7 +938,10 @@ class VeFaaS:
             logger.info(f"VeFaaS application {name} with ID {app_id} created.")
             logger.info(f"Start to release VeFaaS application {app_id}.")
             url = self._release_application(app_id)
-            self.ensure_application_route_methods(app_id)
+            self.ensure_application_route_methods(
+                app_id,
+                disable_cors=disable_gateway_cors,
+            )
             logger.info(f"VeFaaS application {name} with ID {app_id} released.")
         except Exception:
             if keep_failed_deploy:


### PR DESCRIPTION
## Summary

- disable route-wide APIG CORS for Studio deployments and updates
- preserve existing CORS behavior for non-Studio VeFaaS applications
- keep website integrations on their token- and domain-scoped application CORS policy
- add regression coverage for insecure, safe, deploy, and update paths across providers

## Testing

- `uv run pytest tests/test_cloud.py -q`
- `uv run pytest tests/cli/test_studio_deploy_target.py -q`
- `uv run pytest tests/cli/test_studio_update.py -q`
- `uv run pytest tests/frontend/server/website_integration/test_website_integration.py tests/cli/test_frontend_runtime_proxy.py -q`
- `uvx pre-commit run --files tests/cli/test_studio_deploy_target.py tests/cli/test_studio_update.py tests/test_cloud.py veadk/cli/cli_frontend.py veadk/cloud/cloud_agent_engine.py veadk/integrations/ve_faas/ve_faas.py`