### PR TITLE
fix(studio): allow private MCP endpoints within attached VPC

### DIFF
--- a/tests/cli/test_generated_agent_backend_codegen.py
+++ b/tests/cli/test_generated_agent_backend_codegen.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 import py_compile
 import socket
 
@@ -731,8 +732,88 @@ def test_url_policy_rejects_dns_to_private_ip(monkeypatch) -> None:
         ]
 
     monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
-    with pytest.raises(DebugPolicyError):
+    with pytest.raises(DebugPolicyError, match="不属于当前云上 Studio"):
         validate_url_not_private("https://example.com", field_name="url")
+
+
+def test_url_policy_allows_dns_inside_studio_vpc(monkeypatch) -> None:
+    def fake_getaddrinfo(*args, **kwargs):
+        return [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                6,
+                "",
+                ("10.20.8.35", 443),
+            )
+        ]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    validate_url_not_private(
+        "https://mcp.customer.internal/mcp",
+        field_name="mcpTools.url",
+        private_network_resolver=lambda: (ipaddress.ip_network("10.20.0.0/16"),),
+    )
+
+
+def test_url_policy_rejects_metadata_even_inside_allowed_range() -> None:
+    with pytest.raises(DebugPolicyError, match="禁止访问的系统地址"):
+        validate_url_not_private(
+            "http://169.254.169.254/latest/meta-data",
+            field_name="mcpTools.url",
+            private_network_resolver=lambda: (ipaddress.ip_network("0.0.0.0/0"),),
+        )
+
+
+def test_debug_policy_resolves_vpc_networks_once_for_mcp_and_a2a(
+    monkeypatch,
+) -> None:
+    resolutions = {
+        "mcp.customer.internal": "10.20.8.35",
+        "agent.customer.internal": "10.20.9.40",
+    }
+
+    def fake_getaddrinfo(host, port, *args, **kwargs):
+        return [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                6,
+                "",
+                (resolutions[host], port),
+            )
+        ]
+
+    calls = 0
+
+    def private_networks():
+        nonlocal calls
+        calls += 1
+        return (ipaddress.ip_network("10.20.0.0/16"),)
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    draft = AgentDraft(
+        name="demo",
+        instruction="Use private services.",
+        mcpTools=[
+            {
+                "name": "private-mcp",
+                "transport": "http",
+                "url": "https://mcp.customer.internal/mcp",
+            }
+        ],
+        subAgents=[
+            AgentDraft(
+                name="private-a2a",
+                agentType="a2a",
+                a2aUrl="https://agent.customer.internal",
+            )
+        ],
+    )
+
+    validate_debug_policy(draft, private_network_resolver=private_networks)
+
+    assert calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_generated_agent_backend_codegen_extended.py
+++ b/tests/cli/test_generated_agent_backend_codegen_extended.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import io
 import json
 import secrets
@@ -30,6 +31,7 @@ import yaml
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
+from veadk.cli import cli_frontend
 from veadk.cli.cli_frontend import (
     _redact_debug_text,
     _run_frontend_server,
@@ -985,6 +987,168 @@ class _FakeSocket:
 
     def getsockname(self) -> tuple[str, int]:
         return ("127.0.0.1", 54321)
+
+
+def _generated_debug_app(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Any:
+    captured: dict[str, Any] = {}
+    monkeypatch.setenv("VOLCENGINE_ACCESS_KEY", "test-ak")
+    monkeypatch.setenv("VOLCENGINE_SECRET_KEY", "test-sk")
+    monkeypatch.setattr("dotenv.find_dotenv", lambda *args, **kwargs: "")
+    monkeypatch.setattr(
+        "uvicorn.run",
+        lambda app, **kwargs: captured.setdefault("app", app),
+    )
+    _run_frontend_server(
+        agents_dir=str(tmp_path),
+        frontend_dir=None,
+        site_logo=None,
+        site_title=None,
+        host="127.0.0.1",
+        port=8765,
+        dev=True,
+        vite=True,
+        oauth2_user_pool=None,
+        oauth2_user_pool_client=None,
+        oauth2_user_pool_uid=None,
+        oauth2_user_pool_client_uid=None,
+        oauth2_redirect_uri=None,
+        oauth2_provider=None,
+        oauth2_provider_label=None,
+        auth_mode="frontend",
+        generated_agent_test_run_ttl=60,
+        open_browser=False,
+    )
+    return captured["app"]
+
+
+def test_local_generated_debug_allows_private_mcp(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("VEADK_STUDIO_FUNCTION_ID", raising=False)
+    monkeypatch.delenv("_FAAS_FUNC_ID", raising=False)
+
+    async def keep_mcp_endpoints(draft):
+        return draft
+
+    monkeypatch.setattr(
+        "veadk.cli.generated_agent_mcp.resolve_debug_mcp_endpoints",
+        keep_mcp_endpoints,
+    )
+    app = _generated_debug_app(monkeypatch, tmp_path)
+    _FakeProcess.created.clear()
+    monkeypatch.setattr(_FakeAsyncClient, "listed_apps", ["private_mcp_agent"])
+    monkeypatch.setattr("subprocess.Popen", _FakeProcess)
+    monkeypatch.setattr("httpx.AsyncClient", _FakeAsyncClient)
+    real_socket = socket.socket
+    monkeypatch.setattr(
+        "socket.socket",
+        lambda *args, **kwargs: (
+            real_socket(*args, **kwargs)
+            if len(args) >= 4 or "fileno" in kwargs
+            else _FakeSocket(*args, **kwargs)
+        ),
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/web/generated-agent-test-runs",
+            json={
+                "draft": {
+                    "name": "private-mcp-agent",
+                    "instruction": "Use MCP.",
+                    "mcpTools": [
+                        {
+                            "name": "private",
+                            "transport": "http",
+                            "url": "http://10.1.2.3/mcp",
+                        }
+                    ],
+                }
+            },
+        )
+
+    assert response.status_code == 200
+    assert _FakeProcess.created
+
+
+def test_cloud_generated_debug_rejects_private_mcp_outside_vpc(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("_FAAS_FUNC_ID", "function-test")
+    monkeypatch.setattr(
+        cli_frontend,
+        "discover_studio_vpc_networks",
+        lambda **kwargs: (ipaddress.ip_network("10.20.0.0/16"),),
+    )
+    app = _generated_debug_app(monkeypatch, tmp_path)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/web/generated-agent-test-runs",
+            json={
+                "draft": {
+                    "name": "private-mcp-agent",
+                    "instruction": "Use MCP.",
+                    "mcpTools": [
+                        {
+                            "name": "private",
+                            "transport": "http",
+                            "url": "http://10.30.1.8/mcp",
+                        }
+                    ],
+                }
+            },
+        )
+
+    assert response.status_code == 400
+    assert "不属于当前云上 Studio 所连接的 VPC 网段" in response.json()["detail"]
+    assert "PrivateLink" in response.json()["detail"]
+
+
+def test_cloud_generated_debug_preserves_mcp_connection_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from veadk.cli.generated_agent_mcp import McpDebugConnectionError
+
+    monkeypatch.setenv("_FAAS_FUNC_ID", "function-test")
+    original_detail = "MCP 工具 `offline` 连接失败：原始连接错误"
+
+    async def fail_mcp_discovery(draft):
+        del draft
+        raise McpDebugConnectionError(original_detail)
+
+    monkeypatch.setattr(
+        "veadk.cli.generated_agent_mcp.resolve_debug_mcp_endpoints",
+        fail_mcp_discovery,
+    )
+    app = _generated_debug_app(monkeypatch, tmp_path)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/web/generated-agent-test-runs",
+            json={
+                "draft": {
+                    "name": "offline-mcp-agent",
+                    "instruction": "Use MCP.",
+                    "mcpTools": [
+                        {
+                            "name": "offline",
+                            "transport": "http",
+                            "url": "https://8.8.8.8/mcp",
+                        }
+                    ],
+                }
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == original_detail
 
 
 def test_debug_text_redacts_environment_and_inline_markers(

--- a/tests/cli/test_studio_vpc_network.py
+++ b/tests/cli/test_studio_vpc_network.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from veadk.cli.studio_vpc_network import (
+    StudioVpcDiscoveryError,
+    discover_studio_vpc_networks,
+    is_vefaas_runtime,
+    studio_function_id,
+)
+
+
+class _VeFaaSClient:
+    def __init__(self, vpc_config: object) -> None:
+        self.vpc_config = vpc_config
+        self.function_ids: list[str] = []
+
+    def get_function(self, request: object) -> object:
+        self.function_ids.append(str(getattr(request, "id")))
+        return SimpleNamespace(vpc_config=self.vpc_config)
+
+
+class _VpcClient:
+    def __init__(self) -> None:
+        self.vpc_ids: list[str] = []
+        self.subnet_ids: list[str] = []
+
+    def describe_vpc_attributes(self, request: object) -> object:
+        self.vpc_ids.append(str(getattr(request, "vpc_id")))
+        return SimpleNamespace(
+            cidr_block="10.20.0.0/16",
+            secondary_cidr_blocks=["10.30.0.0/16"],
+            user_cidr_blocks=["100.96.0.0/16"],
+            ipv6_cidr_block="fd00:20::/56",
+            ipv6_cidr_blocks=[],
+        )
+
+    def describe_subnet_attributes(self, request: object) -> object:
+        subnet_id = str(getattr(request, "subnet_id"))
+        self.subnet_ids.append(subnet_id)
+        return SimpleNamespace(
+            vpc_id="vpc-test",
+            cidr_block="10.20.8.0/24",
+            ipv6_cidr_block="fd00:20:0:8::/64",
+        )
+
+
+def test_vefaas_runtime_detection_and_function_id_fallback() -> None:
+    assert not is_vefaas_runtime({})
+    assert is_vefaas_runtime({"_FAAS_FUNC_ID": "function-runtime"})
+    assert studio_function_id({"_FAAS_FUNC_ID": "function-runtime"}) == (
+        "function-runtime"
+    )
+    assert (
+        studio_function_id(
+            {
+                "_FAAS_FUNC_ID": "function-runtime",
+                "VEADK_STUDIO_FUNCTION_ID": "function-studio",
+            }
+        )
+        == "function-studio"
+    )
+
+
+def test_discovers_vpc_primary_secondary_user_and_subnet_cidrs() -> None:
+    vefaas = _VeFaaSClient(
+        SimpleNamespace(
+            enable_vpc=True,
+            vpc_id="vpc-test",
+            subnet_ids=["subnet-test"],
+        )
+    )
+    vpc = _VpcClient()
+
+    networks = discover_studio_vpc_networks(
+        provider="volcengine",
+        region="cn-beijing",
+        access_key="ak",
+        secret_key="sk",
+        function_id="function-test",
+        vefaas_client=vefaas,
+        vpc_client=vpc,
+    )
+
+    assert {str(network) for network in networks} == {
+        "10.20.0.0/16",
+        "10.20.8.0/24",
+        "10.30.0.0/16",
+        "100.96.0.0/16",
+        "fd00:20::/56",
+        "fd00:20:0:8::/64",
+    }
+    assert vefaas.function_ids == ["function-test"]
+    assert vpc.vpc_ids == ["vpc-test"]
+    assert vpc.subnet_ids == ["subnet-test"]
+
+
+def test_returns_no_private_ranges_when_function_has_no_vpc() -> None:
+    networks = discover_studio_vpc_networks(
+        provider="volcengine",
+        region="cn-beijing",
+        access_key="ak",
+        secret_key="sk",
+        function_id="function-test",
+        vefaas_client=_VeFaaSClient(None),
+        vpc_client=_VpcClient(),
+    )
+
+    assert networks == ()
+
+
+def test_rejects_subnet_outside_function_vpc() -> None:
+    vefaas = _VeFaaSClient(
+        SimpleNamespace(
+            enable_vpc=True,
+            vpc_id="vpc-test",
+            subnet_ids=["subnet-test"],
+        )
+    )
+    vpc = _VpcClient()
+
+    def mismatched_subnet(request: object) -> object:
+        return SimpleNamespace(
+            vpc_id="vpc-other",
+            cidr_block="10.99.0.0/24",
+            ipv6_cidr_block="",
+        )
+
+    vpc.describe_subnet_attributes = mismatched_subnet  # type: ignore[method-assign]
+    with pytest.raises(StudioVpcDiscoveryError, match="outside the attached VPC"):
+        discover_studio_vpc_networks(
+            provider="volcengine",
+            region="cn-beijing",
+            access_key="ak",
+            secret_key="sk",
+            function_id="function-test",
+            vefaas_client=vefaas,
+            vpc_client=vpc,
+        )

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -61,6 +61,13 @@ from veadk.cli.studio_account_id import (
     studio_account_id_environment,
 )
 from veadk.cli.studio_telemetry import studio_telemetry_config
+from veadk.cli.studio_vpc_network import (
+    IpNetwork,
+    StudioVpcDiscoveryError,
+    discover_studio_vpc_networks,
+    is_vefaas_runtime,
+    studio_function_id,
+)
 from veadk.utils.cloud_provider import (
     DEFAULT_BYTEPLUS_REGION,
     DEFAULT_BYTEPLUS_VIKING_MEMORY_HOST,
@@ -1808,11 +1815,13 @@ def _run_frontend_server(
 
     _agent_loader = AgentLoader(agents_dir)
 
-    # Generated-agent debug is intentionally feature-complete in both local and
-    # remote Studio deployments: the backend receives AgentDraft JSON, generates
-    # the same project content as "Generate project", writes it to a temp dir,
-    # and starts a runner for the debug session.
-    generated_agent_test_run_allows_local_resources = True
+    # Local Studio remains convenient for developer-owned MCP/A2A services.
+    # VeFaaS Studio limits private endpoints to the VPC attached to this function.
+    generated_agent_test_run_allows_local_resources = not is_vefaas_runtime()
+    generated_agent_vpc_cache: dict[str, object] = {
+        "loaded_at": 0.0,
+        "networks": None,
+    }
 
     generated_agent_test_run_ttl = max(60, generated_agent_test_run_ttl)
     access_policy = StudioAccessPolicy.from_csv(
@@ -2209,6 +2218,37 @@ def _run_frontend_server(
             detail="Volcengine credentials not found (set VOLCENGINE_ACCESS_KEY/"
             "SECRET_KEY, or run inside a VeFaaS function with an IAM role)",
         )
+
+    def _cloud_studio_private_networks() -> tuple[IpNetwork, ...]:
+        cached = generated_agent_vpc_cache["networks"]
+        loaded_at = float(generated_agent_vpc_cache["loaded_at"] or 0.0)
+        if isinstance(cached, tuple) and monotonic() - loaded_at < 300:
+            return cached
+
+        try:
+            access_key, secret_key, session_token = _resolve_ve_credentials()
+            networks = discover_studio_vpc_networks(
+                provider=provider,
+                region=(
+                    os.getenv("VEADK_STUDIO_DEPLOY_REGION")
+                    or os.getenv("APP_REGION")
+                    or default_region(provider)
+                ),
+                access_key=access_key,
+                secret_key=secret_key,
+                session_token=session_token,
+                function_id=studio_function_id(),
+            )
+        except (HTTPException, StudioVpcDiscoveryError) as exc:
+            logger.warning("Unable to resolve Studio VPC ranges: %s", exc)
+            raise DebugPolicyError(
+                "无法确认当前云上 Studio 的 VPC 网段，已停止连接私网 MCP/A2A。"
+                "请检查 VeFaaS VPC 配置和函数角色的 VPC 只读权限。"
+            ) from exc
+
+        generated_agent_vpc_cache["loaded_at"] = monotonic()
+        generated_agent_vpc_cache["networks"] = networks
+        return networks
 
     def _default_cloud_region() -> str:
         return default_region(provider)
@@ -4024,6 +4064,11 @@ def _run_frontend_server(
                         generated_agent_test_run_allows_local_resources
                     ),
                     managed_cloud_provider=provider,
+                    private_network_resolver=(
+                        None
+                        if generated_agent_test_run_allows_local_resources
+                        else _cloud_studio_private_networks
+                    ),
                 )
                 draft = await resolve_debug_mcp_endpoints(draft)
             else:

--- a/veadk/cli/generated_agent_security.py
+++ b/veadk/cli/generated_agent_security.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import ipaddress
 import socket
+from collections.abc import Callable, Sequence
 from urllib.parse import urlparse
 
 from veadk.cli.generated_agent_catalog import (
@@ -62,6 +63,9 @@ _METADATA_IPS = {
     ipaddress.ip_address("169.254.169.254"),
 }
 
+IpNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+PrivateNetworkResolver = Callable[[], Sequence[IpNetwork]]
+
 
 def validate_project_policy(draft: AgentDraft) -> None:
     total = _validate_node(
@@ -79,16 +83,28 @@ def validate_debug_policy(
     *,
     allow_local_runtime_resources: bool = False,
     managed_cloud_provider: str | None = None,
+    private_network_resolver: PrivateNetworkResolver | None = None,
 ) -> None:
     trusted_debug_model_api_base(
         draft,
         managed_cloud_provider=managed_cloud_provider,
     )
+    private_networks: tuple[IpNetwork, ...] | None = None
+
+    def resolve_private_networks() -> tuple[IpNetwork, ...]:
+        nonlocal private_networks
+        if private_networks is None:
+            private_networks = tuple(
+                private_network_resolver() if private_network_resolver else ()
+            )
+        return private_networks
+
     total = _validate_node(
         draft,
         depth=0,
         allow_local_runtime_resources=allow_local_runtime_resources,
         allow_stdio_mcp=False,
+        private_network_resolver=resolve_private_networks,
     )
     if total > MAX_SUBAGENTS + 1:
         raise DebugPolicyError(f"Too many agents: {total}")
@@ -136,6 +152,7 @@ def _validate_node(
     depth: int,
     allow_local_runtime_resources: bool,
     allow_stdio_mcp: bool,
+    private_network_resolver: PrivateNetworkResolver | None = None,
 ) -> int:
     if depth > MAX_DEPTH:
         raise DebugPolicyError(f"Agent tree is too deep (>{MAX_DEPTH})")
@@ -152,7 +169,11 @@ def _validate_node(
         if not registry_backed_remote and not draft.a2aUrl.strip():
             raise DebugPolicyError("A2A URL is required")
         if not registry_backed_remote and not allow_local_runtime_resources:
-            validate_url_not_private(draft.a2aUrl, field_name="a2aUrl")
+            validate_url_not_private(
+                draft.a2aUrl,
+                field_name="a2aUrl",
+                private_network_resolver=private_network_resolver,
+            )
     if draft.a2aRegistry.enabled and not draft.a2aRegistry.registrySpaceId.strip():
         raise DebugPolicyError("A2A registry space id is required")
 
@@ -195,7 +216,11 @@ def _validate_node(
         if tool.transport == "stdio" and not allow_stdio_mcp:
             raise DebugPolicyError("MCP stdio transport is disabled for debug runs")
         if tool.transport == "http" and not allow_local_runtime_resources:
-            validate_url_not_private(tool.url, field_name="mcpTools.url")
+            validate_url_not_private(
+                tool.url,
+                field_name="mcpTools.url",
+                private_network_resolver=private_network_resolver,
+            )
         for arg in tool.args:
             _check_len("MCP arg", arg, MAX_MCP_ARG_LEN)
 
@@ -206,6 +231,7 @@ def _validate_node(
             depth=depth + 1,
             allow_local_runtime_resources=allow_local_runtime_resources,
             allow_stdio_mcp=allow_stdio_mcp,
+            private_network_resolver=private_network_resolver,
         )
     return total
 
@@ -215,6 +241,7 @@ def validate_url_not_private(
     *,
     field_name: str,
     resolve_dns: bool = True,
+    private_network_resolver: PrivateNetworkResolver | None = None,
 ) -> None:
     raw = (raw_url or "").strip()
     if not raw:
@@ -229,10 +256,16 @@ def validate_url_not_private(
         raise DebugPolicyError(f"{field_name} points to a forbidden host")
 
     try:
-        _reject_private_ip(ipaddress.ip_address(host), field_name=field_name)
-        return
+        literal_ip = ipaddress.ip_address(host)
     except ValueError:
-        pass
+        literal_ip = None
+    if literal_ip is not None:
+        _validate_target_ip(
+            literal_ip,
+            field_name=field_name,
+            private_network_resolver=private_network_resolver,
+        )
+        return
 
     if not resolve_dns:
         return
@@ -251,26 +284,57 @@ def validate_url_not_private(
             continue
         seen.add(ip_raw)
         try:
-            _reject_private_ip(ipaddress.ip_address(ip_raw), field_name=field_name)
+            resolved_ip = ipaddress.ip_address(ip_raw)
         except ValueError as exc:
             raise DebugPolicyError(f"{field_name} resolved to an invalid IP") from exc
+        _validate_target_ip(
+            resolved_ip,
+            field_name=field_name,
+            private_network_resolver=private_network_resolver,
+        )
 
 
 def _default_port(scheme: str) -> int:
     return 443 if scheme == "https" else 80
 
 
-def _reject_private_ip(ip: ipaddress._BaseAddress, *, field_name: str) -> None:
+def _endpoint_label(field_name: str) -> str:
+    return "MCP 地址" if field_name == "mcpTools.url" else "A2A 地址"
+
+
+def _validate_target_ip(
+    ip: ipaddress._BaseAddress,
+    *,
+    field_name: str,
+    private_network_resolver: PrivateNetworkResolver | None,
+) -> None:
     if (
         ip in _METADATA_IPS
-        or ip.is_private
         or ip.is_loopback
         or ip.is_link_local
         or ip.is_multicast
         or ip.is_reserved
         or ip.is_unspecified
     ):
-        raise DebugPolicyError(f"{field_name} points to a private or reserved address")
+        raise DebugPolicyError(
+            f"{_endpoint_label(field_name)}解析到禁止访问的系统地址 {ip}。"
+            "云上 Studio 不允许访问环回、链路本地、云元数据或保留地址。"
+        )
+    if ip.is_global:
+        return
+
+    allowed_networks = tuple(
+        private_network_resolver() if private_network_resolver else ()
+    )
+    if any(
+        ip.version == network.version and ip in network for network in allowed_networks
+    ):
+        return
+    raise DebugPolicyError(
+        f"{_endpoint_label(field_name)}解析到私网地址 {ip}，"
+        "但该地址不属于当前云上 Studio 所连接的 VPC 网段。"
+        "请确认 Studio 与服务位于同一 VPC，或已通过 PrivateLink 连通。"
+    )
 
 
 def _validate_catalog_ids(

--- a/veadk/cli/studio_vpc_network.py
+++ b/veadk/cli/studio_vpc_network.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Discover the VPC address space attached to a cloud-hosted Studio."""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+from collections.abc import Mapping
+from typing import Any
+
+import volcenginesdkcore
+import volcenginesdkvefaas
+import volcenginesdkvpc
+
+from veadk.utils.cloud_provider import CloudProvider, vefaas_openapi_host
+
+IpNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+
+
+class StudioVpcDiscoveryError(RuntimeError):
+    """Raised when a VeFaaS Studio's attached VPC cannot be determined."""
+
+
+def is_vefaas_runtime(environ: Mapping[str, str] | None = None) -> bool:
+    """Return whether the current process is running as a VeFaaS function."""
+    values = os.environ if environ is None else environ
+    return bool(
+        str(values.get("VEADK_STUDIO_FUNCTION_ID") or "").strip()
+        or str(values.get("_FAAS_FUNC_ID") or "").strip()
+    )
+
+
+def studio_function_id(environ: Mapping[str, str] | None = None) -> str:
+    values = os.environ if environ is None else environ
+    return str(
+        values.get("VEADK_STUDIO_FUNCTION_ID") or values.get("_FAAS_FUNC_ID") or ""
+    ).strip()
+
+
+def _configuration(
+    *,
+    access_key: str,
+    secret_key: str,
+    session_token: str | None,
+    region: str,
+    host: str | None = None,
+) -> volcenginesdkcore.Configuration:
+    configuration = volcenginesdkcore.Configuration()
+    configuration.ak = access_key
+    configuration.sk = secret_key
+    configuration.session_token = session_token or ""
+    configuration.region = region
+    if host:
+        configuration.host = f"https://{host}"
+    configuration.client_side_validation = True
+    return configuration
+
+
+def _vefaas_client(
+    *,
+    provider: CloudProvider,
+    region: str,
+    access_key: str,
+    secret_key: str,
+    session_token: str | None,
+) -> Any:
+    configuration = _configuration(
+        access_key=access_key,
+        secret_key=secret_key,
+        session_token=session_token,
+        region=region,
+        host=(
+            vefaas_openapi_host(region, provider) if provider == "byteplus" else None
+        ),
+    )
+    return volcenginesdkvefaas.VEFAASApi(volcenginesdkcore.ApiClient(configuration))
+
+
+def _vpc_client(
+    *,
+    provider: CloudProvider,
+    region: str,
+    access_key: str,
+    secret_key: str,
+    session_token: str | None,
+) -> Any:
+    configuration = _configuration(
+        access_key=access_key,
+        secret_key=secret_key,
+        session_token=session_token,
+        region=region,
+        host=(f"vpc.{region}.byteplusapi.com" if provider == "byteplus" else None),
+    )
+    return volcenginesdkvpc.VPCApi(volcenginesdkcore.ApiClient(configuration))
+
+
+def _network(value: object) -> IpNetwork | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return ipaddress.ip_network(text, strict=False)
+    except ValueError as exc:
+        raise StudioVpcDiscoveryError("VeFaaS returned an invalid VPC CIDR.") from exc
+
+
+def _add_network(target: set[IpNetwork], value: object) -> None:
+    network = _network(value)
+    if network is not None:
+        target.add(network)
+
+
+def discover_studio_vpc_networks(
+    *,
+    provider: CloudProvider,
+    region: str,
+    access_key: str,
+    secret_key: str,
+    session_token: str | None = None,
+    function_id: str,
+    vefaas_client: Any | None = None,
+    vpc_client: Any | None = None,
+) -> tuple[IpNetwork, ...]:
+    """Return the VPC and subnet CIDRs attached to ``function_id``.
+
+    PrivateLink endpoints in the consumer VPC resolve to endpoint ENI addresses
+    from these ranges, so no per-MCP endpoint registration is required.
+    """
+    if not function_id.strip():
+        raise StudioVpcDiscoveryError("The current VeFaaS function ID is unavailable.")
+
+    try:
+        function_client = vefaas_client or _vefaas_client(
+            provider=provider,
+            region=region,
+            access_key=access_key,
+            secret_key=secret_key,
+            session_token=session_token,
+        )
+        function = function_client.get_function(
+            volcenginesdkvefaas.GetFunctionRequest(id=function_id)
+        )
+        vpc_config = getattr(function, "vpc_config", None)
+        vpc_id = str(getattr(vpc_config, "vpc_id", "") or "").strip()
+        if not vpc_config or not getattr(vpc_config, "enable_vpc", False) or not vpc_id:
+            return ()
+
+        network_client = vpc_client or _vpc_client(
+            provider=provider,
+            region=region,
+            access_key=access_key,
+            secret_key=secret_key,
+            session_token=session_token,
+        )
+        vpc = network_client.describe_vpc_attributes(
+            volcenginesdkvpc.DescribeVpcAttributesRequest(vpc_id=vpc_id)
+        )
+        networks: set[IpNetwork] = set()
+        _add_network(networks, getattr(vpc, "cidr_block", ""))
+        _add_network(networks, getattr(vpc, "ipv6_cidr_block", ""))
+        for attr in ("secondary_cidr_blocks", "user_cidr_blocks"):
+            for cidr in getattr(vpc, attr, None) or ():
+                _add_network(networks, cidr)
+        for value in getattr(vpc, "ipv6_cidr_blocks", None) or ():
+            _add_network(networks, getattr(value, "ipv6_cidr_block", value))
+
+        for subnet_id in getattr(vpc_config, "subnet_ids", None) or ():
+            subnet = network_client.describe_subnet_attributes(
+                volcenginesdkvpc.DescribeSubnetAttributesRequest(
+                    subnet_id=str(subnet_id)
+                )
+            )
+            subnet_vpc_id = str(getattr(subnet, "vpc_id", "") or "").strip()
+            if subnet_vpc_id and subnet_vpc_id != vpc_id:
+                raise StudioVpcDiscoveryError(
+                    "VeFaaS returned a subnet outside the attached VPC."
+                )
+            _add_network(networks, getattr(subnet, "cidr_block", ""))
+            _add_network(networks, getattr(subnet, "ipv6_cidr_block", ""))
+
+        return tuple(
+            sorted(
+                networks,
+                key=lambda item: (
+                    item.version,
+                    int(item.network_address),
+                    item.prefixlen,
+                ),
+            )
+        )
+    except StudioVpcDiscoveryError:
+        raise
+    except Exception as exc:
+        raise StudioVpcDiscoveryError(
+            "Failed to query the current VeFaaS VPC configuration."
+        ) from exc


### PR DESCRIPTION
## Summary

- discover the VPC and subnet CIDRs attached to a cloud-hosted Studio function
- allow MCP and A2A endpoints that resolve inside the attached VPC, including cross-account PrivateLink endpoint ENIs
- continue allowing private endpoints in local Studio while permanently rejecting loopback, link-local, metadata, reserved, multicast, and unspecified addresses in cloud Studio
- preserve original MCP connection errors and return an actionable policy message only for blocked network targets

## Validation

- `pre-commit run --all-files`
- `uv run pytest -q tests/cli/test_studio_vpc_network.py tests/cli/test_generated_agent_backend_codegen.py tests/cli/test_generated_agent_backend_codegen_extended.py` — 104 passed
- full test suite — 2718 passed, 5 skipped, 6 subtests passed; two existing debug-readiness timing cases passed when rerun individually

## Cloud validation

Validated from source deployments in both Volcano Engine (cn-beijing) and BytePlus (ap-southeast-1):

| Target | Volcano Engine | BytePlus |
| --- | --- | --- |
| Public MCP | Allowed and ready | Allowed and ready |
| Private IP inside Studio VPC | Allowed; original MCP response surfaced | Allowed; original MCP response surfaced |
| Private IP outside Studio VPC | Blocked with actionable VPC/PrivateLink guidance | Blocked with actionable VPC/PrivateLink guidance |
| Loopback / metadata IP | Blocked as system address | Blocked as system address |
| Cross-account PrivateLink hostname | Resolved to endpoint ENI inside Studio VPC and reached endpoint | Resolved to endpoint ENI inside Studio VPC and reached endpoint |