### PR TITLE
fix: support BytePlus APMPlus routing

### DIFF
--- a/tests/auth/veauth/test_apmplus_veauth.py
+++ b/tests/auth/veauth/test_apmplus_veauth.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+
+from veadk.auth.veauth.apmplus_veauth import get_apmplus_token
+
+
+@pytest.fixture(autouse=True)
+def _environment(monkeypatch):
+    monkeypatch.setenv("VOLCENGINE_ACCESS_KEY", "ak")
+    monkeypatch.setenv("VOLCENGINE_SECRET_KEY", "sk")
+    monkeypatch.delenv("VOLCENGINE_SESSION_TOKEN", raising=False)
+    monkeypatch.delenv("VOLC_SESSIONTOKEN", raising=False)
+    monkeypatch.delenv("CLOUD_PROVIDER", raising=False)
+    monkeypatch.delenv("AGENTKIT_CLOUD_PROVIDER", raising=False)
+    monkeypatch.delenv("REGION", raising=False)
+    monkeypatch.delenv("BYTEPLUS_REGION", raising=False)
+
+
+def test_volcengine_uses_volcengine_host_and_region():
+    with patch("veadk.auth.veauth.apmplus_veauth.ve_request") as request:
+        request.return_value = {"data": {"app_key": "app-key"}}
+
+        assert get_apmplus_token() == "app-key"
+
+    assert request.call_args.kwargs["region"] == "cn-beijing"
+    assert request.call_args.kwargs["host"] == "open.volcengineapi.com"
+    assert request.call_args.kwargs["header"]["X-Apmplus-Region"] == "cn_beijing"
+
+
+def test_byteplus_uses_byteplus_host_and_region(monkeypatch):
+    monkeypatch.setenv("CLOUD_PROVIDER", "byteplus")
+    with patch("veadk.auth.veauth.apmplus_veauth.ve_request") as request:
+        request.return_value = {"data": {"app_key": "app-key"}}
+
+        assert get_apmplus_token() == "app-key"
+
+    assert request.call_args.kwargs["region"] == "ap-southeast-1"
+    assert request.call_args.kwargs["host"] == "open.byteplusapi.com"
+    assert request.call_args.kwargs["header"]["X-Apmplus-Region"] == "ap_southeast_1"
+
+
+def test_explicit_provider_and_credentials_override_environment(monkeypatch):
+    monkeypatch.setenv("CLOUD_PROVIDER", "volcengine")
+    monkeypatch.setenv("VOLCENGINE_SESSION_TOKEN", "environment-token")
+    with patch("veadk.auth.veauth.apmplus_veauth.ve_request") as request:
+        request.return_value = {"data": {"app_key": "app-key"}}
+
+        get_apmplus_token(
+            cloud_provider="byteplus",
+            access_key="explicit-ak",
+            secret_key="explicit-sk",
+            session_token="explicit-token",
+        )
+
+    assert request.call_args.kwargs["ak"] == "explicit-ak"
+    assert request.call_args.kwargs["sk"] == "explicit-sk"
+    assert request.call_args.kwargs["host"] == "open.byteplusapi.com"
+    assert request.call_args.kwargs["header"]["X-Security-Token"] == "explicit-token"

--- a/tests/config/test_tracing_config.py
+++ b/tests/config/test_tracing_config.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from veadk.configs.tracing_configs import APMPlusConfig
+
+
+def test_apmplus_endpoint_defaults_to_volcengine_region(monkeypatch):
+    monkeypatch.delenv("AGENTKIT_CLOUD_PROVIDER", raising=False)
+    monkeypatch.delenv("CLOUD_PROVIDER", raising=False)
+    monkeypatch.delenv("REGION", raising=False)
+    monkeypatch.delenv("OBSERVABILITY_OPENTELEMETRY_APMPLUS_ENDPOINT", raising=False)
+
+    assert (
+        APMPlusConfig().otel_exporter_endpoint
+        == "http://apmplus-cn-beijing.volces.com:4317"
+    )
+
+
+def test_apmplus_endpoint_defaults_to_byteplus_region(monkeypatch):
+    monkeypatch.delenv("AGENTKIT_CLOUD_PROVIDER", raising=False)
+    monkeypatch.setenv("CLOUD_PROVIDER", "byteplus")
+    monkeypatch.delenv("BYTEPLUS_REGION", raising=False)
+    monkeypatch.delenv("OBSERVABILITY_OPENTELEMETRY_APMPLUS_ENDPOINT", raising=False)
+
+    assert (
+        APMPlusConfig().otel_exporter_endpoint
+        == "http://apmplus-ap-southeast-1.volces.com:4317"
+    )
+
+
+def test_apmplus_endpoint_environment_override_takes_precedence(monkeypatch):
+    monkeypatch.setenv("CLOUD_PROVIDER", "byteplus")
+    monkeypatch.setenv(
+        "OBSERVABILITY_OPENTELEMETRY_APMPLUS_ENDPOINT",
+        "http://custom-apmplus.example.com:4317",
+    )
+
+    assert (
+        APMPlusConfig().otel_exporter_endpoint
+        == "http://custom-apmplus.example.com:4317"
+    )

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -27,7 +27,18 @@ from veadk.cloud.cloud_agent_engine import CloudAgentEngine
 from veadk.integrations.ve_apig.ve_apig import APIGateway
 from veadk.integrations.ve_code_pipeline.ve_code_pipeline import VeCodePipeline
 from veadk.integrations.ve_faas.ve_faas import VeFaaS
-from veadk.utils.cloud_provider import cp_openapi_host, default_region
+from veadk.utils.cloud_provider import (
+    apmplus_otlp_endpoint,
+    cp_openapi_host,
+    default_region,
+)
+
+
+def test_apmplus_otlp_endpoint_uses_region() -> None:
+    assert (
+        apmplus_otlp_endpoint("ap-southeast-1")
+        == "http://apmplus-ap-southeast-1.volces.com:4317"
+    )
 
 
 def test_vefaas_create_function_uses_configured_project() -> None:

--- a/veadk/auth/veauth/apmplus_veauth.py
+++ b/veadk/auth/veauth/apmplus_veauth.py
@@ -15,19 +15,42 @@
 import os
 
 from veadk.auth.veauth.utils import get_credential_from_vefaas_iam
+from veadk.utils.cloud_provider import (
+    apmplus_openapi_host,
+    cloud_provider_from_env,
+    default_region,
+    normalize_cloud_provider,
+)
 from veadk.utils.logger import get_logger
 from veadk.utils.volcengine_sign import ve_request
 
 logger = get_logger(__name__)
 
 
-def get_apmplus_token(region: str = "") -> str:
+def get_apmplus_token(
+    region: str = "",
+    *,
+    cloud_provider: str | None = None,
+    access_key: str | None = None,
+    secret_key: str | None = None,
+    session_token: str | None = None,
+) -> str:
     logger.info("Fetching APMPlus token...")
-    region = region or os.getenv("REGION") or "cn-beijing"
+    provider = (
+        normalize_cloud_provider(cloud_provider)
+        if cloud_provider is not None
+        else cloud_provider_from_env()
+    )
+    region = region or default_region(provider)
+    host = apmplus_openapi_host(provider)
 
-    access_key = os.getenv("VOLCENGINE_ACCESS_KEY")
-    secret_key = os.getenv("VOLCENGINE_SECRET_KEY")
-    session_token = ""
+    access_key = access_key or os.getenv("VOLCENGINE_ACCESS_KEY")
+    secret_key = secret_key or os.getenv("VOLCENGINE_SECRET_KEY")
+    session_token = (
+        session_token
+        or os.getenv("VOLCENGINE_SESSION_TOKEN")
+        or os.getenv("VOLC_SESSIONTOKEN", "")
+    )
 
     if not (access_key and secret_key):
         # try to get from vefaas iam
@@ -49,7 +72,7 @@ def get_apmplus_token(region: str = "") -> str:
         service="apmplus_server",
         version="2024-07-30",
         region=region,
-        host="open.volcengineapi.com",
+        host=host,
     )
     try:
         api_key = res["data"]["app_key"]

--- a/veadk/configs/tracing_configs.py
+++ b/veadk/configs/tracing_configs.py
@@ -20,7 +20,6 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from veadk.auth.veauth.apmplus_veauth import get_apmplus_token
 from veadk.consts import (
-    DEFAULT_APMPLUS_OTEL_EXPORTER_ENDPOINT,
     DEFAULT_APMPLUS_OTEL_EXPORTER_SERVICE_NAME,
     DEFAULT_COZELOOP_OTEL_EXPORTER_ENDPOINT,
     DEFAULT_COZELOOP_SPACE_NAME,
@@ -29,6 +28,16 @@ from veadk.consts import (
 )
 from veadk.integrations.ve_cozeloop.ve_cozeloop import VeCozeloop
 from veadk.integrations.ve_tls.ve_tls import VeTLS
+from veadk.utils.cloud_provider import (
+    apmplus_otlp_endpoint,
+    cloud_provider_from_env,
+    default_region,
+)
+
+
+def _default_apmplus_otel_exporter_endpoint() -> str:
+    provider = cloud_provider_from_env()
+    return apmplus_otlp_endpoint(default_region(provider))
 
 
 class OpenTelemetryConfig(BaseSettings):
@@ -40,7 +49,7 @@ class OpenTelemetryConfig(BaseSettings):
 
 class APMPlusConfig(BaseSettings):
     otel_exporter_endpoint: str = Field(
-        default=DEFAULT_APMPLUS_OTEL_EXPORTER_ENDPOINT,
+        default_factory=_default_apmplus_otel_exporter_endpoint,
         alias="OBSERVABILITY_OPENTELEMETRY_APMPLUS_ENDPOINT",
     )
 

--- a/veadk/utils/cloud_provider.py
+++ b/veadk/utils/cloud_provider.py
@@ -113,6 +113,11 @@ def apmplus_openapi_host(provider: CloudProvider) -> str:
     return "open.volcengineapi.com"
 
 
+def apmplus_otlp_endpoint(region: str) -> str:
+    """Return the regional APMPlus OTLP/gRPC endpoint."""
+    return f"http://apmplus-{region}.volces.com:4317"
+
+
 def agentkit_openapi_base(region: str, provider: CloudProvider) -> str:
     """Return the AgentKit OpenAPI base URL used by Studio proxy helpers."""
     if provider == "byteplus":


### PR DESCRIPTION
## Summary

- route APMPlus GetAppKey requests through the provider-specific OpenAPI host and default region
- derive the default APMPlus OTLP endpoint from the active cloud region
- preserve explicit endpoint overrides and add coverage for Volcengine and BytePlus routing

## Testing

- `uv run --extra extensions --with greenlet pytest -n 16` (2629 passed, 6 skipped)
- `uv run --extra extensions --with greenlet pre-commit run --all-files`
- live BytePlus GetAppKey request with configured AK/SK succeeded against `open.byteplusapi.com`