### PR TITLE
fix(studio): initialize feedback datasets without workspace

### DIFF
--- a/frontend/server/evaluation_automation/repository.py
+++ b/frontend/server/evaluation_automation/repository.py
@@ -159,6 +159,8 @@ class AgentKitAutoEvaluationRepository:
         page_size: int = 100,
     ) -> list[AutoEvaluationCase]:
         workspace_id = await self._resolve_workspace_id()
+        if workspace_id is None:
+            return []
         result: list[AutoEvaluationCase] = []
         for kind in ("good", "bad"):
             name = auto_set_name(agent_name, kind)
@@ -214,6 +216,17 @@ class AgentKitAutoEvaluationRepository:
     async def _ensure_set(self, agent_name: str, kind: str) -> _SetRef:
         workspace_id = await self._resolve_workspace_id()
         name = auto_set_name(agent_name, kind)
+        if workspace_id is None:
+            try:
+                return await self._create_set(name, workspace_id=None)
+            except AgentKitOpenApiError as error:
+                if error.code != _DUPLICATE_DATASET_ERROR_CODE:
+                    raise
+                existing = await self._wait_for_set(name, workspace_id=None)
+                if existing is not None:
+                    return existing
+                raise
+
         fallback = self._fallback_name(name, workspace_id)
         for candidate in (name, fallback):
             existing = await self._find_set(candidate, workspace_id=workspace_id)
@@ -229,10 +242,13 @@ class AgentKitAutoEvaluationRepository:
                 return existing
         return await self._create_set(fallback, workspace_id=workspace_id)
 
-    async def _create_set(self, name: str, *, workspace_id: str) -> _SetRef:
+    async def _create_set(self, name: str, *, workspace_id: str | None) -> _SetRef:
+        query = dict(self._project_query)
+        if workspace_id:
+            query["WorkspaceId"] = workspace_id
         response = await self._post(
             action="CreateEvaluationSet",
-            query={**self._project_query, "WorkspaceId": workspace_id},
+            query=query,
             payload={
                 "Name": name,
                 "Description": "AgentKit Studio 会话静默自动评测集",
@@ -262,7 +278,7 @@ class AgentKitAutoEvaluationRepository:
             raise RuntimeError("AgentKit automatic evaluation set is not visible")
         return visible
 
-    async def _resolve_workspace_id(self) -> str:
+    async def _resolve_workspace_id(self) -> str | None:
         if self._workspace_id:
             return self._workspace_id
         response = await self._post(
@@ -278,12 +294,15 @@ class AgentKitAutoEvaluationRepository:
             if workspace_id:
                 self._workspace_id = workspace_id
                 return workspace_id
-        raise RuntimeError("AgentKit account does not expose an evaluation workspace")
+        return None
 
-    async def _find_set(self, name: str, *, workspace_id: str) -> _SetRef | None:
+    async def _find_set(self, name: str, *, workspace_id: str | None) -> _SetRef | None:
+        query = dict(self._project_query)
+        if workspace_id:
+            query["WorkspaceId"] = workspace_id
         response = await self._post(
             action="ListEvaluationSets",
-            query={**self._project_query, "WorkspaceId": workspace_id},
+            query=query,
             payload={"Name": name, "PageNumber": 1, "PageSize": 100},
         )
         for item in (response.get("Result") or {}).get("EvaluationSets") or []:
@@ -296,10 +315,13 @@ class AgentKitAutoEvaluationRepository:
             item_id = str(item.get("Id") or "")
             if not item_id or not resolved_workspace_id:
                 raise RuntimeError("AgentKit evaluation set has invalid identifiers")
+            self._workspace_id = resolved_workspace_id
             return _SetRef(item_id, resolved_workspace_id, name)
         return None
 
-    async def _wait_for_set(self, name: str, *, workspace_id: str) -> _SetRef | None:
+    async def _wait_for_set(
+        self, name: str, *, workspace_id: str | None
+    ) -> _SetRef | None:
         for delay in _LOOKUP_DELAYS:
             await asyncio.sleep(delay)
             existing = await self._find_set(name, workspace_id=workspace_id)

--- a/tests/cli/test_frontend_evaluation_feedback.py
+++ b/tests/cli/test_frontend_evaluation_feedback.py
@@ -122,20 +122,26 @@ def test_studio_findskill_route_uses_studio_skill_catalog(
 
 
 @pytest.mark.parametrize(
-    ("agent_info_status", "expected_agent_name"),
-    [(200, "客服助手"), (404, "agent")],
-    ids=["agent-info", "legacy-runtime-fallback"],
+    ("agent_info_status", "expected_agent_name", "initially_empty"),
+    [
+        (200, "客服助手", False),
+        (404, "agent", False),
+        (200, "客服助手", True),
+    ],
+    ids=["agent-info", "legacy-runtime-fallback", "first-feedback-dataset"],
 )
 def test_message_feedback_writes_dataset_and_session_state(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     agent_info_status: int,
     expected_agent_name: str,
+    initially_empty: bool,
 ) -> None:
     app = _create_frontend_app(monkeypatch, tmp_path)
     openapi_calls: list[dict[str, Any]] = []
     session_patches: list[dict[str, Any]] = []
     annotation_comment = "选中片段：回答\n\n批注：事实错误"
+    created = False
 
     class _FakeRuntimeClient:
         def __init__(self, **kwargs: Any) -> None:
@@ -200,6 +206,7 @@ def test_message_feedback_writes_dataset_and_session_state(
             raise AssertionError((method, url))
 
         async def post(self, url: str, **kwargs: Any) -> _FakeResponse:
+            nonlocal created
             del url
             action = kwargs["params"]["Action"]
             openapi_calls.append(
@@ -210,6 +217,8 @@ def test_message_feedback_writes_dataset_and_session_state(
                 }
             )
             if action == "ListEvaluationSets":
+                if initially_empty and not created:
+                    return _FakeResponse({"Result": {"EvaluationSets": []}})
                 return _FakeResponse(
                     {
                         "Result": {
@@ -223,6 +232,9 @@ def test_message_feedback_writes_dataset_and_session_state(
                         }
                     }
                 )
+            if action == "CreateEvaluationSet":
+                created = True
+                return _FakeResponse({"Result": {"EvaluationSetId": "set-1"}})
             if action == "BatchCreateEvaluationSetItems":
                 return _FakeResponse(
                     {
@@ -267,15 +279,22 @@ def test_message_feedback_writes_dataset_and_session_state(
     assert response.json()["evaluationItemId"] == "item-1"
     assert response.json()["evaluationSetName"] == (f"{expected_agent_name}_good_case")
     assert response.json()["statePersistence"] == "browser"
-    assert [call["action"] for call in openapi_calls] == [
+    expected_actions = [
         "ListEvaluationSets",
         "ListEvaluationSets",
         "BatchCreateEvaluationSetItems",
         "ListEvaluationSets",
         "ListEvaluationSets",
     ]
+    if initially_empty:
+        expected_actions.insert(1, "CreateEvaluationSet")
+    assert [call["action"] for call in openapi_calls] == expected_actions
     assert openapi_calls[0]["params"]["ProjectName"] == "support"
-    assert openapi_calls[1]["params"]["WorkspaceId"] == "workspace-1"
+    if initially_empty:
+        assert "WorkspaceId" not in openapi_calls[1]["params"]
+        assert "WorkspaceId" not in openapi_calls[2]["params"]
+    else:
+        assert openapi_calls[1]["params"]["WorkspaceId"] == "workspace-1"
     state = session_patches[0]["state_delta"]["veadk_feedback:assistant-event"]
     assert state["rating"] == "good"
     assert state["comment"] == annotation_comment

--- a/tests/frontend/server/evaluation_automation/test_repository.py
+++ b/tests/frontend/server/evaluation_automation/test_repository.py
@@ -270,3 +270,82 @@ async def test_agentkit_repository_creates_and_lists_an_auto_dataset() -> None:
         for field in create_call["payload"]["EvaluationSetSchema"]["FieldSchemas"]
     }
     assert {"source", "score", "reason", "evaluator_version"} <= field_keys
+
+
+@pytest.mark.asyncio
+async def test_agentkit_repository_creates_first_dataset_without_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+    created = False
+
+    async def post(
+        *, action: str, payload: dict[str, Any], query: dict[str, str] | None = None
+    ) -> dict[str, Any]:
+        nonlocal created
+        calls.append({"action": action, "payload": payload, "query": query})
+        if action == "ListEvaluationSets":
+            if created and payload.get("Name") == "客服助手_auto_good_case":
+                return {
+                    "Result": {
+                        "EvaluationSets": [
+                            {
+                                "Id": "auto-good",
+                                "Name": "客服助手_auto_good_case",
+                                "WorkspaceId": "workspace-1",
+                            }
+                        ]
+                    }
+                }
+            return {"Result": {"EvaluationSets": []}}
+        if action == "CreateEvaluationSet":
+            created = True
+            return {"Result": {"EvaluationSetId": "auto-good"}}
+        if action == "BatchCreateEvaluationSetItems":
+            return {
+                "Result": {
+                    "ItemOutputs": [
+                        {"ItemId": "item-1", "ItemKey": "key-1", "IsNewItem": True}
+                    ]
+                }
+            }
+        raise AssertionError(action)
+
+    async def no_sleep(delay: float) -> None:
+        del delay
+
+    monkeypatch.setattr(
+        "frontend.server.evaluation_automation.repository.asyncio.sleep",
+        no_sleep,
+    )
+    repository = AgentKitAutoEvaluationRepository(post, project_name="support")
+    case = AutoEvaluationCase(
+        id="",
+        itemKey="key-1",
+        kind="good",
+        input="问题",
+        output="回答",
+        agentName="客服助手",
+        sessionId="session",
+        messageId="message",
+        runtimeId="runtime",
+        invocationId="invocation",
+        userId="user",
+        createdAt="2026-08-05T10:00:00+08:00",
+        score=0.92,
+        reason="回答完整。",
+        evaluatorVersion="v1",
+    )
+
+    stored = await repository.upsert(case)
+
+    assert stored.id == "item-1"
+    assert stored.workspace_id == "workspace-1"
+    assert [call["action"] for call in calls] == [
+        "ListEvaluationSets",
+        "CreateEvaluationSet",
+        "ListEvaluationSets",
+        "BatchCreateEvaluationSetItems",
+    ]
+    assert calls[1]["query"] == {"ProjectName": "support"}
+    assert calls[2]["query"] == {"ProjectName": "support"}

--- a/tests/integrations/agentkit/evaluation/test_client.py
+++ b/tests/integrations/agentkit/evaluation/test_client.py
@@ -21,6 +21,7 @@ import pytest
 from veadk.integrations.agentkit.evaluation.client import (
     AgentKitEvaluationDatasetsClient,
     AgentKitOpenApiError,
+    EvaluationSetRef,
     feedback_set_name,
 )
 
@@ -159,6 +160,62 @@ async def test_ensure_set_creates_and_resolves_workspace() -> None:
         field["Key"] for field in create_payload["EvaluationSetSchema"]["FieldSchemas"]
     }
     assert {"input", "output", "session_id", "message_id"} <= field_keys
+
+
+@pytest.mark.asyncio
+async def test_ensure_set_creates_first_dataset_without_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+    created = False
+
+    async def post(
+        *,
+        action: str,
+        payload: dict[str, Any],
+        query: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        nonlocal created
+        calls.append({"action": action, "payload": payload, "query": query})
+        if action == "ListEvaluationSets":
+            if created and payload.get("Name") == "客服助手_good_case":
+                return {
+                    "Result": {
+                        "EvaluationSets": [
+                            {
+                                "Id": "set-1",
+                                "Name": "客服助手_good_case",
+                                "WorkspaceId": "workspace-1",
+                            }
+                        ]
+                    }
+                }
+            return {"Result": {"EvaluationSets": []}}
+        if action == "CreateEvaluationSet":
+            created = True
+            return {"Result": {"EvaluationSetId": "set-1"}}
+        raise AssertionError(action)
+
+    monkeypatch.setattr(
+        "veadk.integrations.agentkit.evaluation.client.asyncio.sleep",
+        _no_sleep,
+    )
+    client = AgentKitEvaluationDatasetsClient(post, project_name="support")
+
+    evaluation_set = await client.ensure_feedback_set("客服助手", "good")
+
+    assert evaluation_set == EvaluationSetRef(
+        id="set-1",
+        workspace_id="workspace-1",
+        name="客服助手_good_case",
+    )
+    assert [call["action"] for call in calls] == [
+        "ListEvaluationSets",
+        "CreateEvaluationSet",
+        "ListEvaluationSets",
+    ]
+    assert calls[1]["query"] == {"ProjectName": "support"}
+    assert calls[2]["query"] == {"ProjectName": "support"}
 
 
 @pytest.mark.asyncio

--- a/veadk/integrations/agentkit/evaluation/client.py
+++ b/veadk/integrations/agentkit/evaluation/client.py
@@ -149,6 +149,17 @@ class AgentKitEvaluationDatasetsClient:
         """Return the feedback set, creating it when absent."""
         name = feedback_set_name(agent_name, rating)
         workspace_id = await self._resolve_workspace_id()
+        if workspace_id is None:
+            try:
+                return await self._create_set(name, workspace_id=None)
+            except AgentKitOpenApiError as error:
+                if error.code != _DUPLICATE_DATASET_ERROR_CODE:
+                    raise
+                existing = await self._wait_for_set(name, workspace_id=None)
+                if existing is not None:
+                    return existing
+                raise
+
         fallback_name = _fallback_set_name(name, workspace_id)
         existing = await self._find_set(name, workspace_id=workspace_id)
         if existing is not None:
@@ -186,12 +197,15 @@ class AgentKitEvaluationDatasetsClient:
         self,
         name: str,
         *,
-        workspace_id: str,
+        workspace_id: str | None,
     ) -> EvaluationSetRef:
         """Create one evaluation set and verify its stable identifiers."""
+        query = dict(self._project_query)
+        if workspace_id:
+            query["WorkspaceId"] = workspace_id
         created = await self._post(
             action="CreateEvaluationSet",
-            query={**self._project_query, "WorkspaceId": workspace_id},
+            query=query,
             payload={
                 "Name": name,
                 "Description": "AgentKit Studio 对话反馈自动回流评测集",
@@ -214,8 +228,8 @@ class AgentKitEvaluationDatasetsClient:
             )
         return visible
 
-    async def _resolve_workspace_id(self) -> str:
-        """Resolve the account's evaluation workspace from visible datasets."""
+    async def _resolve_workspace_id(self) -> str | None:
+        """Resolve the project's evaluation workspace when a dataset exists."""
         if self._workspace_id is not None:
             return self._workspace_id
         response = await self._post(
@@ -232,7 +246,7 @@ class AgentKitEvaluationDatasetsClient:
             if workspace_id:
                 self._workspace_id = workspace_id
                 return workspace_id
-        raise RuntimeError("AgentKit account does not expose an evaluation workspace")
+        return None
 
     async def upsert_item(
         self,
@@ -293,6 +307,8 @@ class AgentKitEvaluationDatasetsClient:
         if rating not in {"good", "bad"}:
             raise ValueError(f"unsupported feedback rating: {rating}")
         workspace_id = await self._resolve_workspace_id()
+        if workspace_id is None:
+            return None, []
         set_name = feedback_set_name(agent_name, rating)
         evaluation_set = await self._find_set(
             set_name,
@@ -339,11 +355,14 @@ class AgentKitEvaluationDatasetsClient:
         self,
         name: str,
         *,
-        workspace_id: str,
+        workspace_id: str | None,
     ) -> EvaluationSetRef | None:
+        query = dict(self._project_query)
+        if workspace_id:
+            query["WorkspaceId"] = workspace_id
         response = await self._post(
             action="ListEvaluationSets",
-            query={**self._project_query, "WorkspaceId": workspace_id},
+            query=query,
             payload={"Name": name, "PageNumber": 1, "PageSize": 100},
         )
         items = (response.get("Result") or {}).get("EvaluationSets") or []
@@ -358,6 +377,7 @@ class AgentKitEvaluationDatasetsClient:
         )
         if not evaluation_set_id or not resolved_workspace_id:
             raise RuntimeError("AgentKit evaluation set is missing stable identifiers")
+        self._workspace_id = resolved_workspace_id
         return EvaluationSetRef(
             id=evaluation_set_id,
             workspace_id=resolved_workspace_id,
@@ -368,7 +388,7 @@ class AgentKitEvaluationDatasetsClient:
         self,
         name: str,
         *,
-        workspace_id: str,
+        workspace_id: str | None,
     ) -> EvaluationSetRef | None:
         """Wait until a newly created evaluation set is list-visible."""
         for delay in _DUPLICATE_LOOKUP_DELAYS:


### PR DESCRIPTION
## Summary

- create the first AgentKit feedback dataset without requiring a pre-existing workspace ID
- resolve and cache the workspace ID once the newly created dataset becomes visible
- apply the same cold-start behavior to automatic evaluation datasets while preserving existing-dataset behavior
- add client, repository, and Studio endpoint regression coverage

## Testing

- `pre-commit run --files ...`
- `pytest -q tests/integrations/agentkit/evaluation/test_client.py tests/frontend/server/evaluation_automation tests/cli/test_frontend_evaluation_feedback.py` (43 passed)
- full `pytest -q` attempted: 2739 passed, 5 skipped; unrelated local baseline issues remained in media log capture and sidecar wheel tests (local uv lacks `--no-create-gitignore`)