### PR TITLE
fix(studio): consolidate managed Sidecar deployment fixes

### DIFF
--- a/frontend/server/deployment_resources.py
+++ b/frontend/server/deployment_resources.py
@@ -875,7 +875,15 @@ class DeploymentResourceService:
         base_image: str,
         config: Mapping[str, str],
     ) -> dict[str, str]:
-        """Bind a managed Sidecar build to the CR that owns its base image."""
+        """Bind account-owned bases while leaving external public bases unbound.
+
+        A managed base can live in a platform-owned public registry. Such a
+        registry is intentionally absent from the customer's ``ListRegistries``
+        result, and the application image must still be pushed to a CR owned by
+        the customer. Only anchor when the base host belongs to exactly one CR
+        in the current account; a successful lookup with no match therefore
+        means that the immutable base is external to the account.
+        """
         if self.provider != "volcengine":
             raise ManagedSidecarRegistryError(
                 "Harness Sidecar 当前无法定位所需的客户 CR。"
@@ -912,6 +920,8 @@ class DeploymentResourceService:
                 "无法从当前账号唯一定位受控 Harness Sidecar 基础镜像所在的 CR。"
             ) from error
 
+        if not matches:
+            return dict(config)
         if len(matches) != 1:
             raise ManagedSidecarRegistryError(
                 "无法从当前账号唯一定位受控 Harness Sidecar 基础镜像所在的 CR。"

--- a/tests/cli/test_frontend_runtime_proxy.py
+++ b/tests/cli/test_frontend_runtime_proxy.py
@@ -378,26 +378,35 @@ def test_runtime_route_channel_connects_after_runtime_probe(
     )
     app = _create_frontend_app(monkeypatch, tmp_path)
 
+    runtime = SimpleNamespace(
+        runtime_id="runtime-1",
+        project_name="default",
+        network_configurations=[
+            SimpleNamespace(
+                endpoint="https://runtime.example",
+                network_type="public",
+            )
+        ],
+        authorizer_configuration=SimpleNamespace(
+            key_auth=SimpleNamespace(api_key="runtime-api-key"),
+            custom_jwt_authorizer=None,
+        ),
+        tags=[],
+    )
+
     class _FakeRuntimeClient:
         def __init__(self, **kwargs: Any) -> None:
             del kwargs
 
         def get_runtime(self, request: Any) -> SimpleNamespace:
             del request
+            raise RuntimeError("InvalidAgentKitRuntime.NotFound: hidden")
+
+        def list_runtimes(self, request: Any) -> SimpleNamespace:
+            del request
             return SimpleNamespace(
-                runtime_id="runtime-1",
-                project_name="default",
-                network_configurations=[
-                    SimpleNamespace(
-                        endpoint="https://runtime.example",
-                        network_type="public",
-                    )
-                ],
-                authorizer_configuration=SimpleNamespace(
-                    key_auth=SimpleNamespace(api_key="runtime-api-key"),
-                    custom_jwt_authorizer=None,
-                ),
-                tags=[],
+                agent_kit_runtimes=[runtime],
+                next_token=None,
             )
 
     monkeypatch.setattr(
@@ -419,6 +428,67 @@ def test_runtime_route_channel_connects_after_runtime_probe(
         "endpoint": "https://runtime.example",
         "authorization": "Bearer runtime-api-key",
     }
+
+
+def test_runtime_tool_capabilities_use_list_fallback_when_get_is_hidden(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app = _create_frontend_app(monkeypatch, tmp_path)
+    runtime = SimpleNamespace(
+        runtime_id="runtime-1",
+        network_configurations=[
+            SimpleNamespace(
+                endpoint="https://runtime.example",
+                network_type="public",
+            )
+        ],
+        authorizer_configuration=SimpleNamespace(
+            key_auth=SimpleNamespace(api_key="runtime-api-key"),
+            custom_jwt_authorizer=None,
+        ),
+        tags=[],
+    )
+
+    class _FakeRuntimeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            del kwargs
+
+        def get_runtime(self, request: Any) -> SimpleNamespace:
+            del request
+            raise RuntimeError("InvalidAgentKitRuntime.NotFound: hidden")
+
+        def list_runtimes(self, request: Any) -> SimpleNamespace:
+            del request
+            return SimpleNamespace(
+                agent_kit_runtimes=[runtime],
+                next_token=None,
+            )
+
+    monkeypatch.setattr(
+        "agentkit.sdk.runtime.client.AgentkitRuntimeClient",
+        _FakeRuntimeClient,
+    )
+
+    async def fake_runtime_supports_bff_tools(**kwargs: Any) -> bool:
+        assert kwargs == {
+            "endpoint": "https://runtime.example",
+            "authorization": "Bearer runtime-api-key",
+        }
+        return True
+
+    monkeypatch.setattr(
+        "frontend.server.studio_tools.runtime_supports_bff_tools",
+        fake_runtime_supports_bff_tools,
+    )
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/web/runtime-tool-channel/runtime-1/capabilities?region=cn-beijing"
+        )
+
+    assert response.status_code == 200
+    assert response.json()["supported"] is True
 
 
 def test_runtime_proxy_uses_plain_run_sse_when_runtime_lacks_bff_tool_host(
@@ -1748,6 +1818,150 @@ def test_runtime_proxy_retry_policy(
             if network_type == "private"
             else "runtime_proxy_connect_error"
         )
+
+
+@pytest.mark.parametrize(
+    "error_code",
+    ["InvalidResource.NotFound", "InvalidAgentKitRuntime.NotFound"],
+)
+def test_runtime_proxy_classifies_runtime_lookup_not_found_without_raw_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    error_code: str,
+) -> None:
+    app = _create_frontend_app(monkeypatch, tmp_path)
+
+    class _FakeRuntimeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            del kwargs
+
+        def get_runtime(self, request: Any) -> SimpleNamespace:
+            del request
+            raise RuntimeError(f"{error_code}: protected-upstream-detail")
+
+        def list_runtimes(self, request: Any) -> SimpleNamespace:
+            del request
+            return SimpleNamespace(
+                agent_kit_runtimes=[],
+                next_token=None,
+            )
+
+    monkeypatch.setattr(
+        "agentkit.sdk.runtime.client.AgentkitRuntimeClient",
+        _FakeRuntimeClient,
+    )
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/web/runtime-proxy/runtime-1/list-apps?_runtime_region=cn-shanghai"
+        )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "runtime_not_found"}
+    assert "protected-upstream-detail" not in response.text
+
+
+def test_runtime_proxy_uses_exact_list_item_when_role_get_runtime_is_hidden(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app = _create_frontend_app(monkeypatch, tmp_path)
+    list_requests: list[Any] = []
+
+    class _FakeRuntimeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            assert kwargs["region"] == "cn-shanghai"
+
+        def get_runtime(self, request: Any) -> SimpleNamespace:
+            del request
+            raise RuntimeError(
+                "InvalidAgentKitRuntime.NotFound: protected-upstream-detail"
+            )
+
+        def list_runtimes(self, request: Any) -> SimpleNamespace:
+            list_requests.append(request)
+            return SimpleNamespace(
+                agent_kit_runtimes=[
+                    SimpleNamespace(
+                        runtime_id="runtime-1",
+                        name="runtime-name",
+                        status="Ready",
+                        current_version_number=2,
+                        network_configurations=[
+                            SimpleNamespace(
+                                endpoint="https://runtime.example",
+                                network_type="public",
+                            )
+                        ],
+                        authorizer_configuration=SimpleNamespace(
+                            key_auth=SimpleNamespace(api_key="runtime-api-key"),
+                            custom_jwt_authorizer=None,
+                        ),
+                        tags=[],
+                    )
+                ],
+                next_token=None,
+            )
+
+    monkeypatch.setattr(
+        "agentkit.sdk.runtime.client.AgentkitRuntimeClient",
+        _FakeRuntimeClient,
+    )
+
+    class _FakeUpstreamResponse:
+        status_code = 200
+        headers: ClassVar[dict[str, str]] = {"content-type": "application/json"}
+
+        async def aiter_raw(self):
+            yield b'["demo_agent"]'
+
+        async def aclose(self) -> None:
+            pass
+
+    class _FakeAsyncClient:
+        def __init__(self, **kwargs: Any) -> None:
+            del kwargs
+
+        def build_request(
+            self,
+            method: str,
+            url: str,
+            *,
+            params: dict[str, str],
+            headers: dict[str, str],
+            content: bytes,
+        ) -> object:
+            assert method == "GET"
+            assert url == "https://runtime.example/list-apps"
+            assert params == {}
+            assert headers["Authorization"] == "Bearer runtime-api-key"
+            assert content == b""
+            return object()
+
+        async def send(
+            self,
+            request: object,
+            *,
+            stream: bool,
+        ) -> _FakeUpstreamResponse:
+            del request
+            assert stream is True
+            return _FakeUpstreamResponse()
+
+        async def aclose(self) -> None:
+            pass
+
+    monkeypatch.setattr("httpx.AsyncClient", _FakeAsyncClient)
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/web/runtime-proxy/runtime-1/list-apps"
+            "?_runtime_region=cn-shanghai&probe_retry=connect"
+        )
+
+    assert response.status_code == 200
+    assert response.json() == ["demo_agent"]
+    assert len(list_requests) == 1
 
 
 def test_runtime_proxy_resolves_studio_media_before_forwarding(

--- a/tests/cli/test_managed_sidecar_source.py
+++ b/tests/cli/test_managed_sidecar_source.py
@@ -46,14 +46,14 @@ def _package(root: Path) -> Path:
     return package
 
 
-def test_rewrite_uses_source_snapshot_and_pins_public_sdk() -> None:
+def test_rewrite_uses_source_snapshot_and_pins_runtime_dependencies() -> None:
     rewritten = rewrite_managed_sidecar_requirements(
         "\n".join(
             (
                 "veadk-python[harness-sidecar]>=1.1.1",
                 "agentkit_sdk_python>=0.8.0,<0.9.0",
                 "agentkit-harness-sidecar-integration==0.1.0",
-                "google-adk>=1.34.0",
+                "google_adk==1.23.0",
                 "mcp==1.20.0",
                 "",
             )
@@ -65,9 +65,10 @@ def test_rewrite_uses_source_snapshot_and_pins_public_sdk() -> None:
     assert "agentkit-harness-sidecar-integration" not in rewritten
     assert rewritten.splitlines()[1] == "agentkit-sdk-python==0.8.1"
     assert rewritten.splitlines().count("agentkit-sdk-python==0.8.1") == 1
-    assert "google-adk>=1.34.0" in rewritten
     assert rewritten.splitlines().count("mcp==1.26.0") == 1
     assert "mcp==1.20.0" not in rewritten
+    assert rewritten.splitlines().count("google-adk>=1.34.0") == 1
+    assert "google_adk==1.23.0" not in rewritten
 
 
 def test_rewrite_preserves_comments_and_rejects_missing_veadk() -> None:
@@ -118,6 +119,8 @@ def test_stage_copies_only_safe_runtime_source_and_rewrites_requirements(
     requirements = (project / "requirements.txt").read_text(encoding="utf-8")
     assert requirements.splitlines().count("agentkit-sdk-python==0.8.1") == 1
     assert requirements.splitlines().count("mcp==1.26.0") == 1
+    assert requirements.splitlines().count("google-adk>=1.34.0") == 1
+    assert "\ngoogle-adk\n" not in f"\n{requirements}"
     assert "veadk-python[" not in requirements
 
 

--- a/tests/cli/test_managed_sidecar_source.py
+++ b/tests/cli/test_managed_sidecar_source.py
@@ -14,13 +14,17 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
 from veadk.cli import managed_sidecar_source
 from veadk.cli.managed_sidecar_source import (
+    MANAGED_SIDECAR_SOURCE_MARKER,
+    MANAGED_SIDECAR_SOURCE_SCHEMA,
     ManagedSidecarSourceError,
+    managed_sidecar_source_snapshot,
     rewrite_managed_sidecar_requirements,
     stage_managed_sidecar_veadk_source,
 )
@@ -98,6 +102,7 @@ def test_stage_copies_only_safe_runtime_source_and_rewrites_requirements(
     webui.mkdir()
     (webui / "bundle.js").write_bytes(b"browser-only")
     (package / ".env.local").write_text("SECRET=ignored\n", encoding="utf-8")
+    (package / ".python-version").write_text("3.12\n", encoding="utf-8")
     project = tmp_path / "project"
     project.mkdir()
     (project / "requirements.txt").write_text(
@@ -112,16 +117,53 @@ def test_stage_copies_only_safe_runtime_source_and_rewrites_requirements(
 
     assert snapshot.file_count == len(_REQUIRED_FILES) + 1
     assert snapshot.total_bytes > 0
+    assert len(snapshot.sha256) == 64
     assert (project / "veadk/extensions/harness/sidecar.py").is_file()
     assert not (project / "veadk/__pycache__").exists()
     assert not (project / "veadk/webui").exists()
     assert not (project / "veadk/.env.local").exists()
+    assert not (project / "veadk/.python-version").exists()
     requirements = (project / "requirements.txt").read_text(encoding="utf-8")
     assert requirements.splitlines().count("agentkit-sdk-python==0.8.1") == 1
     assert requirements.splitlines().count("mcp==1.26.0") == 1
     assert requirements.splitlines().count("google-adk>=1.34.0") == 1
     assert "\ngoogle-adk\n" not in f"\n{requirements}"
     assert "veadk-python[" not in requirements
+    assert json.loads(
+        (project / MANAGED_SIDECAR_SOURCE_MARKER).read_text(encoding="utf-8")
+    ) == {
+        "fileCount": snapshot.file_count,
+        "schemaVersion": MANAGED_SIDECAR_SOURCE_SCHEMA,
+        "sha256": snapshot.sha256,
+        "totalBytes": snapshot.total_bytes,
+    }
+
+
+def test_source_fingerprint_has_a_cross_runtime_stable_vector(tmp_path: Path) -> None:
+    package = tmp_path / "veadk"
+    (package / "nested").mkdir(parents=True)
+    (package / "a.py").write_bytes(b"alpha\n")
+    (package / "nested/b.json").write_bytes(b"{}\n")
+
+    files = managed_sidecar_source._source_files(package)
+
+    assert managed_sidecar_source._fingerprint_source_files(files) == (
+        "89a1c958a26e3cc0948692702b52a6652027b7c59934b8337d8cad30a67cbe21"
+    )
+
+
+def test_source_snapshot_changes_with_managed_bytes(tmp_path: Path) -> None:
+    package = _package(tmp_path / "installed")
+    first = managed_sidecar_source_snapshot(package)
+
+    changed_path = package / "extensions/harness/sidecar.py"
+    original = changed_path.read_bytes()
+    changed_path.write_bytes(b"!" + original[1:])
+    second = managed_sidecar_source_snapshot(package)
+
+    assert first.file_count == second.file_count
+    assert first.total_bytes == second.total_bytes
+    assert first.sha256 != second.sha256
 
 
 def test_stage_fails_closed_for_existing_target(tmp_path: Path) -> None:
@@ -135,6 +177,20 @@ def test_stage_fails_closed_for_existing_target(tmp_path: Path) -> None:
     (project / "veadk").mkdir()
 
     with pytest.raises(ManagedSidecarSourceError, match="target_exists"):
+        stage_managed_sidecar_veadk_source(project, package_dir=package)
+
+
+def test_stage_fails_closed_for_existing_marker(tmp_path: Path) -> None:
+    package = _package(tmp_path / "installed")
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "requirements.txt").write_text(
+        "veadk-python[harness-sidecar]\n",
+        encoding="utf-8",
+    )
+    (project / MANAGED_SIDECAR_SOURCE_MARKER).write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ManagedSidecarSourceError, match="marker_exists"):
         stage_managed_sidecar_veadk_source(project, package_dir=package)
 
 

--- a/tests/cli/test_studio_rbac.py
+++ b/tests/cli/test_studio_rbac.py
@@ -2849,6 +2849,43 @@ def test_runtime_detail_proxy_and_delete_enforce_role_and_owner(
     assert deleted == ["runtime-developer", "runtime-other"]
 
 
+def test_runtime_proxy_list_fallback_still_enforces_runtime_owner(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from agentkit.sdk.runtime.client import AgentkitRuntimeClient
+
+    runtime = _runtime_with_public_endpoint(_runtime("runtime-other", "someone-else"))
+
+    def get_runtime(_self: Any, _request: Any) -> SimpleNamespace:
+        raise RuntimeError("InvalidAgentKitRuntime.NotFound: protected-detail")
+
+    def list_runtimes(_self: Any, _request: Any) -> SimpleNamespace:
+        return SimpleNamespace(
+            agent_kit_runtimes=[runtime],
+            next_token=None,
+        )
+
+    monkeypatch.setattr(AgentkitRuntimeClient, "get_runtime", get_runtime)
+    monkeypatch.setattr(AgentkitRuntimeClient, "list_runtimes", list_runtimes)
+    app = _create_studio_app(
+        monkeypatch,
+        tmp_path,
+        admins="admin",
+        developers="developer",
+    )
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/web/runtime-proxy/runtime-other/list-apps?region=cn-beijing",
+            headers={"X-VeADK-Local-User": "developer"},
+        )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "runtime_access_denied"
+    assert "protected-detail" not in response.text
+
+
 def test_agent_usage_requires_management_role_and_runtime_ownership(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/frontend/server/test_deployment_resources.py
+++ b/tests/frontend/server/test_deployment_resources.py
@@ -280,6 +280,31 @@ def test_managed_sidecar_auto_cr_anchors_to_base_image_registry() -> None:
 @pytest.mark.parametrize(
     "config",
     [
+        {},
+        {
+            "cr_instance_name": "customer-registry",
+            "cr_namespace_name": "agentkit",
+            "cr_repo_name": "customer-agent",
+        },
+    ],
+)
+def test_managed_sidecar_public_base_keeps_customer_application_cr(
+    config: dict[str, str],
+) -> None:
+    service = _managed_sidecar_resource_service()
+
+    assert (
+        service.anchor_managed_sidecar_registry(
+            "platform-public.example.invalid/sidecar/runtime@sha256:test-only",
+            config,
+        )
+        == config
+    )
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
         {"cr_instance_name": "unrelated"},
         {
             "cr_instance_name": "managed",

--- a/veadk/cli/agentkit_sandbox_region.py
+++ b/veadk/cli/agentkit_sandbox_region.py
@@ -24,7 +24,10 @@ from veadk.utils.cloud_provider import (
 
 _SANDBOX_REGIONS = ("cn-beijing", "cn-shanghai")
 _BYTEPLUS_SANDBOX_REGIONS = ("ap-southeast-1",)
-_RESOURCE_NOT_FOUND_CODE = "InvalidResource.NotFound"
+_RESOURCE_NOT_FOUND_CODES = (
+    "InvalidResource.NotFound",
+    "InvalidAgentKitRuntime.NotFound",
+)
 
 
 def sandbox_region_candidates(
@@ -66,4 +69,5 @@ def resolve_sandbox_client_region(region: str | None, *, provider: str) -> str:
 
 
 def is_agentkit_resource_not_found(error: object) -> bool:
-    return _RESOURCE_NOT_FOUND_CODE.lower() in str(error or "").lower()
+    message = str(error or "").lower()
+    return any(code.lower() in message for code in _RESOURCE_NOT_FOUND_CODES)

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -7294,6 +7294,47 @@ def _run_frontend_server(
         )
         return client.get_runtime(_rt.GetRuntimeRequest(runtime_id=runtime_id))
 
+    def _list_runtime_for_connection(
+        runtime_id: str,
+        region: str,
+    ) -> Any | None:
+        """Resolve an exact visible Runtime for connection-only access.
+
+        A VeFaaS service role can list an authorized Runtime while GetRuntime
+        hides the same resource behind NotFound. List entries still contain the
+        endpoint, authorizer, and ownership tags needed by data-plane routes.
+        Keep this fallback bounded and connection-only; mutation and full-detail
+        routes continue to require GetRuntime.
+        """
+        from agentkit.sdk.runtime import types as _rt
+        from agentkit.sdk.runtime.client import AgentkitRuntimeClient
+
+        ak, sk, token = _resolve_ve_credentials()
+        client = AgentkitRuntimeClient(
+            access_key=ak,
+            secret_key=sk,
+            session_token=token or "",
+            region=region,
+        )
+        matches: list[Any] = []
+        next_token = ""
+        for _ in range(20):
+            kwargs: dict[str, Any] = {"page_size": 100}
+            if next_token:
+                kwargs["next_token"] = next_token
+            response = client.list_runtimes(_rt.ListRuntimesRequest(**kwargs))
+            matches.extend(
+                runtime
+                for runtime in (response.agent_kit_runtimes or [])
+                if str(getattr(runtime, "runtime_id", "") or "") == runtime_id
+            )
+            if len(matches) > 1:
+                raise RuntimeError("duplicate Runtime identity in ListRuntimes")
+            next_token = str(getattr(response, "next_token", "") or "")
+            if not next_token:
+                break
+        return matches[0] if matches else None
+
     def _authorized_runtime(
         request: Request,
         runtime_id: str,
@@ -7317,6 +7358,43 @@ def _run_frontend_server(
             )
         if managed_only and tags.get("veadk:managed") != "true":
             raise HTTPException(status_code=404, detail="Runtime not found")
+        return runtime
+
+    def _authorized_runtime_for_connection(
+        request: Request,
+        runtime_id: str,
+        region: str,
+    ) -> Any:
+        try:
+            return _authorized_runtime(
+                request,
+                runtime_id,
+                region,
+                coded_access_error=True,
+            )
+        except HTTPException:
+            raise
+        except Exception as error:
+            if not is_agentkit_resource_not_found(error):
+                raise
+            runtime = _list_runtime_for_connection(runtime_id, region)
+            if runtime is None:
+                raise
+
+        principal = _current_principal(request)
+        role = _request_role(request)
+        tags = _runtime_tags(runtime)
+        if role != StudioRole.ADMIN and not runtime_belongs_to(tags, principal):
+            raise HTTPException(
+                status_code=404,
+                detail="runtime_access_denied",
+            )
+        logger.info(
+            "runtime connection metadata resolved through exact ListRuntimes "
+            "fallback runtime_id=%s region=%s",
+            runtime_id,
+            region,
+        )
         return runtime
 
     from frontend.server.cronjobs import (
@@ -8073,11 +8151,10 @@ def _run_frontend_server(
 
         region = _coerce_cloud_region(request.query_params.get("region"))
         try:
-            runtime = _authorized_runtime(
+            runtime = _authorized_runtime_for_connection(
                 request,
                 runtime_id,
                 region,
-                coded_access_error=True,
             )
             endpoint, apikey, auth_type, _ = _resolve_runtime_conn(
                 runtime_id,
@@ -8121,11 +8198,10 @@ def _run_frontend_server(
 
         region = _coerce_cloud_region(request.query_params.get("region"))
         try:
-            runtime = _authorized_runtime(
+            runtime = _authorized_runtime_for_connection(
                 request,
                 runtime_id,
                 region,
-                coded_access_error=True,
             )
             endpoint, apikey, auth_type, _ = _resolve_runtime_conn(
                 runtime_id,
@@ -8352,11 +8428,10 @@ def _run_frontend_server(
             proxy_region or request.query_params.get("region")
         )
         try:
-            runtime = _authorized_runtime(
+            runtime = _authorized_runtime_for_connection(
                 request,
                 runtime_id,
                 region,
-                coded_access_error=True,
             )
             endpoint, apikey, auth_type, endpoint_network_type = _resolve_runtime_conn(
                 runtime_id,
@@ -8365,9 +8440,27 @@ def _run_frontend_server(
             )
         except HTTPException:
             raise
-        except Exception as e:
-            logger.error(f"resolve runtime conn failed: {e}", exc_info=True)
-            raise HTTPException(status_code=502, detail=str(e))
+        except Exception as error:
+            if is_agentkit_resource_not_found(error):
+                logger.info(
+                    "runtime lookup not found runtime_id=%s region=%s",
+                    runtime_id,
+                    region,
+                )
+                raise HTTPException(
+                    status_code=404,
+                    detail="runtime_not_found",
+                ) from error
+            logger.error(
+                "resolve runtime conn failed runtime_id=%s region=%s",
+                runtime_id,
+                region,
+                exc_info=True,
+            )
+            raise HTTPException(
+                status_code=502,
+                detail="runtime_lookup_failed",
+            ) from error
 
         # Drop Studio-only query params; keep any real API query params.
         studio_query_params = {"probe_retry", "_method", "_runtime_region"}

--- a/veadk/cli/managed_sidecar_source.py
+++ b/veadk/cli/managed_sidecar_source.py
@@ -26,11 +26,13 @@ _REQUIREMENT_NAME_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)")
 _REMOVED_DISTRIBUTIONS = {
     "agentkit-sdk-python",
     "agentkit-harness-sidecar-integration",
+    "google-adk",
     "mcp",
     "veadk-python",
 }
 _MANAGED_SDK_REQUIREMENT = "agentkit-sdk-python==0.8.1"
 _MANAGED_MCP_REQUIREMENT = "mcp==1.26.0"
+_MANAGED_ADK_REQUIREMENT = "google-adk>=1.34.0"
 _IGNORED_PARTS = {".git", "__pycache__", "webui"}
 _IGNORED_SUFFIXES = {".pyc", ".pyo"}
 _BLOCKED_SUFFIXES = {".key", ".p12", ".pem", ".pfx"}
@@ -68,7 +70,7 @@ def _canonical_requirement_name(line: str) -> str | None:
 
 
 def rewrite_managed_sidecar_requirements(requirements: str) -> str:
-    """Use in-snapshot VeADK and install the approved public SDK explicitly."""
+    """Use in-snapshot VeADK and install approved runtime dependencies."""
 
     lines: list[str] = []
     veadk_removed = False
@@ -84,6 +86,7 @@ def rewrite_managed_sidecar_requirements(requirements: str) -> str:
         "# veadk-python is provided by the Studio-managed public source snapshot.",
         _MANAGED_SDK_REQUIREMENT,
         _MANAGED_MCP_REQUIREMENT,
+        _MANAGED_ADK_REQUIREMENT,
         *lines,
     ]
     return "\n".join(lines).rstrip() + "\n"

--- a/veadk/cli/managed_sidecar_source.py
+++ b/veadk/cli/managed_sidecar_source.py
@@ -16,8 +16,11 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 import shutil
+import struct
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -47,6 +50,9 @@ _REQUIRED_SOURCE_FILES = (
 )
 _MAX_SOURCE_FILE_BYTES = 8 * 1024 * 1024
 _MAX_SOURCE_TOTAL_BYTES = 16 * 1024 * 1024
+MANAGED_SIDECAR_SOURCE_SCHEMA = "veadk.managed-sidecar-source/v1"
+MANAGED_SIDECAR_SOURCE_MARKER = ".veadk-managed-sidecar-source.json"
+_SOURCE_FINGERPRINT_DOMAIN = f"{MANAGED_SIDECAR_SOURCE_SCHEMA}\0".encode()
 
 
 class ManagedSidecarSourceError(RuntimeError):
@@ -57,6 +63,7 @@ class ManagedSidecarSourceError(RuntimeError):
 class ManagedSidecarSourceSnapshot:
     file_count: int
     total_bytes: int
+    sha256: str
 
 
 def _canonical_requirement_name(line: str) -> str | None:
@@ -83,7 +90,7 @@ def rewrite_managed_sidecar_requirements(requirements: str) -> str:
     if not veadk_removed:
         raise ManagedSidecarSourceError("veadk_requirement_missing")
     lines = [
-        "# veadk-python is provided by the Studio-managed public source snapshot.",
+        "# veadk-python is provided by the managed Sidecar platform contract.",
         _MANAGED_SDK_REQUIREMENT,
         _MANAGED_MCP_REQUIREMENT,
         _MANAGED_ADK_REQUIREMENT,
@@ -98,7 +105,7 @@ def _source_files(package_dir: Path) -> list[tuple[Path, Path, int]]:
     for source in sorted(package_dir.rglob("*")):
         relative = source.relative_to(package_dir)
         if any(
-            part in _IGNORED_PARTS or part.startswith(".env") for part in relative.parts
+            part in _IGNORED_PARTS or part.startswith(".") for part in relative.parts
         ):
             continue
         if source.is_symlink():
@@ -117,6 +124,55 @@ def _source_files(package_dir: Path) -> list[tuple[Path, Path, int]]:
     return files
 
 
+def _fingerprint_source_files(files: list[tuple[Path, Path, int]]) -> str:
+    digest = hashlib.sha256(_SOURCE_FINGERPRINT_DOMAIN)
+    for source, relative, size in files:
+        relative_bytes = relative.as_posix().encode("utf-8")
+        digest.update(struct.pack(">Q", len(relative_bytes)))
+        digest.update(relative_bytes)
+        digest.update(struct.pack(">Q", size))
+        with source.open("rb") as source_file:
+            while chunk := source_file.read(1024 * 1024):
+                digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validated_source_root(package_dir: Path | None) -> Path:
+    source_root = (package_dir or Path(__file__).resolve().parents[1]).resolve()
+    if source_root.name != "veadk" or any(
+        not (source_root / relative).is_file() for relative in _REQUIRED_SOURCE_FILES
+    ):
+        raise ManagedSidecarSourceError("managed_source_incomplete")
+    return source_root
+
+
+def _snapshot_from_files(
+    files: list[tuple[Path, Path, int]],
+) -> ManagedSidecarSourceSnapshot:
+    return ManagedSidecarSourceSnapshot(
+        file_count=len(files),
+        total_bytes=sum(size for _source, _relative, size in files),
+        sha256=_fingerprint_source_files(files),
+    )
+
+
+def managed_sidecar_source_snapshot(
+    package_dir: Path | None = None,
+) -> ManagedSidecarSourceSnapshot:
+    """Fingerprint the public VeADK source owned by a managed Sidecar base."""
+
+    return _snapshot_from_files(_source_files(_validated_source_root(package_dir)))
+
+
+def _marker_payload(snapshot: ManagedSidecarSourceSnapshot) -> dict[str, int | str]:
+    return {
+        "fileCount": snapshot.file_count,
+        "schemaVersion": MANAGED_SIDECAR_SOURCE_SCHEMA,
+        "sha256": snapshot.sha256,
+        "totalBytes": snapshot.total_bytes,
+    }
+
+
 def stage_managed_sidecar_veadk_source(
     project_dir: Path,
     *,
@@ -125,11 +181,7 @@ def stage_managed_sidecar_veadk_source(
     """Copy public VeADK runtime source into one ephemeral deployment tree."""
 
     project_dir = project_dir.resolve()
-    source_root = (package_dir or Path(__file__).resolve().parents[1]).resolve()
-    if source_root.name != "veadk" or any(
-        not (source_root / relative).is_file() for relative in _REQUIRED_SOURCE_FILES
-    ):
-        raise ManagedSidecarSourceError("managed_source_incomplete")
+    source_root = _validated_source_root(package_dir)
 
     requirements_path = project_dir / "requirements.txt"
     if not requirements_path.is_file():
@@ -137,11 +189,15 @@ def stage_managed_sidecar_veadk_source(
     target_root = project_dir / "veadk"
     if target_root.exists():
         raise ManagedSidecarSourceError("managed_source_target_exists")
+    marker_path = project_dir / MANAGED_SIDECAR_SOURCE_MARKER
+    if marker_path.exists():
+        raise ManagedSidecarSourceError("managed_source_marker_exists")
 
     rewritten = rewrite_managed_sidecar_requirements(
         requirements_path.read_text(encoding="utf-8")
     )
     files = _source_files(source_root)
+    snapshot = _snapshot_from_files(files)
 
     target_root.mkdir(mode=0o755)
     for source, relative, _size in files:
@@ -150,7 +206,9 @@ def stage_managed_sidecar_veadk_source(
         shutil.copyfile(source, target)
         target.chmod(source.stat().st_mode & 0o777)
     requirements_path.write_text(rewritten, encoding="utf-8")
-    return ManagedSidecarSourceSnapshot(
-        file_count=len(files),
-        total_bytes=sum(size for _source, _relative, size in files),
+    marker_path.write_text(
+        json.dumps(_marker_payload(snapshot), sort_keys=True, separators=(",", ":"))
+        + "\n",
+        encoding="utf-8",
     )
+    return snapshot


### PR DESCRIPTION
## Summary

- enforce the managed Sidecar SDK, MCP, and Google ADK dependency contract while fingerprinting the bundled VeADK source
- support platform-owned public Sidecar bases without overriding the customer's application CR selection
- add an RBAC-preserving, connection-only `ListRuntimes` fallback when a service role can list a Runtime but `GetRuntime` hides it

This consolidates and supersedes #966, #968, #985, and #990 on top of the latest `main`.

## Test plan

- `183 passed` across the four focused Sidecar, deployment-resource, Runtime-proxy, and RBAC test files
- `pre-commit run --all-files` (Ruff check, Ruff format, hardcoded-secret detection)
- changed-file Ruff check and format check
- Pyright regression comparison: 72 existing diagnostics on both current `main` and this branch, 0 new diagnostics
- full `pytest -q`: 2715 passed, 6 skipped; two debug-process readiness timeouts passed immediately when rerun in isolation (2/2)
