### PR TITLE
fix(studio): package all frontend runtime modules

### DIFF
--- a/.github/workflows/publish-studio-release.yaml
+++ b/.github/workflows/publish-studio-release.yaml
@@ -119,6 +119,99 @@ jobs:
           test "${#manifests[@]}" -eq 1
           unzip -t "${bundles[0]}"
 
+      - name: Simulate customer update and smoke-test Studio
+        env:
+          BYTEPLUS_ACCESS_KEY: smoke
+          BYTEPLUS_SECRET_KEY: smoke
+          PIP_INDEX_URL: https://mirrors.aliyun.com/pypi/simple/
+          UV_DEFAULT_INDEX: https://mirrors.aliyun.com/pypi/simple/
+          VOLCENGINE_ACCESS_KEY: smoke
+          VOLCENGINE_SECRET_KEY: smoke
+        run: |
+          set -euo pipefail
+          package_dir="$RUNNER_TEMP/studio-release-package"
+          runtime_venv="$RUNNER_TEMP/studio-release-runtime"
+          export package_dir runtime_venv
+
+          uv run --group dev python - <<'PY'
+          import os
+          from pathlib import Path
+
+          from veadk.cli.studio_self_update import extract_studio_bundle
+
+          output_dir = Path(os.environ["RUNNER_TEMP"]) / "studio-release-output"
+          bundle = next(output_dir.glob("studio-bundle-*.zip"))
+          extract_studio_bundle(bundle, Path(os.environ["package_dir"]))
+          PY
+
+          uv venv "$runtime_venv"
+          (
+            cd "$package_dir"
+            uv pip install --python "$runtime_venv/bin/python" -r requirements.txt
+          )
+
+          (
+            cd "$package_dir"
+            "$runtime_venv/bin/python" - <<'PY'
+          from pathlib import Path
+
+          import frontend
+          import veadk
+          import frontend.server.cronjobs
+          import frontend.service.studio_release_server
+          import frontend.service.studio_scheduler
+
+          runtime_root = Path(veadk.__file__).resolve().parents[1]
+          assert Path(frontend.__file__).resolve().is_relative_to(runtime_root)
+          webui = Path(veadk.__file__).resolve().parent / "webui" / "index.html"
+          assert webui.is_file()
+          print(f"Validated installed Studio packages from {runtime_root}")
+          PY
+          )
+
+          smoke_studio() {
+            provider="$1"
+            port="$2"
+            log="$RUNNER_TEMP/studio-${provider}.log"
+            response="$RUNNER_TEMP/studio-${provider}-ui-config.json"
+            (
+              cd "$package_dir"
+              PATH="$runtime_venv/bin:$PATH" \
+                CLOUD_PROVIDER="$provider" \
+                AGENTKIT_CLOUD_PROVIDER="$provider" \
+                _FAAS_RUNTIME_PORT="$port" \
+                ./run.sh
+            ) >"$log" 2>&1 &
+            pid=$!
+            for _ in {1..60}; do
+              if ! kill -0 "$pid" 2>/dev/null; then
+                cat "$log"
+                return 1
+              fi
+              if curl --fail --silent \
+                "http://127.0.0.1:${port}/web/ui-config" >"$response"; then
+                if ! curl --fail --silent --show-error \
+                  "http://127.0.0.1:${port}/" >/dev/null; then
+                  kill "$pid" 2>/dev/null || true
+                  wait "$pid" 2>/dev/null || true
+                  cat "$log"
+                  return 1
+                fi
+                kill "$pid" 2>/dev/null || true
+                wait "$pid" || true
+                return 0
+              fi
+              sleep 1
+            done
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+            cat "$log"
+            return 1
+          }
+
+          smoke_studio byteplus 18877
+          smoke_studio volcengine 18878
+
   publish:
     if: >-
       github.event_name == 'workflow_dispatch' &&

--- a/frontend/service/studio_release_server/publisher.py
+++ b/frontend/service/studio_release_server/publisher.py
@@ -311,7 +311,7 @@ def _build_frontend_assets(
         raise StudioPublisherError("Studio frontend build produced no index.html.")
 
 
-def _stage_wheel_source(
+def stage_studio_wheel_source(
     source_root: Path,
     frontend_assets: Path,
     wheel_source: Path,
@@ -331,15 +331,77 @@ def _stage_wheel_source(
         wheel_source / "veadk",
         ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "webui"),
     )
-    frontend_package = wheel_source / "frontend"
-    frontend_package.mkdir()
-    shutil.copy2(source_root / "frontend" / "__init__.py", frontend_package)
+    frontend_root = source_root / "frontend"
+
+    def ignore_frontend_build_inputs(directory: str, names: list[str]) -> set[str]:
+        current = Path(directory)
+        ignored = {
+            name
+            for name in names
+            if name == "__pycache__"
+            or name.endswith(".pyc")
+            or name == ".vite"
+            or name == ".env"
+            or name.startswith(".env.")
+        }
+        if current == frontend_root:
+            ignored.update(
+                {
+                    "README.md",
+                    "SPEC.md",
+                    "dist",
+                    "index.html",
+                    "node_modules",
+                    "package-lock.json",
+                    "package.json",
+                    "public",
+                    "scripts",
+                    "skills",
+                    "src",
+                    "tests",
+                    "tsconfig.json",
+                    "vite.config.ts",
+                    "vite.website-integration.config.ts",
+                    "vitest.harness-sidecar.config.ts",
+                }.intersection(names)
+            )
+        return ignored
+
     shutil.copytree(
-        source_root / "frontend" / "server",
-        frontend_package / "server",
-        ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+        frontend_root,
+        wheel_source / "frontend",
+        ignore=ignore_frontend_build_inputs,
     )
     shutil.copytree(frontend_assets, wheel_source / "veadk" / "webui")
+
+
+def _studio_runtime_modules(source_root: Path) -> set[str]:
+    """List every importable frontend Python module intended for Studio runtime."""
+    frontend_root = source_root / "frontend"
+    modules: set[str] = set()
+    for source in frontend_root.rglob("*.py"):
+        parent = source.parent
+        while parent != source_root and (parent / "__init__.py").is_file():
+            if parent == frontend_root:
+                modules.add(source.relative_to(source_root).as_posix())
+                break
+            parent = parent.parent
+    return modules
+
+
+def _validate_studio_wheel(wheel: Path, source_root: Path) -> None:
+    """Reject release wheels missing any importable Studio runtime module."""
+    required_modules = _studio_runtime_modules(source_root)
+    try:
+        with zipfile.ZipFile(wheel) as archive:
+            missing = required_modules.difference(archive.namelist())
+    except (OSError, zipfile.BadZipFile) as error:
+        raise StudioPublisherError("Built VeADK wheel is invalid.") from error
+    if missing:
+        raise StudioPublisherError(
+            "Built VeADK wheel is missing Studio runtime modules: "
+            + ", ".join(sorted(missing))
+        )
 
 
 def _build_local_requirements(
@@ -350,7 +412,7 @@ def _build_local_requirements(
     env: Mapping[str, str],
 ) -> str:
     wheel_source = package_dir / "wheel-source"
-    _stage_wheel_source(source_root, frontend_assets, wheel_source)
+    stage_studio_wheel_source(source_root, frontend_assets, wheel_source)
     uv = shutil.which("uv", path=env.get("PATH"))
     if uv is None:
         raise StudioPublisherError("uv is required to build the VeADK wheel.")
@@ -369,6 +431,7 @@ def _build_local_requirements(
         raise StudioPublisherError(
             "Local source build did not produce one VeADK wheel."
         )
+    _validate_studio_wheel(built_wheels[0], wheel_source)
     dependencies: list[Path] = []
     for source in sorted(dependency_wheels.glob("*.whl")):
         target = package_dir / source.name

--- a/frontend/service/studio_release_server/publisher.py
+++ b/frontend/service/studio_release_server/publisher.py
@@ -375,23 +375,18 @@ def stage_studio_wheel_source(
     shutil.copytree(frontend_assets, wheel_source / "veadk" / "webui")
 
 
-def _studio_runtime_modules(source_root: Path) -> set[str]:
-    """List every importable frontend Python module intended for Studio runtime."""
-    frontend_root = source_root / "frontend"
-    modules: set[str] = set()
-    for source in frontend_root.rglob("*.py"):
-        parent = source.parent
-        while parent != source_root and (parent / "__init__.py").is_file():
-            if parent == frontend_root:
-                modules.add(source.relative_to(source_root).as_posix())
-                break
-            parent = parent.parent
-    return modules
+def studio_runtime_modules(source_root: Path) -> set[str]:
+    """List every importable Python module shipped in the Studio wheel."""
+    return {
+        source.relative_to(source_root).as_posix()
+        for package_name in ("veadk", "frontend")
+        for source in (source_root / package_name).rglob("*.py")
+    }
 
 
-def _validate_studio_wheel(wheel: Path, source_root: Path) -> None:
+def validate_studio_wheel(wheel: Path, source_root: Path) -> None:
     """Reject release wheels missing any importable Studio runtime module."""
-    required_modules = _studio_runtime_modules(source_root)
+    required_modules = studio_runtime_modules(source_root)
     try:
         with zipfile.ZipFile(wheel) as archive:
             missing = required_modules.difference(archive.namelist())
@@ -431,7 +426,7 @@ def _build_local_requirements(
         raise StudioPublisherError(
             "Local source build did not produce one VeADK wheel."
         )
-    _validate_studio_wheel(built_wheels[0], wheel_source)
+    validate_studio_wheel(built_wheels[0], wheel_source)
     dependencies: list[Path] = []
     for source in sorted(dependency_wheels.glob("*.whl")):
         target = package_dir / source.name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,12 +125,13 @@ dev = [
 [tool.setuptools.packages.find]
 include = [
     "veadk*",
-    "frontend",
-    "frontend.server*",
-    "frontend.service",
-    "frontend.service.studio_scheduler*",
+    "frontend*",
 ]
-exclude = ["assets*", "ide*", "tests*"]
+exclude = [
+    "assets*",
+    "ide*",
+    "tests*",
+]
 
 [tool.setuptools]
 include-package-data = true

--- a/tests/cli/test_studio_deploy_target.py
+++ b/tests/cli/test_studio_deploy_target.py
@@ -2318,6 +2318,10 @@ def test_studio_deploy_from_source_bundles_unmirrored_dependencies(
     monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/uv")
     monkeypatch.setattr("subprocess.run", _fake_build)
     monkeypatch.setattr(
+        "veadk.cli.studio_package.validate_studio_wheel",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(
         "urllib.request.urlopen", lambda *_args, **_kwargs: _FakeWheelResponse()
     )
     wheel_hashes = iter(
@@ -2408,6 +2412,10 @@ def test_studio_deploy_from_source_writes_lf_run_script(
     )
     monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/uv")
     monkeypatch.setattr("subprocess.run", _fake_build)
+    monkeypatch.setattr(
+        "veadk.cli.studio_package.validate_studio_wheel",
+        lambda *_args: None,
+    )
 
     result = CliRunner().invoke(
         studio,

--- a/tests/cli/test_studio_update.py
+++ b/tests/cli/test_studio_update.py
@@ -142,6 +142,10 @@ def test_stage_wheel_source_includes_studio_python_backend(tmp_path: Path) -> No
     source_root = tmp_path / "source"
     (source_root / "veadk").mkdir(parents=True)
     (source_root / "veadk" / "__init__.py").write_text("", encoding="utf-8")
+    (source_root / "veadk" / "future_runtime").mkdir()
+    (source_root / "veadk" / "future_runtime" / "handler.py").write_text(
+        "HANDLER = True\n", encoding="utf-8"
+    )
     (source_root / "frontend" / "server").mkdir(parents=True)
     (source_root / "frontend" / "__init__.py").write_text("", encoding="utf-8")
     (source_root / "frontend" / "server" / "__init__.py").write_text(
@@ -191,6 +195,9 @@ def test_stage_wheel_source_includes_studio_python_backend(tmp_path: Path) -> No
     ).read_text() == "HANDLER = True\n"
     assert not (wheel_source / "frontend" / "src").exists()
     assert (wheel_source / "frontend" / "service" / "studio_release_server").is_dir()
+    assert (
+        wheel_source / "veadk" / "future_runtime" / "handler.py"
+    ).read_text() == "HANDLER = True\n"
 
 
 def test_find_studio_deployments_searches_regions_and_filters_project(

--- a/tests/cli/test_studio_update.py
+++ b/tests/cli/test_studio_update.py
@@ -150,10 +150,20 @@ def test_stage_wheel_source_includes_studio_python_backend(tmp_path: Path) -> No
     (source_root / "frontend" / "server" / "routes.py").write_text(
         "ROUTES = []\n", encoding="utf-8"
     )
+    (source_root / "frontend" / "future_runtime").mkdir(parents=True)
+    (source_root / "frontend" / "future_runtime" / "__init__.py").write_text(
+        "", encoding="utf-8"
+    )
+    (source_root / "frontend" / "future_runtime" / "handler.py").write_text(
+        "HANDLER = True\n", encoding="utf-8"
+    )
     (source_root / "frontend" / "service" / "studio_scheduler").mkdir(parents=True)
     (source_root / "frontend" / "service" / "__init__.py").write_text(
         "", encoding="utf-8"
     )
+    release_server = source_root / "frontend" / "service" / "studio_release_server"
+    release_server.mkdir()
+    (release_server / "__init__.py").write_text("", encoding="utf-8")
     (
         source_root / "frontend" / "service" / "studio_scheduler" / "__init__.py"
     ).write_text("", encoding="utf-8")
@@ -176,6 +186,11 @@ def test_stage_wheel_source_includes_studio_python_backend(tmp_path: Path) -> No
     assert (
         wheel_source / "frontend" / "service" / "studio_scheduler" / "app.py"
     ).read_text() == "HANDLER = True\n"
+    assert (
+        wheel_source / "frontend" / "future_runtime" / "handler.py"
+    ).read_text() == "HANDLER = True\n"
+    assert not (wheel_source / "frontend" / "src").exists()
+    assert (wheel_source / "frontend" / "service" / "studio_release_server").is_dir()
 
 
 def test_find_studio_deployments_searches_regions_and_filters_project(

--- a/tests/test_studio_release_server.py
+++ b/tests/test_studio_release_server.py
@@ -576,7 +576,13 @@ def test_standalone_publisher_builds_bundle_from_source_files(
 
     def _run(command: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[Any]:
         output_dir = Path(command[command.index("-o") + 1])
-        (output_dir / "veadk_python-1.0.0-py3-none-any.whl").write_bytes(b"veadk")
+        with zipfile.ZipFile(
+            output_dir / "veadk_python-1.0.0-py3-none-any.whl", "w"
+        ) as wheel:
+            for name in release_publisher._studio_runtime_modules(
+                Path(__file__).parents[1]
+            ):
+                wheel.writestr(name, "")
         return subprocess.CompletedProcess(command, 0)
 
     monkeypatch.setattr(release_publisher.subprocess, "run", _run)
@@ -603,6 +609,59 @@ def test_standalone_publisher_builds_bundle_from_source_files(
         )
     assert manifest.git_sha == "a" * 40
     assert manifest.sha256 == hashlib.sha256(bundle.read_bytes()).hexdigest()
+
+
+def test_standalone_publisher_stages_scheduler_backend(tmp_path: Path) -> None:
+    source_root = tmp_path / "source"
+    (source_root / "veadk").mkdir(parents=True)
+    (source_root / "veadk" / "__init__.py").write_text("", encoding="utf-8")
+    for filename in ("pyproject.toml", "README.md", "LICENSE"):
+        (source_root / filename).write_text("", encoding="utf-8")
+    (source_root / "frontend" / "server").mkdir(parents=True)
+    (source_root / "frontend" / "server" / "__init__.py").write_text(
+        "", encoding="utf-8"
+    )
+    future_runtime = source_root / "frontend" / "future_runtime"
+    future_runtime.mkdir()
+    (future_runtime / "__init__.py").write_text("", encoding="utf-8")
+    (future_runtime / "handler.py").write_text("HANDLER = True\n", encoding="utf-8")
+    (source_root / "frontend" / "__init__.py").write_text("", encoding="utf-8")
+    scheduler = source_root / "frontend" / "service" / "studio_scheduler"
+    scheduler.mkdir(parents=True)
+    (scheduler.parent / "__init__.py").write_text("", encoding="utf-8")
+    release_server = scheduler.parent / "studio_release_server"
+    release_server.mkdir()
+    (release_server / "__init__.py").write_text("", encoding="utf-8")
+    (scheduler / "__init__.py").write_text("", encoding="utf-8")
+    (scheduler / "models.py").write_text("MODEL = True\n", encoding="utf-8")
+    frontend_assets = tmp_path / "frontend-assets"
+    frontend_assets.mkdir()
+    (frontend_assets / "index.html").write_text("studio", encoding="utf-8")
+
+    wheel_source = tmp_path / "wheel-source"
+    release_publisher.stage_studio_wheel_source(
+        source_root, frontend_assets, wheel_source
+    )
+
+    assert (
+        wheel_source / "frontend" / "service" / "studio_scheduler" / "models.py"
+    ).read_text(encoding="utf-8") == "MODEL = True\n"
+    assert (wheel_source / "frontend" / "future_runtime" / "handler.py").read_text(
+        encoding="utf-8"
+    ) == "HANDLER = True\n"
+    assert (wheel_source / "frontend" / "service" / "studio_release_server").is_dir()
+
+
+def test_standalone_publisher_rejects_wheel_without_scheduler(tmp_path: Path) -> None:
+    wheel = tmp_path / "veadk.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("frontend/server/cronjobs/service.py", "")
+
+    with pytest.raises(
+        release_publisher.StudioPublisherError,
+        match="missing Studio runtime modules",
+    ):
+        release_publisher._validate_studio_wheel(wheel, Path(__file__).parents[1])
 
 
 def test_builder_shallow_clones_only_main_build_files(

--- a/tests/test_studio_release_server.py
+++ b/tests/test_studio_release_server.py
@@ -579,7 +579,7 @@ def test_standalone_publisher_builds_bundle_from_source_files(
         with zipfile.ZipFile(
             output_dir / "veadk_python-1.0.0-py3-none-any.whl", "w"
         ) as wheel:
-            for name in release_publisher._studio_runtime_modules(
+            for name in release_publisher.studio_runtime_modules(
                 Path(__file__).parents[1]
             ):
                 wheel.writestr(name, "")
@@ -652,16 +652,29 @@ def test_standalone_publisher_stages_scheduler_backend(tmp_path: Path) -> None:
     assert (wheel_source / "frontend" / "service" / "studio_release_server").is_dir()
 
 
-def test_standalone_publisher_rejects_wheel_without_scheduler(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "missing_module",
+    (
+        "frontend/service/studio_scheduler/models.py",
+        "veadk/cli/studio_update.py",
+    ),
+)
+def test_standalone_publisher_rejects_wheel_without_runtime_module(
+    tmp_path: Path,
+    missing_module: str,
+) -> None:
     wheel = tmp_path / "veadk.whl"
+    source_root = Path(__file__).parents[1]
     with zipfile.ZipFile(wheel, "w") as archive:
-        archive.writestr("frontend/server/cronjobs/service.py", "")
+        for name in release_publisher.studio_runtime_modules(source_root):
+            if name != missing_module:
+                archive.writestr(name, "")
 
     with pytest.raises(
         release_publisher.StudioPublisherError,
-        match="missing Studio runtime modules",
+        match=missing_module,
     ):
-        release_publisher._validate_studio_wheel(wheel, Path(__file__).parents[1])
+        release_publisher.validate_studio_wheel(wheel, source_root)
 
 
 def test_builder_shallow_clones_only_main_build_files(

--- a/veadk/cli/studio_package.py
+++ b/veadk/cli/studio_package.py
@@ -23,6 +23,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from frontend.service.studio_release_server.publisher import stage_studio_wheel_source
+
 from veadk.cli.frontend_branding import SiteLogo
 from veadk.cli.studio_dependencies import stage_studio_dependency_wheels
 from veadk.utils.cloud_provider import DEFAULT_CLOUD_PROVIDER, CloudProvider
@@ -201,38 +203,4 @@ def _stage_wheel_source(
     source_root: Path, frontend_assets: Path, wheel_source: Path
 ) -> None:
     """Copy package sources and substitute freshly built frontend assets."""
-    wheel_source.mkdir(parents=True)
-    for filename in ("pyproject.toml", "README.md", "LICENSE"):
-        shutil.copy2(source_root / filename, wheel_source / filename)
-    git_metadata = source_root / ".git"
-    if git_metadata.is_file():
-        shutil.copy2(git_metadata, wheel_source / ".git")
-    elif git_metadata.is_dir():
-        (wheel_source / ".git").write_text(
-            f"gitdir: {git_metadata.resolve()}\n", encoding="utf-8"
-        )
-    shutil.copytree(
-        source_root / "veadk",
-        wheel_source / "veadk",
-        ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "webui"),
-    )
-    frontend_package = wheel_source / "frontend"
-    frontend_package.mkdir()
-    shutil.copy2(source_root / "frontend" / "__init__.py", frontend_package)
-    shutil.copytree(
-        source_root / "frontend" / "server",
-        frontend_package / "server",
-        ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
-    )
-    service_package = frontend_package / "service"
-    service_package.mkdir()
-    shutil.copy2(
-        source_root / "frontend" / "service" / "__init__.py",
-        service_package,
-    )
-    shutil.copytree(
-        source_root / "frontend" / "service" / "studio_scheduler",
-        service_package / "studio_scheduler",
-        ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
-    )
-    shutil.copytree(frontend_assets, wheel_source / "veadk" / "webui")
+    stage_studio_wheel_source(source_root, frontend_assets, wheel_source)

--- a/veadk/cli/studio_package.py
+++ b/veadk/cli/studio_package.py
@@ -23,8 +23,10 @@ import subprocess
 import sys
 from pathlib import Path
 
-from frontend.service.studio_release_server.publisher import stage_studio_wheel_source
-
+from frontend.service.studio_release_server.publisher import (
+    stage_studio_wheel_source,
+    validate_studio_wheel,
+)
 from veadk.cli.frontend_branding import SiteLogo
 from veadk.cli.studio_dependencies import stage_studio_dependency_wheels
 from veadk.utils.cloud_provider import DEFAULT_CLOUD_PROVIDER, CloudProvider
@@ -166,6 +168,7 @@ def build_local_studio_requirements(
     wheels = list(package_dir.glob("veadk*.whl"))
     if not wheels:
         raise ValueError("Local source build produced no veadk wheel.")
+    validate_studio_wheel(wheels[0], wheel_source)
 
     dependencies = stage_studio_dependency_wheels(
         package_dir,


### PR DESCRIPTION
## Summary
- replace the Studio packaging allowlist with default inclusion for future `frontend` and `veadk` Python modules
- keep only explicit non-runtime frontend inputs and caches on a denylist
- share one staging implementation between local updates, source deployments, and the standalone release publisher
- reject any release wheel missing a staged Python module from either package tree
- make the PR release check extract the generated bundle through the production updater path, install it into a clean runtime, verify imports and built UI assets, then start and probe Studio for both BytePlus and Volcengine

## Root cause
The regular Studio update packager and standalone release publisher maintained separate allowlists. Scheduled tasks updated only one path, so the published wheel contained cronjobs code that imported an absent scheduler package. The previous PR release check only built and unzipped the bundle, so it could not prove that a customer could install and run it.

## Validation
- `uv run --group dev pytest -q tests/test_studio_release_server.py tests/cli/test_studio_release.py tests/cli/test_studio_self_update.py tests/cli/test_studio_update.py` (116 passed)
- focused source-deployment regression tests (64 passed)
- pre-commit passed
- Pyright passed for the changed Python implementation files
- built a real release bundle from this branch and validated all 600 staged Python modules
- extracted the bundle through `extract_studio_bundle`, installed its wheel into an isolated target, imported `frontend.server.cronjobs`, `frontend.service.studio_scheduler`, and `frontend.service.studio_release_server`, and started/probed Studio under both BytePlus and Volcengine provider settings
