### PR TITLE
fix(studio): enforce local session ownership

### DIFF
--- a/tests/cli/test_studio_rbac.py
+++ b/tests/cli/test_studio_rbac.py
@@ -2140,6 +2140,181 @@ def test_media_routes_enforce_user_ownership_and_allow_explicit_admin(
 
 
 @pytest.mark.parametrize("provider", ["volcengine", "byteplus"])
+def test_non_admin_cannot_access_another_users_local_adk_session(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    provider: str,
+) -> None:
+    app = _create_studio_app(
+        monkeypatch,
+        tmp_path,
+        auth_mode="gateway",
+        admins="admin",
+        developers="developer",
+        provider=provider,
+    )
+    requests = [
+        ("GET", "/apps/demo/users/owner/sessions", None),
+        ("POST", "/apps/demo/users/owner/sessions", {}),
+        ("GET", "/apps/demo/users/owner/sessions/session-1", None),
+        ("PATCH", "/apps/demo/users/owner/sessions/session-1", {"state_delta": {}}),
+        ("DELETE", "/apps/demo/users/owner/sessions/session-1", None),
+        (
+            "POST",
+            "/run",
+            {"app_name": "demo", "user_id": "owner", "session_id": "session-1"},
+        ),
+        (
+            "POST",
+            "/run_sse",
+            {"app_name": "demo", "user_id": "owner", "session_id": "session-1"},
+        ),
+    ]
+
+    with TestClient(app) as client:
+        for actor in ("reader", "developer"):
+            authorization = f"Bearer {_unsigned_jwt({'sub': actor})}"
+            for method, path, payload in requests:
+                response = client.request(
+                    method,
+                    path,
+                    headers={"Authorization": authorization},
+                    json=payload,
+                )
+
+                assert response.status_code == 403, (actor, method, path)
+                assert response.json() == {
+                    "detail": "Cross-user session access is not allowed"
+                }
+
+
+def test_local_adk_session_access_requires_a_trusted_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app = _create_studio_app(
+        monkeypatch,
+        tmp_path,
+        auth_mode="gateway",
+        admins="admin",
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/apps/demo/users/owner/sessions")
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Studio identity is required"}
+
+
+def test_legacy_full_access_does_not_imply_cross_user_session_access(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app = _create_studio_app(
+        monkeypatch,
+        tmp_path,
+        auth_mode="gateway",
+    )
+    authorization = f"Bearer {_unsigned_jwt({'sub': 'reader'})}"
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/apps/demo/users/owner/sessions",
+            headers={"Authorization": authorization},
+        )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Cross-user session access is not allowed"}
+
+
+def test_local_adk_session_access_accepts_a_trusted_identity_alias(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app = _create_studio_app(
+        monkeypatch,
+        tmp_path,
+        auth_mode="gateway",
+        admins="admin",
+    )
+    authorization = "Bearer " + _unsigned_jwt(
+        {"sub": "stable-id", "email": "Owner@Example.com"}
+    )
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/apps/demo/users/owner@example.com/sessions",
+            headers={"Authorization": authorization},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_admin_can_manage_another_users_local_adk_session_with_audit_log(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    audit_logs: list[str] = []
+    original_info = __import__(
+        "veadk.cli.cli_frontend", fromlist=["logger"]
+    ).logger.info
+
+    def _capture_info(message: str, *args: object) -> None:
+        rendered = message % args if args else message
+        if rendered.startswith("Studio admin cross-user session access "):
+            audit_logs.append(rendered)
+        original_info(message, *args)
+
+    monkeypatch.setattr("veadk.cli.cli_frontend.logger.info", _capture_info)
+    app = _create_studio_app(
+        monkeypatch,
+        tmp_path,
+        auth_mode="gateway",
+        admins="admin",
+        developers="developer",
+    )
+    authorization = f"Bearer {_unsigned_jwt({'sub': 'admin'})}"
+    collection_path = "/apps/demo/users/owner/sessions"
+
+    with TestClient(app) as client:
+        created = client.post(
+            collection_path,
+            headers={"Authorization": authorization},
+            json={"session_id": "session-1", "state": {"status": "created"}},
+        )
+        listed = client.get(
+            collection_path,
+            headers={"Authorization": authorization},
+        )
+        fetched = client.get(
+            f"{collection_path}/session-1",
+            headers={"Authorization": authorization},
+        )
+        updated = client.patch(
+            f"{collection_path}/session-1",
+            headers={"Authorization": authorization},
+            json={"state_delta": {"status": "updated"}},
+        )
+        deleted = client.delete(
+            f"{collection_path}/session-1",
+            headers={"Authorization": authorization},
+        )
+
+    assert created.status_code == 200
+    assert listed.status_code == 200
+    assert [session["id"] for session in listed.json()] == ["session-1"]
+    assert fetched.status_code == 200
+    assert fetched.json()["state"]["status"] == "created"
+    assert updated.status_code == 200
+    assert updated.json()["state"]["status"] == "updated"
+    assert deleted.status_code == 200
+    assert len(audit_logs) == 5
+    assert all('"actor": "admin"' in entry for entry in audit_logs)
+    assert all('"target_user": "owner"' in entry for entry in audit_logs)
+
+
+@pytest.mark.parametrize("provider", ["volcengine", "byteplus"])
 def test_model_api_key_value_requires_agent_management_role(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -118,6 +118,8 @@ _CP_BUILD_LOG_MAX_CHARS = 50000
 _CP_BUILD_LOG_MAX_LINES = 1000
 _CP_BUILD_LOG_FINAL_ERROR_RETRIES = 5
 _CP_BUILD_LOG_FINAL_ERROR_RETRY_INTERVAL_SECONDS = 2.0
+_LOCAL_ADK_SESSION_PATH_RE = re.compile(r"^/apps/[^/]+/users/([^/]+)/sessions(?:/|$)")
+_LOCAL_ADK_RUN_PATHS = frozenset({"/run", "/run_sse"})
 _CP_BUILD_LOG_ERROR_TAIL_CHECK_CHARS = 1024
 _DEPLOY_PHASE_ORDER = {"build": 0, "deploy": 1, "publish": 2, "update": 3}
 _DEPLOY_PHASE_MARKERS = (
@@ -1543,7 +1545,7 @@ def _run_frontend_server(
     # Agent introspection for the UI's agent picker (name, model, tools). Reuses
     # ADK's AgentLoader, which caches each loaded `root_agent`.
     from fastapi import HTTPException, Query, Request
-    from fastapi.responses import Response
+    from fastapi.responses import JSONResponse, Response
     from google.adk.cli.utils.agent_loader import AgentLoader
     import httpx
 
@@ -1661,6 +1663,61 @@ def _run_frontend_server(
         media_service,
         authorize_user=_authorize_media_user,
     )
+
+    if studio:
+
+        @app.middleware("http")
+        async def _authorize_local_adk_session(request: Request, call_next):
+            """Bind local ADK session operations to the authenticated principal."""
+            requested_user_id: str | None = None
+            path_match = _LOCAL_ADK_SESSION_PATH_RE.match(request.url.path)
+            if path_match is not None:
+                requested_user_id = path_match.group(1)
+            elif request.method == "POST" and request.url.path in _LOCAL_ADK_RUN_PATHS:
+                try:
+                    payload = await request.json()
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    payload = None
+                if isinstance(payload, dict) and isinstance(
+                    payload.get("user_id"), str
+                ):
+                    requested_user_id = payload["user_id"]
+
+            if requested_user_id is None:
+                return await call_next(request)
+
+            principal = _current_principal(request)
+            if principal is None:
+                return JSONResponse(
+                    {"detail": "Studio identity is required"},
+                    status_code=401,
+                )
+
+            if requested_user_id.casefold() in principal.identifiers:
+                return await call_next(request)
+
+            # ``role_for`` intentionally grants legacy admin capabilities when
+            # RBAC is unconfigured. Cross-user data access is more sensitive and
+            # therefore requires an explicit administrator-list match.
+            if principal.identifiers & access_policy.admins:
+                logger.info(
+                    "Studio admin cross-user session access %s",
+                    json.dumps(
+                        {
+                            "actor": principal.owner_id,
+                            "target_user": requested_user_id,
+                            "method": request.method,
+                            "path": request.url.path,
+                        },
+                        ensure_ascii=True,
+                    ),
+                )
+                return await call_next(request)
+
+            return JSONResponse(
+                {"detail": "Cross-user session access is not allowed"},
+                status_code=403,
+            )
 
     from veadk.cli.frontend_issue_feedback import mount_issue_feedback_route
 


### PR DESCRIPTION
## Summary

- bind local ADK session routes and run requests to the authenticated Studio principal
- allow explicitly configured Studio administrators to manage cross-user sessions with audit logging
- preserve compatibility with trusted identity aliases while rejecting unauthenticated and unauthorized access
- cover Volcengine and BytePlus behavior with RBAC regression tests

## Tests

- `pre-commit run --files veadk/cli/cli_frontend.py tests/cli/test_studio_rbac.py`
- `pytest -q tests/cli/test_studio_rbac.py --maxfail=1` (90 passed)