### PR TITLE
fix(studio): protect server-backed resource lists

### DIFF
--- a/tests/cli/test_frontend_runtime_proxy.py
+++ b/tests/cli/test_frontend_runtime_proxy.py
@@ -523,6 +523,8 @@ def _create_frontend_app(
     site_title: str | None = None,
     studio: bool = False,
     provider: str = "volcengine",
+    admins: str | None = None,
+    developers: str | None = None,
 ) -> FastAPI:
     captured: dict[str, Any] = {}
     monkeypatch.setattr("dotenv.find_dotenv", lambda *args, **kwargs: "")
@@ -551,6 +553,8 @@ def _create_frontend_app(
         oauth2_provider_label=None,
         auth_mode="frontend",
         generated_agent_test_run_ttl=60,
+        studio_admins=admins,
+        studio_developers=developers,
         open_browser=False,
         provider=provider,  # type: ignore[arg-type]
         studio=studio,
@@ -1186,7 +1190,7 @@ def test_runtime_list_surfaces_all_regional_failures(
 def test_viking_knowledgebases_include_agentkit_imported_bases(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    app = _create_frontend_app(monkeypatch, tmp_path)
+    app = _create_frontend_app(monkeypatch, tmp_path, admins="admin")
     requests: list[tuple[str, int]] = []
 
     class _FakeKnowledgeClient:
@@ -1254,7 +1258,10 @@ def test_viking_knowledgebases_include_agentkit_imported_bases(
     monkeypatch.setattr("volcenginesdkvikingdb.VIKINGDBApi", _FakeVikingDbApi)
 
     with TestClient(app) as client:
-        response = client.get("/web/viking-knowledgebases")
+        response = client.get(
+            "/web/viking-knowledgebases",
+            headers={"X-VeADK-Local-User": "admin"},
+        )
 
     assert response.status_code == 200
     data = response.json()

--- a/tests/cli/test_frontend_skill_spaces.py
+++ b/tests/cli/test_frontend_skill_spaces.py
@@ -35,6 +35,8 @@ def _create_frontend_app(
     tmp_path: Path,
     *,
     provider: str = "volcengine",
+    admins: str | None = None,
+    developers: str | None = None,
 ) -> FastAPI:
     captured: dict[str, Any] = {}
     monkeypatch.setattr("dotenv.find_dotenv", lambda *args, **kwargs: "")
@@ -67,6 +69,8 @@ def _create_frontend_app(
         oauth2_provider_label=None,
         auth_mode="frontend",
         generated_agent_test_run_ttl=60,
+        studio_admins=admins,
+        studio_developers=developers,
         open_browser=False,
         provider=provider,
     )
@@ -100,7 +104,7 @@ def test_frontend_server_compresses_large_static_responses(
 def test_list_a2a_spaces_paginates_and_maps_names(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    app = _create_frontend_app(monkeypatch, tmp_path)
+    app = _create_frontend_app(monkeypatch, tmp_path, developers="developer")
     calls: list[dict[str, Any]] = []
 
     class _FakeResponse:
@@ -169,6 +173,7 @@ def test_list_a2a_spaces_paginates_and_maps_names(
         response = client.get(
             "/web/a2a-spaces",
             params={"region": "cn-beijing", "page_size": 2, "project": "default"},
+            headers={"X-VeADK-Local-User": "developer"},
         )
 
     assert response.status_code == 200

--- a/tests/cli/test_studio_rbac.py
+++ b/tests/cli/test_studio_rbac.py
@@ -95,6 +95,41 @@ def _create_studio_app(
 
 
 @pytest.mark.parametrize(
+    ("provider", "path"),
+    [
+        (provider, path)
+        for provider in ("volcengine", "byteplus")
+        for path in (
+            "/web/a2a-spaces",
+            "/web/viking-knowledgebases",
+        )
+    ],
+)
+def test_server_credential_resource_lists_require_agent_management_role(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    provider: str,
+    path: str,
+) -> None:
+    app = _create_studio_app(
+        monkeypatch,
+        tmp_path,
+        admins="admin",
+        developers="developer",
+        provider=provider,
+    )
+
+    with TestClient(app) as client:
+        response = client.get(
+            path,
+            headers={"X-VeADK-Local-User": "reader"},
+        )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Agent management is not allowed"}
+
+
+@pytest.mark.parametrize(
     (
         "provider",
         "inherited_name",

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -9441,11 +9441,13 @@ def _run_frontend_server(
 
     @app.get("/web/a2a-spaces")
     async def _web_list_a2a_spaces(
+        request: Request,
         region: str = "",
         page_size: int = Query(default=100, ge=1, le=100),
         project: str | None = None,
     ):
         """List all AgentKit A2A Spaces visible to server credentials."""
+        _require_agent_management(request)
         region = _coerce_cloud_region(region)
         try:
             _resolve_ve_credentials()
@@ -9992,10 +9994,12 @@ def _run_frontend_server(
 
     @app.get("/web/viking-knowledgebases")
     async def _web_list_viking_knowledgebases(
+        request: Request,
         region: str = "",
         project: str = "",
     ):
         """List VikingDB KnowledgeBase collections visible to server creds."""
+        _require_agent_management(request)
         from volcengine.viking_knowledgebase import VikingKnowledgeBaseService
 
         region = _coerce_cloud_region(region)


### PR DESCRIPTION
## Summary
- require Studio developer or admin role before listing A2A Spaces
- require Studio developer or admin role before listing VikingDB knowledge bases
- preserve access when RBAC is disabled and add Volcengine/BytePlus denial coverage

## Testing
- uv run --group dev pre-commit run --files veadk/cli/cli_frontend.py tests/cli/test_frontend_skill_spaces.py tests/cli/test_frontend_runtime_proxy.py tests/cli/test_studio_rbac.py
- uv run pytest tests/cli/test_studio_rbac.py tests/cli/test_frontend_skill_spaces.py tests/cli/test_frontend_runtime_proxy.py