### PR TITLE
fix(studio): enforce media ownership

### DIFF
--- a/tests/cli/test_studio_rbac.py
+++ b/tests/cli/test_studio_rbac.py
@@ -17,6 +17,7 @@
 import base64
 import itertools
 import json
+import logging
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -2007,6 +2008,100 @@ def test_access_endpoint_resolves_local_roles_and_blocks_user_management(
     assert user.json()["telemetry"]["accountId"] == "2100123456"
     assert forbidden.status_code == 403
     assert legacy_skill_creator.status_code == 404
+
+
+@pytest.mark.parametrize("provider", ["volcengine", "byteplus"])
+def test_media_routes_enforce_user_ownership_and_allow_explicit_admin(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    provider: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("VEADK_MEDIA_LOCAL_DIR", str(tmp_path / "media"))
+    app = _create_studio_app(
+        monkeypatch,
+        tmp_path,
+        admins="admin@example.com",
+        developers="owner@example.com",
+        provider=provider,
+    )
+
+    identities = {
+        "owner": {"sub": "owner-sub", "email": "owner@example.com"},
+        "reader": {"sub": "reader-sub", "email": "reader@example.com"},
+        "admin": {"sub": "admin-sub", "email": "admin@example.com"},
+    }
+
+    class _FakeOAuth2Handler:
+        def get_session_from_request(self, request: Request) -> object | None:
+            user_info = identities.get(request.headers.get("X-Test-Identity", ""))
+            return SimpleNamespace(user_info=user_info) if user_info else None
+
+    app.state.oauth2_handler = _FakeOAuth2Handler()
+    owner_headers = {"X-Test-Identity": "owner"}
+    reader_headers = {
+        "X-Test-Identity": "reader",
+        "X-VeADK-Local-User": "owner@example.com",
+    }
+    admin_headers = {"X-Test-Identity": "admin"}
+    with TestClient(app) as client:
+        upload = client.post(
+            "/web/media",
+            headers=owner_headers,
+            data={
+                "app_name": "demo",
+                "user_id": "owner@example.com",
+                "session_id": "session",
+            },
+            files={"file": ("private.txt", b"private", "text/plain")},
+        )
+        assert upload.status_code == 200
+        media_id = upload.json()["id"]
+        media_path = f"/web/media/demo/owner@example.com/session/{media_id}"
+
+        assert client.get(media_path).status_code == 401
+        blocked_upload = client.post(
+            "/web/media",
+            headers=reader_headers,
+            data={
+                "app_name": "demo",
+                "user_id": "owner@example.com",
+                "session_id": "session",
+            },
+            files={"file": ("blocked.txt", b"blocked", "text/plain")},
+        )
+        assert blocked_upload.status_code == 403
+        assert client.get(media_path, headers=reader_headers).status_code == 403
+        assert (
+            client.get(f"{media_path}/content", headers=reader_headers).status_code
+            == 403
+        )
+        assert (
+            client.post(f"{media_path}/delete", headers=reader_headers).status_code
+            == 403
+        )
+        assert (
+            client.post(
+                "/web/media/demo/owner@example.com/session/delete",
+                headers=reader_headers,
+            ).status_code
+            == 403
+        )
+
+        assert client.get(f"{media_path}/content", headers=owner_headers).content == (
+            b"private"
+        )
+        with caplog.at_level(logging.INFO, logger="veadk.cli.cli_frontend"):
+            assert (
+                client.get(f"{media_path}/content", headers=admin_headers).content
+                == b"private"
+            )
+
+    assert any(
+        "studio media cross-user access actor='admin-sub' "
+        "target_user_id='owner@example.com'" in record.getMessage()
+        for record in caplog.records
+    )
 
 
 @pytest.mark.parametrize("provider", ["volcengine", "byteplus"])

--- a/tests/multimodal/test_api.py
+++ b/tests/multimodal/test_api.py
@@ -15,7 +15,7 @@
 
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.testclient import TestClient
 
 from veadk.multimodal.api import mount_media_routes
@@ -75,3 +75,48 @@ def test_upload_rejects_unsupported_file(tmp_path: Path) -> None:
 
     assert response.status_code == 400
     assert "Unsupported media type" in response.json()["detail"]
+
+
+def test_authorizer_protects_every_user_scoped_media_route(tmp_path: Path) -> None:
+    app = FastAPI()
+    authorized_requests: list[tuple[str, str, str]] = []
+
+    def authorize_user(request: Request, user_id: str) -> None:
+        authorized_requests.append((request.method, request.url.path, user_id))
+        if user_id != "owner":
+            raise HTTPException(status_code=403, detail="forbidden")
+
+    mount_media_routes(
+        app,
+        MediaService(LocalMediaStorage(tmp_path)),
+        authorize_user=authorize_user,
+    )
+    client = TestClient(app)
+
+    upload = client.post(
+        "/web/media",
+        data={"app_name": "demo", "user_id": "owner", "session_id": "session"},
+        files={"file": ("guide.md", b"# Private", "text/markdown")},
+    )
+    assert upload.status_code == 200
+    media_id = upload.json()["id"]
+    media_path = f"/web/media/demo/reader/session/{media_id}"
+
+    blocked_upload = client.post(
+        "/web/media",
+        data={"app_name": "demo", "user_id": "reader", "session_id": "session"},
+        files={"file": ("blocked.md", b"# Blocked", "text/markdown")},
+    )
+    assert blocked_upload.status_code == 403
+
+    assert client.get(media_path).status_code == 403
+    assert client.get(f"{media_path}/content").status_code == 403
+    assert client.delete(media_path).status_code == 403
+    assert client.post(f"{media_path}/delete").status_code == 403
+    assert client.delete("/web/media/demo/reader/session").status_code == 403
+    assert client.post("/web/media/demo/reader/session/delete").status_code == 403
+
+    owner_content_path = f"/web/media/demo/owner/session/{media_id}/content"
+    assert client.get(owner_content_path).content == b"# Private"
+    assert client.get("/web/media/capabilities").status_code == 200
+    assert len(authorized_requests) == 9

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -1575,7 +1575,6 @@ def _run_frontend_server(
     from veadk.multimodal.transport import resolve_runtime_media
 
     _agent_loader = AgentLoader(agents_dir)
-    mount_media_routes(app, media_service)
 
     # Generated-agent debug is intentionally feature-complete in both local and
     # remote Studio deployments: the backend receives AgentDraft JSON, generates
@@ -1622,6 +1621,46 @@ def _run_frontend_server(
         if access_policy.enabled and principal is None:
             raise HTTPException(status_code=401, detail="Studio identity is required")
         return access_policy.role_for(principal)
+
+    def _authorize_media_user(request: Request, requested_user_id: str) -> None:
+        principal = _current_principal(request)
+        authentication_enabled = (
+            auth_mode == "gateway"
+            or getattr(app.state, "oauth2_handler", None) is not None
+            or access_policy.enabled
+        )
+        if principal is None:
+            if authentication_enabled:
+                raise HTTPException(
+                    status_code=401,
+                    detail="Studio identity is required",
+                )
+            return
+        if requested_user_id.casefold() in principal.identifiers:
+            return
+        if (
+            access_policy.enabled
+            and access_policy.role_for(principal) == StudioRole.ADMIN
+        ):
+            logger.info(
+                "studio media cross-user access actor=%r target_user_id=%r "
+                "method=%s path=%r",
+                principal.owner_id,
+                requested_user_id,
+                request.method,
+                request.url.path,
+            )
+            return
+        raise HTTPException(
+            status_code=403,
+            detail="Media access is limited to the current user",
+        )
+
+    mount_media_routes(
+        app,
+        media_service,
+        authorize_user=_authorize_media_user,
+    )
 
     from veadk.cli.frontend_issue_feedback import mount_issue_feedback_route
 

--- a/veadk/multimodal/api.py
+++ b/veadk/multimodal/api.py
@@ -18,11 +18,13 @@ from __future__ import annotations
 import os
 from pathlib import Path
 import tempfile
+from typing import Callable
 
 from fastapi import FastAPI
 from fastapi import File
 from fastapi import Form
 from fastapi import HTTPException
+from fastapi import Request
 from fastapi import UploadFile
 from fastapi.responses import FileResponse
 from fastapi.responses import RedirectResponse
@@ -33,8 +35,20 @@ from .service import MediaService
 from .service import SUPPORTED_MIME_TYPES
 
 
-def mount_media_routes(app: FastAPI, service: MediaService) -> None:
+MediaUserAuthorizer = Callable[[Request, str], None]
+
+
+def mount_media_routes(
+    app: FastAPI,
+    service: MediaService,
+    *,
+    authorize_user: MediaUserAuthorizer | None = None,
+) -> None:
     """Mount the multimodal upload, delivery, and cleanup endpoints."""
+
+    def authorize(request: Request, user_id: str) -> None:
+        if authorize_user is not None:
+            authorize_user(request, user_id)
 
     @app.get("/web/media/capabilities")
     async def media_capabilities() -> dict[str, object]:
@@ -46,6 +60,7 @@ def mount_media_routes(app: FastAPI, service: MediaService) -> None:
 
     @app.post("/web/media")
     async def upload_media(
+        request: Request,
         app_name: str = Form(...),
         user_id: str = Form(...),
         session_id: str = Form(...),
@@ -54,6 +69,7 @@ def mount_media_routes(app: FastAPI, service: MediaService) -> None:
         suffix = Path(file.filename or "attachment").suffix
         temp_path: Path | None = None
         try:
+            authorize(request, user_id)
             with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as temp:
                 temp_path = Path(temp.name)
                 size_bytes = 0
@@ -84,8 +100,13 @@ def mount_media_routes(app: FastAPI, service: MediaService) -> None:
 
     @app.get("/web/media/{app_name}/{user_id}/{session_id}/{media_id}")
     async def get_media_metadata(
-        app_name: str, user_id: str, session_id: str, media_id: str
+        request: Request,
+        app_name: str,
+        user_id: str,
+        session_id: str,
+        media_id: str,
     ) -> dict[str, object]:
+        authorize(request, user_id)
         try:
             record = await service.get_record(
                 _media_ref(app_name, user_id, session_id, media_id)
@@ -96,8 +117,13 @@ def mount_media_routes(app: FastAPI, service: MediaService) -> None:
 
     @app.get("/web/media/{app_name}/{user_id}/{session_id}/{media_id}/content")
     async def get_media_content(
-        app_name: str, user_id: str, session_id: str, media_id: str
+        request: Request,
+        app_name: str,
+        user_id: str,
+        session_id: str,
+        media_id: str,
     ) -> Response:
+        authorize(request, user_id)
         ref = _media_ref(app_name, user_id, session_id, media_id)
         try:
             record = await service.get_record(ref)
@@ -120,8 +146,13 @@ def mount_media_routes(app: FastAPI, service: MediaService) -> None:
     @app.delete("/web/media/{app_name}/{user_id}/{session_id}/{media_id}")
     @app.post("/web/media/{app_name}/{user_id}/{session_id}/{media_id}/delete")
     async def delete_media(
-        app_name: str, user_id: str, session_id: str, media_id: str
+        request: Request,
+        app_name: str,
+        user_id: str,
+        session_id: str,
+        media_id: str,
     ) -> None:
+        authorize(request, user_id)
         await service.storage.delete(
             _media_ref(app_name, user_id, session_id, media_id)
         )
@@ -129,8 +160,12 @@ def mount_media_routes(app: FastAPI, service: MediaService) -> None:
     @app.delete("/web/media/{app_name}/{user_id}/{session_id}")
     @app.post("/web/media/{app_name}/{user_id}/{session_id}/delete")
     async def delete_session_media(
-        app_name: str, user_id: str, session_id: str
+        request: Request,
+        app_name: str,
+        user_id: str,
+        session_id: str,
     ) -> None:
+        authorize(request, user_id)
         await service.storage.delete_session(app_name, user_id, session_id)
 
 


### PR DESCRIPTION
## Summary

- authorize every user-scoped Studio media upload, read, and delete route against the authenticated identity
- return 401 when Studio authentication is enabled but identity is missing, and 403 for non-admin cross-user access
- allow explicitly configured admins to access another user media with an audit log
- preserve existing storage paths and unauthenticated single-user local development behavior

## Compatibility

- no media URI or storage migration is required
- existing same-user access continues unchanged
- clients that previously sent a user_id belonging to another user will now receive 403 unless the authenticated principal is an explicitly configured admin
- covered for both Volcengine and BytePlus Studio authentication

## Tests

- uv run pre-commit run --all-files
- uv run pytest tests/multimodal/test_api.py tests/cli/test_studio_rbac.py (89 passed)