### PR TITLE
fix(studio): support public managed sidecar bases

### DIFF
--- a/frontend/server/deployment_resources.py
+++ b/frontend/server/deployment_resources.py
@@ -875,7 +875,15 @@ class DeploymentResourceService:
         base_image: str,
         config: Mapping[str, str],
     ) -> dict[str, str]:
-        """Bind a managed Sidecar build to the CR that owns its base image."""
+        """Bind account-owned bases while leaving external public bases unbound.
+
+        A managed base can live in a platform-owned public registry. Such a
+        registry is intentionally absent from the customer's ``ListRegistries``
+        result, and the application image must still be pushed to a CR owned by
+        the customer. Only anchor when the base host belongs to exactly one CR
+        in the current account; a successful lookup with no match therefore
+        means that the immutable base is external to the account.
+        """
         if self.provider != "volcengine":
             raise ManagedSidecarRegistryError(
                 "Harness Sidecar 当前无法定位所需的客户 CR。"
@@ -912,6 +920,8 @@ class DeploymentResourceService:
                 "无法从当前账号唯一定位受控 Harness Sidecar 基础镜像所在的 CR。"
             ) from error
 
+        if not matches:
+            return dict(config)
         if len(matches) != 1:
             raise ManagedSidecarRegistryError(
                 "无法从当前账号唯一定位受控 Harness Sidecar 基础镜像所在的 CR。"

--- a/tests/frontend/server/test_deployment_resources.py
+++ b/tests/frontend/server/test_deployment_resources.py
@@ -280,6 +280,31 @@ def test_managed_sidecar_auto_cr_anchors_to_base_image_registry() -> None:
 @pytest.mark.parametrize(
     "config",
     [
+        {},
+        {
+            "cr_instance_name": "customer-registry",
+            "cr_namespace_name": "agentkit",
+            "cr_repo_name": "customer-agent",
+        },
+    ],
+)
+def test_managed_sidecar_public_base_keeps_customer_application_cr(
+    config: dict[str, str],
+) -> None:
+    service = _managed_sidecar_resource_service()
+
+    assert (
+        service.anchor_managed_sidecar_registry(
+            "platform-public.example.invalid/sidecar/runtime@sha256:test-only",
+            config,
+        )
+        == config
+    )
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
         {"cr_instance_name": "unrelated"},
         {
             "cr_instance_name": "managed",


### PR DESCRIPTION
## Summary

- Allow immutable managed Harness Sidecar bases to be hosted in a platform public registry outside the customer account.
- - Keep the customer-selected application CR, or let AgentKit auto-create it, when the public base has no match in `ListRegistries`.
- - Preserve fail-closed behavior for account-owned conflicts, ambiguous matches, lookup failures, and unsupported providers.
## Tests

- `pytest -q tests/frontend/server/test_deployment_resources.py` (27 passed)
- - `ruff check frontend/server/deployment_resources.py tests/frontend/server/test_deployment_resources.py`
- - `ruff format --check frontend/server/deployment_resources.py tests/frontend/server/test_deployment_resources.py`
- - `git diff --check`