### PR TITLE
perf(studio): fingerprint managed Sidecar source

### DIFF
--- a/tests/cli/test_managed_sidecar_source.py
+++ b/tests/cli/test_managed_sidecar_source.py
@@ -46,14 +46,14 @@ def _package(root: Path) -> Path:
     return package
 
 
-def test_rewrite_uses_source_snapshot_and_pins_public_sdk() -> None:
+def test_rewrite_uses_source_snapshot_and_pins_runtime_dependencies() -> None:
     rewritten = rewrite_managed_sidecar_requirements(
         "\n".join(
             (
                 "veadk-python[harness-sidecar]>=1.1.1",
                 "agentkit_sdk_python>=0.8.0,<0.9.0",
                 "agentkit-harness-sidecar-integration==0.1.0",
-                "google-adk>=1.34.0",
+                "google_adk==1.23.0",
                 "mcp==1.20.0",
                 "",
             )
@@ -65,9 +65,10 @@ def test_rewrite_uses_source_snapshot_and_pins_public_sdk() -> None:
     assert "agentkit-harness-sidecar-integration" not in rewritten
     assert rewritten.splitlines()[1] == "agentkit-sdk-python==0.8.1"
     assert rewritten.splitlines().count("agentkit-sdk-python==0.8.1") == 1
-    assert "google-adk>=1.34.0" in rewritten
     assert rewritten.splitlines().count("mcp==1.26.0") == 1
     assert "mcp==1.20.0" not in rewritten
+    assert rewritten.splitlines().count("google-adk>=1.34.0") == 1
+    assert "google_adk==1.23.0" not in rewritten
 
 
 def test_rewrite_preserves_comments_and_rejects_missing_veadk() -> None:
@@ -118,6 +119,8 @@ def test_stage_copies_only_safe_runtime_source_and_rewrites_requirements(
     requirements = (project / "requirements.txt").read_text(encoding="utf-8")
     assert requirements.splitlines().count("agentkit-sdk-python==0.8.1") == 1
     assert requirements.splitlines().count("mcp==1.26.0") == 1
+    assert requirements.splitlines().count("google-adk>=1.34.0") == 1
+    assert "\ngoogle-adk\n" not in f"\n{requirements}"
     assert "veadk-python[" not in requirements
 
 

--- a/tests/cli/test_managed_sidecar_source.py
+++ b/tests/cli/test_managed_sidecar_source.py
@@ -14,13 +14,17 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
 from veadk.cli import managed_sidecar_source
 from veadk.cli.managed_sidecar_source import (
+    MANAGED_SIDECAR_SOURCE_MARKER,
+    MANAGED_SIDECAR_SOURCE_SCHEMA,
     ManagedSidecarSourceError,
+    managed_sidecar_source_snapshot,
     rewrite_managed_sidecar_requirements,
     stage_managed_sidecar_veadk_source,
 )
@@ -98,6 +102,7 @@ def test_stage_copies_only_safe_runtime_source_and_rewrites_requirements(
     webui.mkdir()
     (webui / "bundle.js").write_bytes(b"browser-only")
     (package / ".env.local").write_text("SECRET=ignored\n", encoding="utf-8")
+    (package / ".python-version").write_text("3.12\n", encoding="utf-8")
     project = tmp_path / "project"
     project.mkdir()
     (project / "requirements.txt").write_text(
@@ -112,16 +117,53 @@ def test_stage_copies_only_safe_runtime_source_and_rewrites_requirements(
 
     assert snapshot.file_count == len(_REQUIRED_FILES) + 1
     assert snapshot.total_bytes > 0
+    assert len(snapshot.sha256) == 64
     assert (project / "veadk/extensions/harness/sidecar.py").is_file()
     assert not (project / "veadk/__pycache__").exists()
     assert not (project / "veadk/webui").exists()
     assert not (project / "veadk/.env.local").exists()
+    assert not (project / "veadk/.python-version").exists()
     requirements = (project / "requirements.txt").read_text(encoding="utf-8")
     assert requirements.splitlines().count("agentkit-sdk-python==0.8.1") == 1
     assert requirements.splitlines().count("mcp==1.26.0") == 1
     assert requirements.splitlines().count("google-adk>=1.34.0") == 1
     assert "\ngoogle-adk\n" not in f"\n{requirements}"
     assert "veadk-python[" not in requirements
+    assert json.loads(
+        (project / MANAGED_SIDECAR_SOURCE_MARKER).read_text(encoding="utf-8")
+    ) == {
+        "fileCount": snapshot.file_count,
+        "schemaVersion": MANAGED_SIDECAR_SOURCE_SCHEMA,
+        "sha256": snapshot.sha256,
+        "totalBytes": snapshot.total_bytes,
+    }
+
+
+def test_source_fingerprint_has_a_cross_runtime_stable_vector(tmp_path: Path) -> None:
+    package = tmp_path / "veadk"
+    (package / "nested").mkdir(parents=True)
+    (package / "a.py").write_bytes(b"alpha\n")
+    (package / "nested/b.json").write_bytes(b"{}\n")
+
+    files = managed_sidecar_source._source_files(package)
+
+    assert managed_sidecar_source._fingerprint_source_files(files) == (
+        "89a1c958a26e3cc0948692702b52a6652027b7c59934b8337d8cad30a67cbe21"
+    )
+
+
+def test_source_snapshot_changes_with_managed_bytes(tmp_path: Path) -> None:
+    package = _package(tmp_path / "installed")
+    first = managed_sidecar_source_snapshot(package)
+
+    changed_path = package / "extensions/harness/sidecar.py"
+    original = changed_path.read_bytes()
+    changed_path.write_bytes(b"!" + original[1:])
+    second = managed_sidecar_source_snapshot(package)
+
+    assert first.file_count == second.file_count
+    assert first.total_bytes == second.total_bytes
+    assert first.sha256 != second.sha256
 
 
 def test_stage_fails_closed_for_existing_target(tmp_path: Path) -> None:
@@ -135,6 +177,20 @@ def test_stage_fails_closed_for_existing_target(tmp_path: Path) -> None:
     (project / "veadk").mkdir()
 
     with pytest.raises(ManagedSidecarSourceError, match="target_exists"):
+        stage_managed_sidecar_veadk_source(project, package_dir=package)
+
+
+def test_stage_fails_closed_for_existing_marker(tmp_path: Path) -> None:
+    package = _package(tmp_path / "installed")
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "requirements.txt").write_text(
+        "veadk-python[harness-sidecar]\n",
+        encoding="utf-8",
+    )
+    (project / MANAGED_SIDECAR_SOURCE_MARKER).write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ManagedSidecarSourceError, match="marker_exists"):
         stage_managed_sidecar_veadk_source(project, package_dir=package)
 
 

--- a/veadk/cli/managed_sidecar_source.py
+++ b/veadk/cli/managed_sidecar_source.py
@@ -26,11 +26,13 @@ _REQUIREMENT_NAME_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)")
 _REMOVED_DISTRIBUTIONS = {
     "agentkit-sdk-python",
     "agentkit-harness-sidecar-integration",
+    "google-adk",
     "mcp",
     "veadk-python",
 }
 _MANAGED_SDK_REQUIREMENT = "agentkit-sdk-python==0.8.1"
 _MANAGED_MCP_REQUIREMENT = "mcp==1.26.0"
+_MANAGED_ADK_REQUIREMENT = "google-adk>=1.34.0"
 _IGNORED_PARTS = {".git", "__pycache__", "webui"}
 _IGNORED_SUFFIXES = {".pyc", ".pyo"}
 _BLOCKED_SUFFIXES = {".key", ".p12", ".pem", ".pfx"}
@@ -68,7 +70,7 @@ def _canonical_requirement_name(line: str) -> str | None:
 
 
 def rewrite_managed_sidecar_requirements(requirements: str) -> str:
-    """Use in-snapshot VeADK and install the approved public SDK explicitly."""
+    """Use in-snapshot VeADK and install approved runtime dependencies."""
 
     lines: list[str] = []
     veadk_removed = False
@@ -84,6 +86,7 @@ def rewrite_managed_sidecar_requirements(requirements: str) -> str:
         "# veadk-python is provided by the Studio-managed public source snapshot.",
         _MANAGED_SDK_REQUIREMENT,
         _MANAGED_MCP_REQUIREMENT,
+        _MANAGED_ADK_REQUIREMENT,
         *lines,
     ]
     return "\n".join(lines).rstrip() + "\n"

--- a/veadk/cli/managed_sidecar_source.py
+++ b/veadk/cli/managed_sidecar_source.py
@@ -16,8 +16,11 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 import shutil
+import struct
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -47,6 +50,9 @@ _REQUIRED_SOURCE_FILES = (
 )
 _MAX_SOURCE_FILE_BYTES = 8 * 1024 * 1024
 _MAX_SOURCE_TOTAL_BYTES = 16 * 1024 * 1024
+MANAGED_SIDECAR_SOURCE_SCHEMA = "veadk.managed-sidecar-source/v1"
+MANAGED_SIDECAR_SOURCE_MARKER = ".veadk-managed-sidecar-source.json"
+_SOURCE_FINGERPRINT_DOMAIN = f"{MANAGED_SIDECAR_SOURCE_SCHEMA}\0".encode()
 
 
 class ManagedSidecarSourceError(RuntimeError):
@@ -57,6 +63,7 @@ class ManagedSidecarSourceError(RuntimeError):
 class ManagedSidecarSourceSnapshot:
     file_count: int
     total_bytes: int
+    sha256: str
 
 
 def _canonical_requirement_name(line: str) -> str | None:
@@ -83,7 +90,7 @@ def rewrite_managed_sidecar_requirements(requirements: str) -> str:
     if not veadk_removed:
         raise ManagedSidecarSourceError("veadk_requirement_missing")
     lines = [
-        "# veadk-python is provided by the Studio-managed public source snapshot.",
+        "# veadk-python is provided by the managed Sidecar platform contract.",
         _MANAGED_SDK_REQUIREMENT,
         _MANAGED_MCP_REQUIREMENT,
         _MANAGED_ADK_REQUIREMENT,
@@ -98,7 +105,7 @@ def _source_files(package_dir: Path) -> list[tuple[Path, Path, int]]:
     for source in sorted(package_dir.rglob("*")):
         relative = source.relative_to(package_dir)
         if any(
-            part in _IGNORED_PARTS or part.startswith(".env") for part in relative.parts
+            part in _IGNORED_PARTS or part.startswith(".") for part in relative.parts
         ):
             continue
         if source.is_symlink():
@@ -117,6 +124,55 @@ def _source_files(package_dir: Path) -> list[tuple[Path, Path, int]]:
     return files
 
 
+def _fingerprint_source_files(files: list[tuple[Path, Path, int]]) -> str:
+    digest = hashlib.sha256(_SOURCE_FINGERPRINT_DOMAIN)
+    for source, relative, size in files:
+        relative_bytes = relative.as_posix().encode("utf-8")
+        digest.update(struct.pack(">Q", len(relative_bytes)))
+        digest.update(relative_bytes)
+        digest.update(struct.pack(">Q", size))
+        with source.open("rb") as source_file:
+            while chunk := source_file.read(1024 * 1024):
+                digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validated_source_root(package_dir: Path | None) -> Path:
+    source_root = (package_dir or Path(__file__).resolve().parents[1]).resolve()
+    if source_root.name != "veadk" or any(
+        not (source_root / relative).is_file() for relative in _REQUIRED_SOURCE_FILES
+    ):
+        raise ManagedSidecarSourceError("managed_source_incomplete")
+    return source_root
+
+
+def _snapshot_from_files(
+    files: list[tuple[Path, Path, int]],
+) -> ManagedSidecarSourceSnapshot:
+    return ManagedSidecarSourceSnapshot(
+        file_count=len(files),
+        total_bytes=sum(size for _source, _relative, size in files),
+        sha256=_fingerprint_source_files(files),
+    )
+
+
+def managed_sidecar_source_snapshot(
+    package_dir: Path | None = None,
+) -> ManagedSidecarSourceSnapshot:
+    """Fingerprint the public VeADK source owned by a managed Sidecar base."""
+
+    return _snapshot_from_files(_source_files(_validated_source_root(package_dir)))
+
+
+def _marker_payload(snapshot: ManagedSidecarSourceSnapshot) -> dict[str, int | str]:
+    return {
+        "fileCount": snapshot.file_count,
+        "schemaVersion": MANAGED_SIDECAR_SOURCE_SCHEMA,
+        "sha256": snapshot.sha256,
+        "totalBytes": snapshot.total_bytes,
+    }
+
+
 def stage_managed_sidecar_veadk_source(
     project_dir: Path,
     *,
@@ -125,11 +181,7 @@ def stage_managed_sidecar_veadk_source(
     """Copy public VeADK runtime source into one ephemeral deployment tree."""
 
     project_dir = project_dir.resolve()
-    source_root = (package_dir or Path(__file__).resolve().parents[1]).resolve()
-    if source_root.name != "veadk" or any(
-        not (source_root / relative).is_file() for relative in _REQUIRED_SOURCE_FILES
-    ):
-        raise ManagedSidecarSourceError("managed_source_incomplete")
+    source_root = _validated_source_root(package_dir)
 
     requirements_path = project_dir / "requirements.txt"
     if not requirements_path.is_file():
@@ -137,11 +189,15 @@ def stage_managed_sidecar_veadk_source(
     target_root = project_dir / "veadk"
     if target_root.exists():
         raise ManagedSidecarSourceError("managed_source_target_exists")
+    marker_path = project_dir / MANAGED_SIDECAR_SOURCE_MARKER
+    if marker_path.exists():
+        raise ManagedSidecarSourceError("managed_source_marker_exists")
 
     rewritten = rewrite_managed_sidecar_requirements(
         requirements_path.read_text(encoding="utf-8")
     )
     files = _source_files(source_root)
+    snapshot = _snapshot_from_files(files)
 
     target_root.mkdir(mode=0o755)
     for source, relative, _size in files:
@@ -150,7 +206,9 @@ def stage_managed_sidecar_veadk_source(
         shutil.copyfile(source, target)
         target.chmod(source.stat().st_mode & 0o777)
     requirements_path.write_text(rewritten, encoding="utf-8")
-    return ManagedSidecarSourceSnapshot(
-        file_count=len(files),
-        total_bytes=sum(size for _source, _relative, size in files),
+    marker_path.write_text(
+        json.dumps(_marker_payload(snapshot), sort_keys=True, separators=(",", ":"))
+        + "\n",
+        encoding="utf-8",
     )
+    return snapshot


### PR DESCRIPTION
## Summary

- emit a schema-versioned deterministic fingerprint for the VeADK snapshot bundled with the current Studio release
- - let the matching AgentKit CLI elide only an exact managed snapshot already present in the immutable Sidecar base
- - fail closed on stale, missing, malformed, or mismatched markers while leaving customer-owned and ordinary non-Sidecar source unchanged
## Performance

With the paired AgentKit CLI change, the latest managed application archive is 7,299 bytes. A latest-byte cold-cache cloud build completed end to end in 147.52 seconds with zero cache hits, below the four-minute release target with about 92 seconds of margin.

## Verification

- focused VeADK managed-source and contract tests: 20 passed
- - scoped pre-commit hooks and diff check: passed
- - full suite: 2,706 passed, 6 skipped, and 6 subtests passed; two unrelated debug lifecycle timeouts pass in isolation
- - network-isolated Sidecar, MCP, and real-Agent acceptance: passed
- - cloud reconciliation: standard OCI export/push, zero fixed error markers, source cleanup confirmed, and no customer Runtime or FaaS touched
Paired CLI delivery: iaasng/agentkit-cli!79.