### PR TITLE
fix(studio): remove sparse null placeholders from trace output

### DIFF
--- a/tests/cli/test_frontend_apmplus_trace.py
+++ b/tests/cli/test_frontend_apmplus_trace.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from typing import Any
 
@@ -149,6 +150,91 @@ def test_normalize_apmplus_trace_converts_span_shape_for_frontend() -> None:
             },
         }
     ]
+
+
+def test_normalize_apmplus_trace_compacts_sparse_stream_output() -> None:
+    sparse_output = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "parts": [{"type": "text", "text": "有"}],
+                }
+            },
+            {
+                "message": {
+                    "role": "assistant",
+                    "parts": [None, {"type": "text", "text": "的"}],
+                }
+            },
+            {
+                "message": {
+                    "role": "assistant",
+                    "parts": [None, None, {"type": "text", "text": "。"}],
+                }
+            },
+        ]
+    }
+
+    spans = normalize_apmplus_trace(
+        [
+            {
+                "operation_name": "invoke_agent demo",
+                "span_id": "span-1",
+                "trace_id": "trace-1",
+                "gen_ai_output": json.dumps(sparse_output),
+            }
+        ]
+    )
+
+    output = spans[0]["attributes"]["gen_ai.output"]
+    assert json.loads(output) == {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "parts": [{"type": "text", "text": "有"}],
+                }
+            },
+            {
+                "message": {
+                    "role": "assistant",
+                    "parts": [{"type": "text", "text": "的"}],
+                }
+            },
+            {
+                "message": {
+                    "role": "assistant",
+                    "parts": [{"type": "text", "text": "。"}],
+                }
+            },
+        ]
+    }
+    assert "null" not in output
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "plain text",
+        "{not json",
+        "null",
+        '{ "choices": [{"message": {"parts": [{"text": "ok"}]}}] }',
+    ],
+)
+def test_normalize_apmplus_trace_preserves_non_sparse_output(output: str) -> None:
+    spans = normalize_apmplus_trace(
+        [
+            {
+                "operation_name": "invoke_agent demo",
+                "span_id": "span-1",
+                "trace_id": "trace-1",
+                "gen_ai_output": output,
+            }
+        ]
+    )
+
+    assert spans[0]["attributes"]["gen_ai.output"] == output
 
 
 def test_apmplus_trace_falls_back_when_run_sse_candidate_is_missing(

--- a/veadk/cli/frontend_apmplus_trace.py
+++ b/veadk/cli/frontend_apmplus_trace.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 from typing import Any, cast
 
@@ -93,6 +94,37 @@ def _matches_tag(tags: dict[str, Any], keys: tuple[str, ...], value: str) -> boo
     return any(str(tags.get(key) or "") == value for key in keys)
 
 
+def _compact_apmplus_output_parts(value: Any) -> Any:
+    """Remove sparse placeholders from APMPlus streamed choice output."""
+    if not isinstance(value, str):
+        return value
+    try:
+        payload = json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return value
+    if not isinstance(payload, dict) or not isinstance(payload.get("choices"), list):
+        return value
+
+    changed = False
+    for choice in payload["choices"]:
+        if not isinstance(choice, dict):
+            continue
+        message = choice.get("message")
+        if not isinstance(message, dict):
+            continue
+        parts = message.get("parts")
+        if not isinstance(parts, list):
+            continue
+        compact_parts = [part for part in parts if part is not None]
+        if len(compact_parts) != len(parts):
+            message["parts"] = compact_parts
+            changed = True
+
+    if not changed:
+        return value
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+
 def normalize_apmplus_trace(
     spans: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -114,6 +146,10 @@ def normalize_apmplus_trace(
             value = span.get(source)
             if value not in (None, ""):
                 attributes[target] = value
+        if "gen_ai.output" in attributes:
+            attributes["gen_ai.output"] = _compact_apmplus_output_parts(
+                attributes["gen_ai.output"]
+            )
         parent_span_id = str(span.get("parent_span_id") or "") or None
         normalized.append(
             {


### PR DESCRIPTION
## Summary

- compact `null` placeholders from APMPlus streamed `choices[].message.parts` before Studio renders trace output
- preserve non-JSON, non-object, and already compact output unchanged
- add regression coverage for sparse and unchanged output shapes

## Validation

- `uv run pre-commit run --files veadk/cli/frontend_apmplus_trace.py tests/cli/test_frontend_apmplus_trace.py`
- `uv run pytest tests/cli/test_frontend_apmplus_trace.py tests/cli/test_studio_rbac.py::test_runtime_trace_reads_apmplus_and_explains_missing_observability -q` (12 passed)
- Volcengine live Studio trace: 733 raw parts / 600 nulls -> 133 parts / 0 nulls, expected output preserved
- BytePlus live Studio trace API: 678 raw parts / 552 nulls -> 126 parts / 0 nulls, expected output preserved
- desktop Trace Drawer visually verified with the compacted output