### PR TITLE
Feat/auto save memory

### DIFF
--- a/docs/content/docs/framework/memory/long-term/index.en.mdx
+++ b/docs/content/docs/framework/memory/long-term/index.en.mdx
@@ -131,7 +131,7 @@ runner = Runner(agent=root_agent, app_name=APP_NAME)
 
 ### Write: `add_session_to_memory`
 
-When a session ends or hits a checkpoint, call the async `add_session_to_memory` to persist it. `LongTermMemory` first filters events (keeping user text events to improve retrieval quality), then hands them to the backend.
+When a session ends or hits a checkpoint, call the async `add_session_to_memory` to persist it. `LongTermMemory` first filters events with the default policy (regular backends keep user text events; OpenViking keeps user and assistant text events), then hands them to the backend.
 
 ```python
 completed_session = await runner.session_service.get_session(
@@ -173,7 +173,59 @@ agent = Agent(
 ```
 
 To avoid frequent index re-initialization, VeADK exposes `MIN_MESSAGES_THRESHOLD` and `MIN_TIME_THRESHOLD` env vars to tune the save cadence: by default it saves after 10 accumulated events or a 60-second interval; additionally, when you switch `session_id` and start a new turn, VeADK saves the previous session to long-term memory.
-
+## Auto-save Memory Policy
+Configure `auto_save_memory_policy` on `Agent` to decide which events are persisted by automatic long-term-memory saving. If omitted, it is equivalent to `"default"`.
+```python
+from veadk import Agent
+from veadk.memory import MemoryAutoSavePolicy
+from veadk.memory.long_term_memory import LongTermMemory
+agent = Agent(
+    name="ltm_agent",
+    auto_save_session=True,
+    long_term_memory=LongTermMemory(backend="viking", app_name="ltm_demo"),
+    auto_save_memory_policy="default",
+)
+agent_all = Agent(
+    name="ltm_agent_all",
+    auto_save_session=True,
+    long_term_memory=LongTermMemory(backend="viking", app_name="ltm_demo"),
+    auto_save_memory_policy="all",
+)
+agent_custom = Agent(
+    name="ltm_agent_custom",
+    auto_save_session=True,
+    long_term_memory=LongTermMemory(backend="viking", app_name="ltm_demo"),
+    auto_save_memory_policy=MemoryAutoSavePolicy(
+        preset="custom",
+        include_roles=["user", "assistant"],
+        include_event_types=["text", "function_call", "function_response"],
+        exclude_authors=["memory_optimizer"],
+        include_thought=False,
+    ),
+)
+```
+The policy only controls event filtering for automatic long-term-memory saving. It does not change short-term memory, `load_memory` retrieval, or the backend `save_memory` contract. Manual `add_session_to_memory` calls keep the backward-compatible default policy unless you explicitly pass `auto_save_memory_policy`.
+### Presets
+`"default"`: backward-compatible behavior. Regular backends save only `role=user` text events; OpenViking saves `role=user` and `role=assistant` text events. Tool calls, tool responses, media, code execution results, and thought text are not saved by default.
+`"all"`: saves all serializable event types for `role=user`, `role=assistant`, and `role=system`, including text, thought, function/tool calls and responses, media metadata, code execution, transcription, and errors. To avoid writing raw binary payloads to memory, `inline_data.data` is replaced by `data_size` and `data_omitted`.
+`"custom"`: starts from conservative defaults and lets developers select or exclude events with include/exclude fields.
+### Policy Fields
+`include_roles` / `exclude_roles`: filter by normalized role. Role values are `"user"`, `"assistant"`, and `"system"`. ADK/GenAI `content.role="model"` is normalized to `"assistant"`; `event.author=="user"` or `content.role=="user"` is normalized to `"user"`.
+`include_authors` / `exclude_authors`: exact-match filters on `event.author`. `author` is not a fixed enum; it may be `"user"`, an agent name, a runtime bridge component, or an internal processor name.
+`include_event_types` / `exclude_event_types`: filter by content type inferred from the event. If `include_event_types` is set explicitly, it takes precedence and can include non-text event types directly.
+`text_only`: when `include_event_types` is not explicitly set, only text-like parts pass. Defaults to `True`.
+`include_thought`: whether to save thought text where `part.thought=True`. Defaults to `False`; mixed events drop thought parts but keep final text parts.
+`include_empty_text`: whether events without text parts may pass. `"all"` enables it for errors, transcriptions, and other non-plain-text events, but if every inferred type is removed by `exclude_event_types`, no empty event is written.
+### Event Type Inference
+`event_type` is not a native ADK Event field. VeADK infers it from `event.content.parts` and event metadata.
+`text`: a part has `text` and is not thought.
+`thought`: a part has `text` and `thought=True`.
+`function_call` / `function_response`: a part has `function_call` or `function_response`; this is the common ADK tool-call/tool-result shape.
+`tool_call` / `tool_response`: a part has lower-level GenAI `tool_call` or `tool_response`.
+`media`: a part has `inline_data` or `file_data`.
+`executable_code` / `code_execution_result`: a part has an executable-code request or code-execution result.
+`transcription`: the event has `input_transcription` or `output_transcription`.
+`error`: the event has `error_code` or `error_message`.
 ## Cross-session example
 
 An end-to-end flow: session #1 tells the agent a fact and auto-archives it, then a **brand-new** session #2 asks a question — and the agent recalls the fact via memory retrieval (not the context window). This uses the `local` backend, which needs `pip install "veadk-python[extensions]"`.

--- a/docs/content/docs/framework/memory/long-term/index.mdx
+++ b/docs/content/docs/framework/memory/long-term/index.mdx
@@ -131,7 +131,7 @@ runner = Runner(agent=root_agent, app_name=APP_NAME)
 
 ### 写入：`add_session_to_memory`
 
-会话结束或达到某个节点时，调用异步方法 `add_session_to_memory` 把会话持久化。`LongTermMemory` 会先过滤事件（只保留用户文本事件以提升检索质量），再交给后端写入。
+会话结束或达到某个节点时，调用异步方法 `add_session_to_memory` 把会话持久化。`LongTermMemory` 会先按默认策略过滤事件（普通后端只保留用户文本事件，OpenViking 后端保留用户与助手文本事件），再交给后端写入。
 
 ```python
 completed_session = await runner.session_service.get_session(
@@ -173,7 +173,59 @@ agent = Agent(
 ```
 
 为避免索引被频繁初始化，VeADK 提供 `MIN_MESSAGES_THRESHOLD` 与 `MIN_TIME_THRESHOLD` 两个环境变量自定义保存周期：默认在累计 10 条 event 或间隔 60 秒时触发保存；此外，当切换 `session_id` 并发起新问答时，VeADK 会自动把上一个会话写入长期记忆。
-
+## 自动保存记忆策略
+开发者在 `Agent` 上配置 `auto_save_memory_policy` 来控制自动保存长期记忆时哪些 event 会被写入；不配置时等价于 `"default"`。
+```python
+from veadk import Agent
+from veadk.memory import MemoryAutoSavePolicy
+from veadk.memory.long_term_memory import LongTermMemory
+agent = Agent(
+    name="ltm_agent",
+    auto_save_session=True,
+    long_term_memory=LongTermMemory(backend="viking", app_name="ltm_demo"),
+    auto_save_memory_policy="default",
+)
+agent_all = Agent(
+    name="ltm_agent_all",
+    auto_save_session=True,
+    long_term_memory=LongTermMemory(backend="viking", app_name="ltm_demo"),
+    auto_save_memory_policy="all",
+)
+agent_custom = Agent(
+    name="ltm_agent_custom",
+    auto_save_session=True,
+    long_term_memory=LongTermMemory(backend="viking", app_name="ltm_demo"),
+    auto_save_memory_policy=MemoryAutoSavePolicy(
+        preset="custom",
+        include_roles=["user", "assistant"],
+        include_event_types=["text", "function_call", "function_response"],
+        exclude_authors=["memory_optimizer"],
+        include_thought=False,
+    ),
+)
+```
+策略字段只影响自动保存长期记忆的事件筛选，不改变短期记忆、`load_memory` 检索或后端 `save_memory` 的参数契约；手动调用 `add_session_to_memory` 时仍默认使用兼容旧版本的默认策略，只有显式传入 `auto_save_memory_policy` 才会应用自定义筛选。
+### 预置策略
+`"default"`：兼容旧行为。普通后端只保存 `role=user` 的文本事件；OpenViking 后端保存 `role=user` 与 `role=assistant` 的文本事件；默认不保存工具调用、工具返回、媒体、代码执行结果和 thought。
+`"all"`：保存 `role=user`、`role=assistant`、`role=system` 的所有可序列化事件类型，包括文本、thought、function/tool 调用与返回、媒体元信息、代码执行、转写和错误。为避免把原始二进制写入记忆，`inline_data.data` 会被替换为 `data_size` 与 `data_omitted`。
+`"custom"`：从保守默认值开始，由开发者通过 include/exclude 字段精确选择要保存或排除的事件。
+### 策略字段
+`include_roles` / `exclude_roles`：按归一化后的角色筛选，角色枚举为 `"user"`、`"assistant"`、`"system"`；ADK/GenAI 的 `content.role="model"` 会归一化为 `"assistant"`，`event.author=="user"` 或 `content.role=="user"` 会归一化为 `"user"`。
+`include_authors` / `exclude_authors`：按 `event.author` 精确匹配筛选；`author` 不是固定枚举，可能是 `"user"`、agent name、运行时桥接组件或内部处理器名称。
+`include_event_types` / `exclude_event_types`：按 event 中包含的内容类型筛选；显式设置 `include_event_types` 时以该字段为准，可直接保存非文本类型。
+`text_only`：当 `include_event_types` 未显式设置时，只允许文本类 part 通过；默认 `True`。
+`include_thought`：是否保存 `part.thought=True` 的思考文本；默认 `False`，混合事件中会移除 thought part 但保留最终文本。
+`include_empty_text`：是否允许没有文本 part 的事件通过；`"all"` 会开启它以支持错误、转写等非普通文本事件，但如果事件类型被 `exclude_event_types` 全部排除，仍不会写入空事件。
+### Event 类型推断
+`event_type` 不是 ADK Event 的原生字段，VeADK 会从 `event.content.parts` 与事件元数据推断。
+`text`：part 有 `text` 且不是 thought。
+`thought`：part 有 `text` 且 `thought=True`。
+`function_call` / `function_response`：part 含 `function_call` 或 `function_response`，这是 ADK 常用的工具调用与工具返回形态。
+`tool_call` / `tool_response`：part 含 GenAI 底层 `tool_call` 或 `tool_response`。
+`media`：part 含 `inline_data` 或 `file_data`。
+`executable_code` / `code_execution_result`：part 含代码执行请求或执行结果。
+`transcription`：event 含 `input_transcription` 或 `output_transcription`。
+`error`：event 含 `error_code` 或 `error_message`。
 ## 跨会话示例
 
 下面是端到端流程：会话 #1 告诉智能体一个事实并自动归档，然后在**全新的**会话 #2 提问——智能体通过检索长期记忆（而非上下文窗口）回忆起该事实。这里用 `local` 后端，需要 `pip install "veadk-python[extensions]"`。

--- a/examples/09_long_term_memory/README.md
+++ b/examples/09_long_term_memory/README.md
@@ -45,6 +45,18 @@ python main.py
 Session #2's recommendation should respect the peanut allergy and vegetarian
 preference from session #1.
 
+## Auto-save policy preview
+
+To inspect what `auto_save_memory_policy` persists without calling a model or a
+real memory service, run:
+
+```bash
+python auto_save_memory_policy.py
+```
+
+The preview compares `"default"`, `"all"`, and a custom
+`MemoryAutoSavePolicy`.
+
 ## What to try next
 
 - Short-term vs long-term: see [03](../03_short_term_memory/) for the

--- a/examples/09_long_term_memory/README.zh.md
+++ b/examples/09_long_term_memory/README.zh.md
@@ -40,6 +40,16 @@ python main.py
 
 会话 #2 的推荐应当尊重会话 #1 中提到的花生过敏与素食偏好。
 
+## 自动保存策略预览
+
+如果只想查看 `auto_save_memory_policy` 会保存哪些 event，而不调用模型或真实记忆服务，可以运行：
+
+```bash
+python auto_save_memory_policy.py
+```
+
+这个预览会对比 `"default"`、`"all"` 和一个自定义 `MemoryAutoSavePolicy`。
+
 ## 下一步
 
 - 短期 vs 长期：会话内的记忆见 [03](../03_short_term_memory/)。

--- a/examples/09_long_term_memory/auto_save_memory_policy.py
+++ b/examples/09_long_term_memory/auto_save_memory_policy.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Preview how auto_save_memory_policy filters long-term-memory events.
+
+The real auto-save path reads `Agent.auto_save_memory_policy` and passes it to
+`LongTermMemory.add_session_to_memory` after an agent turn. This example avoids
+calling an LLM and uses a recording backend so you can see exactly which events
+each policy would persist.
+"""
+
+import asyncio
+import json
+
+from google.adk.events import Event
+from google.adk.sessions import Session
+from google.genai import types
+from pydantic import Field
+
+from veadk import Agent
+from veadk.memory import MemoryAutoSavePolicy
+from veadk.memory.long_term_memory import LongTermMemory
+from veadk.memory.long_term_memory_backends.base_backend import (
+    BaseLongTermMemoryBackend,
+)
+
+APP_NAME = "ltm_policy_demo"
+USER_ID = "user-42"
+
+
+class RecordingLongTermMemoryBackend(BaseLongTermMemoryBackend):
+    saved_events: list[str] = Field(default_factory=list)
+
+    def precheck_index_naming(self):
+        pass
+
+    def save_memory(self, user_id: str, event_strings: list[str], **kwargs) -> bool:
+        del user_id, kwargs
+        self.saved_events.extend(event_strings)
+        return True
+
+    def search_memory(
+        self, user_id: str, query: str, top_k: int, **kwargs
+    ) -> list[str]:
+        del user_id, query, top_k, kwargs
+        return []
+
+
+def build_agent(
+    policy: str | MemoryAutoSavePolicy,
+) -> tuple[Agent, RecordingLongTermMemoryBackend]:
+    backend = RecordingLongTermMemoryBackend(index=APP_NAME)
+    agent = Agent(
+        name="ltm_policy_agent",
+        model_name="not-used",
+        model_provider="test",
+        model_api_key="not-used",
+        model_api_base="http://localhost",
+        instruction="Preview long-term-memory auto-save policy behavior.",
+        long_term_memory=LongTermMemory(backend=backend, app_name=APP_NAME),
+        auto_save_session=True,
+        auto_save_memory_policy=policy,
+    )
+    return agent, backend
+
+
+def build_session() -> Session:
+    return Session(
+        id="session-1",
+        app_name=APP_NAME,
+        user_id=USER_ID,
+        state={},
+        events=[
+            Event(
+                author="user",
+                content=types.Content(
+                    role="user",
+                    parts=[types.Part(text="Remember that I prefer short answers.")],
+                ),
+            ),
+            Event(
+                author="assistant",
+                content=types.Content(
+                    role="model",
+                    parts=[types.Part(text="Got it. I will keep answers concise.")],
+                ),
+            ),
+            Event(
+                author="assistant",
+                content=types.Content(
+                    role="model",
+                    parts=[
+                        types.Part(
+                            function_call=types.FunctionCall(
+                                id="call-1",
+                                name="load_memory",
+                                args={"query": "answer style"},
+                            )
+                        )
+                    ],
+                ),
+            ),
+            Event(
+                author="user",
+                content=types.Content(
+                    role="user",
+                    parts=[
+                        types.Part(
+                            function_response=types.FunctionResponse(
+                                id="call-1",
+                                name="load_memory",
+                                response={"result": "short answers"},
+                            )
+                        )
+                    ],
+                ),
+            ),
+            Event(
+                author="assistant",
+                content=types.Content(
+                    role="model",
+                    parts=[
+                        types.Part(text="internal reasoning", thought=True),
+                        types.Part(text="Final answer text."),
+                    ],
+                ),
+            ),
+            Event(
+                author="user",
+                content=types.Content(
+                    role="user",
+                    parts=[
+                        types.Part(
+                            inline_data=types.Blob(
+                                mime_type="text/plain",
+                                data=b"raw payload",
+                            )
+                        )
+                    ],
+                ),
+            ),
+        ],
+    )
+
+
+def compact_policy(policy: str | MemoryAutoSavePolicy) -> str:
+    if isinstance(policy, str):
+        return policy
+    return json.dumps(policy.model_dump(exclude_none=True), ensure_ascii=False)
+
+
+async def preview_policy(policy: str | MemoryAutoSavePolicy) -> None:
+    agent, backend = build_agent(policy)
+    assert agent.long_term_memory is not None
+    await agent.long_term_memory.add_session_to_memory(
+        build_session(),
+        auto_save_memory_policy=agent.auto_save_memory_policy,
+    )
+    print(f"\nPolicy: {compact_policy(policy)}")
+    for index, event_string in enumerate(backend.saved_events, start=1):
+        event = json.loads(event_string)
+        print(f"{index}. role={event.get('role')} author={event.get('author')}")
+        print(json.dumps(event.get("parts", []), ensure_ascii=False, indent=2))
+
+
+async def main() -> None:
+    await preview_policy("default")
+    await preview_policy("all")
+    await preview_policy(
+        MemoryAutoSavePolicy(
+            preset="custom",
+            include_roles=["user", "assistant"],
+            include_event_types=["text", "function_call", "function_response"],
+            include_thought=False,
+        )
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/agent/test_agent_contract.py
+++ b/tests/agent/test_agent_contract.py
@@ -30,6 +30,7 @@ _EXPECTED_DEFAULTS = {
     "enable_responses_cache": True,
     "enable_authz": False,
     "auto_save_session": False,
+    "auto_save_memory_policy": "default",
     "enable_supervisor": False,
     "enable_ghostchar": False,
     "enable_dataset_gen": False,

--- a/tests/test_long_term_memory.py
+++ b/tests/test_long_term_memory.py
@@ -12,14 +12,66 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import json
 import os
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
+from google.adk.events import Event
+from google.adk.sessions import Session
 from google.adk.tools import load_memory
+from google.genai import types
+from pydantic import Field
 
 from veadk.agent import Agent
+from veadk.memory import MemoryAutoSavePolicy, save_session_callback
 from veadk.memory.long_term_memory import LongTermMemory
+from veadk.memory.long_term_memory_backends.base_backend import (
+    BaseLongTermMemoryBackend,
+)
+
+
+class _RecordingBackend(BaseLongTermMemoryBackend):
+    saved_call: dict[str, Any] = Field(default_factory=dict)
+
+    def precheck_index_naming(self):
+        pass
+
+    def save_memory(self, user_id: str, event_strings: list[str], **kwargs) -> bool:
+        self.saved_call = {
+            "user_id": user_id,
+            "event_strings": event_strings,
+            "kwargs": kwargs,
+        }
+        return True
+
+    def search_memory(
+        self, user_id: str, query: str, top_k: int, **kwargs
+    ) -> list[str]:
+        return []
+
+
+class OpenVikingLTMBackend(_RecordingBackend):
+    pass
+
+
+def _session_with_events(events: list[Event]) -> Session:
+    return Session(
+        id="session_001",
+        app_name="support_app",
+        user_id="alice",
+        state={},
+        events=events,
+    )
+
+
+def _saved_messages(backend: _RecordingBackend) -> list[dict[str, Any]]:
+    return [json.loads(item) for item in backend.saved_call["event_strings"]]
+
+
+def test_memory_auto_save_policy_is_exported():
+    assert MemoryAutoSavePolicy(preset="all").preset == "all"
 
 
 @pytest.mark.asyncio
@@ -46,3 +98,501 @@ async def test_long_term_memory():
     # assert agent.long_term_memory._backend.index == build_long_term_memory_index(
     #     app_name, user_id
     # )
+
+
+@pytest.mark.asyncio
+async def test_default_auto_save_memory_policy_keeps_user_text_only():
+    backend = _RecordingBackend(index="support_app")
+    memory = LongTermMemory(backend=backend, app_name="support_app")
+    session = _session_with_events(
+        [
+            Event(
+                author="user",
+                content=types.Content(
+                    role="user",
+                    parts=[types.Part(text="记住我喜欢短回答")],
+                ),
+            ),
+            Event(
+                author="assistant",
+                content=types.Content(
+                    role="model",
+                    parts=[types.Part(text="好的，我会记住")],
+                ),
+            ),
+            Event(
+                author="user",
+                content=types.Content(
+                    role="user",
+                    parts=[
+                        types.Part(
+                            function_call=types.FunctionCall(
+                                id="call_1",
+                                name="search",
+                                args={"query": "preference"},
+                            )
+                        ),
+                        types.Part(text="后续文本也应该保存"),
+                    ],
+                ),
+            ),
+        ]
+    )
+
+    await memory.add_session_to_memory(session)
+
+    messages = _saved_messages(backend)
+    assert [message["role"] for message in messages] == ["user", "user"]
+    assert [message["parts"][0]["text"] for message in messages] == [
+        "记住我喜欢短回答",
+        "后续文本也应该保存",
+    ]
+    assert all("author" not in message for message in messages)
+    assert all(
+        "function_call" not in part for message in messages for part in message["parts"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_openviking_auto_save_memory_policy_keeps_assistant_text():
+    backend = OpenVikingLTMBackend(index="support_app")
+    memory = LongTermMemory(backend=backend, app_name="support_app")
+    session = _session_with_events(
+        [
+            Event(
+                author="user",
+                content=types.Content(
+                    role="user",
+                    parts=[types.Part(text="我喜欢短回答")],
+                ),
+            ),
+            Event(
+                author="assistant",
+                content=types.Content(
+                    role="model",
+                    parts=[types.Part(text="已记住")],
+                ),
+            ),
+        ]
+    )
+
+    await memory.add_session_to_memory(session)
+
+    messages = _saved_messages(backend)
+    assert [message["role"] for message in messages] == ["user", "assistant"]
+    assert [message["parts"][0]["text"] for message in messages] == [
+        "我喜欢短回答",
+        "已记住",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_all_auto_save_memory_policy_keeps_structured_events_and_sanitizes_media():
+    backend = _RecordingBackend(index="support_app")
+    memory = LongTermMemory(backend=backend, app_name="support_app")
+    session = _session_with_events(
+        [
+            Event(
+                author="planner",
+                content=types.Content(
+                    role="model",
+                    parts=[types.Part(text="需要查用户偏好")],
+                ),
+            ),
+            Event(
+                author="planner",
+                content=types.Content(
+                    role="model",
+                    parts=[
+                        types.Part(
+                            function_call=types.FunctionCall(
+                                id="call_1",
+                                name="load_memory",
+                                args={"query": "偏好"},
+                            )
+                        )
+                    ],
+                ),
+            ),
+            Event(
+                author="user",
+                content=types.Content(
+                    role="user",
+                    parts=[
+                        types.Part(
+                            function_response=types.FunctionResponse(
+                                id="call_1",
+                                name="load_memory",
+                                response={"result": "短回答"},
+                            )
+                        )
+                    ],
+                ),
+            ),
+            Event(
+                author="user",
+                content=types.Content(
+                    role="user",
+                    parts=[
+                        types.Part(
+                            inline_data=types.Blob(
+                                mime_type="text/plain",
+                                data=b"abc",
+                            )
+                        )
+                    ],
+                ),
+            ),
+        ]
+    )
+
+    await memory.add_session_to_memory(session, auto_save_memory_policy="all")
+
+    messages = _saved_messages(backend)
+    assert [message["role"] for message in messages] == [
+        "assistant",
+        "assistant",
+        "user",
+        "user",
+    ]
+    assert messages[0]["author"] == "planner"
+    assert messages[1]["parts"][0]["function_call"]["name"] == "load_memory"
+    assert messages[2]["parts"][0]["function_response"]["response"] == {
+        "result": "短回答"
+    }
+    inline_data = messages[3]["parts"][0]["inline_data"]
+    assert inline_data == {
+        "mime_type": "text/plain",
+        "data_size": 4,
+        "data_omitted": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_custom_auto_save_memory_policy_filters_roles_and_non_text_parts():
+    backend = _RecordingBackend(index="support_app")
+    memory = LongTermMemory(backend=backend, app_name="support_app")
+    session = _session_with_events(
+        [
+            Event(
+                author="user",
+                content=types.Content(
+                    role="user",
+                    parts=[types.Part(text="用户文本")],
+                ),
+            ),
+            Event(
+                author="assistant",
+                content=types.Content(
+                    role="model",
+                    parts=[types.Part(text="助手文本")],
+                ),
+            ),
+            Event(
+                author="assistant",
+                content=types.Content(
+                    role="model",
+                    parts=[
+                        types.Part(
+                            function_call=types.FunctionCall(
+                                id="call_1",
+                                name="search",
+                                args={},
+                            )
+                        )
+                    ],
+                ),
+            ),
+        ]
+    )
+
+    await memory.add_session_to_memory(
+        session,
+        auto_save_memory_policy={
+            "preset": "custom",
+            "include_roles": ["assistant"],
+        },
+    )
+
+    messages = _saved_messages(backend)
+    assert len(messages) == 1
+    assert messages[0]["role"] == "assistant"
+    assert messages[0]["parts"][0]["text"] == "助手文本"
+
+
+@pytest.mark.asyncio
+async def test_custom_auto_save_memory_policy_explicit_event_types_keep_function_call():
+    backend = _RecordingBackend(index="support_app")
+    memory = LongTermMemory(backend=backend, app_name="support_app")
+    session = _session_with_events(
+        [
+            Event(
+                author="assistant",
+                content=types.Content(
+                    role="model",
+                    parts=[
+                        types.Part(text="不会保存这段普通文本"),
+                        types.Part(
+                            function_call=types.FunctionCall(
+                                id="call_1",
+                                name="search",
+                                args={"query": "偏好"},
+                            )
+                        ),
+                    ],
+                ),
+            )
+        ]
+    )
+
+    await memory.add_session_to_memory(
+        session,
+        auto_save_memory_policy={
+            "preset": "custom",
+            "include_roles": ["assistant"],
+            "include_event_types": ["function_call"],
+        },
+    )
+
+    messages = _saved_messages(backend)
+    assert len(messages) == 1
+    assert messages[0]["parts"] == [
+        {
+            "function_call": {
+                "id": "call_1",
+                "args": {"query": "偏好"},
+                "name": "search",
+            }
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_auto_save_memory_policy_excludes_author_and_event_type():
+    backend = _RecordingBackend(index="support_app")
+    memory = LongTermMemory(backend=backend, app_name="support_app")
+    session = _session_with_events(
+        [
+            Event(
+                author="assistant",
+                content=types.Content(
+                    role="model",
+                    parts=[types.Part(text="助手文本")],
+                ),
+            ),
+            Event(
+                author="memory_optimizer",
+                content=types.Content(
+                    role="model",
+                    parts=[types.Part(text="内部优化结果")],
+                ),
+            ),
+            Event(
+                author="assistant",
+                content=types.Content(
+                    role="model",
+                    parts=[
+                        types.Part(
+                            function_response=types.FunctionResponse(
+                                id="call_1",
+                                name="search",
+                                response={"result": "忽略工具结果"},
+                            )
+                        )
+                    ],
+                ),
+            ),
+        ]
+    )
+
+    await memory.add_session_to_memory(
+        session,
+        auto_save_memory_policy={
+            "preset": "all",
+            "exclude_authors": ["memory_optimizer"],
+            "exclude_event_types": ["function_response"],
+        },
+    )
+
+    messages = _saved_messages(backend)
+    assert len(messages) == 1
+    assert messages[0]["author"] == "assistant"
+    assert messages[0]["parts"] == [{"text": "助手文本"}]
+
+
+@pytest.mark.asyncio
+async def test_auto_save_memory_policy_kwarg_is_not_forwarded_to_backend():
+    backend = _RecordingBackend(index="support_app")
+    memory = LongTermMemory(backend=backend, app_name="support_app")
+    session = _session_with_events(
+        [
+            Event(
+                author="assistant",
+                content=types.Content(
+                    role="model",
+                    parts=[types.Part(text="助手文本")],
+                ),
+            )
+        ]
+    )
+
+    await memory.add_session_to_memory(
+        session,
+        source="manual",
+        auto_save_memory_policy="all",
+    )
+
+    assert backend.saved_call["kwargs"] == {
+        "session_id": "session_001",
+        "app_name": "support_app",
+        "source": "manual",
+    }
+
+
+@pytest.mark.asyncio
+async def test_all_auto_save_memory_policy_keeps_error_event_without_content():
+    backend = _RecordingBackend(index="support_app")
+    memory = LongTermMemory(backend=backend, app_name="support_app")
+    session = _session_with_events(
+        [
+            Event(
+                author="assistant",
+                error_code="500",
+                error_message="tool failed",
+            )
+        ]
+    )
+
+    await memory.add_session_to_memory(session, auto_save_memory_policy="all")
+
+    messages = _saved_messages(backend)
+    assert messages == [
+        {
+            "parts": [
+                {
+                    "text": "500: tool failed",
+                    "part_metadata": {"event_type": "error"},
+                }
+            ],
+            "role": "assistant",
+            "author": "assistant",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_auto_save_memory_policy_strips_thought_but_keeps_final_text():
+    backend = _RecordingBackend(index="support_app")
+    memory = LongTermMemory(backend=backend, app_name="support_app")
+    session = _session_with_events(
+        [
+            Event(
+                author="user",
+                content=types.Content(
+                    role="user",
+                    parts=[
+                        types.Part(text="内部推理", thought=True),
+                        types.Part(text="最终偏好"),
+                    ],
+                ),
+            )
+        ]
+    )
+
+    await memory.add_session_to_memory(session)
+
+    messages = _saved_messages(backend)
+    assert len(messages) == 1
+    assert messages[0]["parts"] == [{"text": "最终偏好"}]
+
+
+@pytest.mark.asyncio
+async def test_auto_save_callback_passes_agent_memory_policy():
+    save_session_callback._session_save_cache.clear()
+    save_session_callback._active_sessions.clear()
+    session = _session_with_events([])
+
+    class Memory:
+        def __init__(self):
+            self.calls = []
+
+        async def add_session_to_memory(self, session: Session, **kwargs):
+            self.calls.append({"session": session, "kwargs": kwargs})
+
+    class SessionService:
+        async def get_session(self, **kwargs):
+            return session
+
+    memory = Memory()
+    callback_context = SimpleNamespace(
+        _invocation_context=SimpleNamespace(
+            agent=SimpleNamespace(
+                long_term_memory=memory,
+                auto_save_memory_policy="all",
+            ),
+            app_name="support_app",
+            user_id="alice",
+            session=session,
+            session_service=SessionService(),
+        )
+    )
+
+    await save_session_callback.save_session_to_long_term_memory(callback_context)
+
+    assert memory.calls == [
+        {
+            "session": session,
+            "kwargs": {"auto_save_memory_policy": "all"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_auto_save_callback_passes_policy_when_session_switches():
+    save_session_callback._session_save_cache.clear()
+    save_session_callback._active_sessions.clear()
+    old_session = _session_with_events([])
+    old_session.id = "old_session"
+    new_session = _session_with_events([])
+    new_session.id = "new_session"
+    save_session_callback._active_sessions[
+        (new_session.app_name, new_session.user_id)
+    ] = old_session.id
+
+    class Memory:
+        def __init__(self):
+            self.calls = []
+
+        async def add_session_to_memory(self, session: Session, **kwargs):
+            self.calls.append({"session_id": session.id, "kwargs": kwargs})
+
+    class SessionService:
+        async def get_session(self, *, session_id: str, **kwargs):
+            return old_session if session_id == old_session.id else new_session
+
+    memory = Memory()
+    callback_context = SimpleNamespace(
+        _invocation_context=SimpleNamespace(
+            agent=SimpleNamespace(
+                long_term_memory=memory,
+                auto_save_memory_policy={"preset": "all"},
+            ),
+            app_name=new_session.app_name,
+            user_id=new_session.user_id,
+            session=new_session,
+            session_service=SessionService(),
+        )
+    )
+
+    await save_session_callback.save_session_to_long_term_memory(callback_context)
+
+    assert memory.calls == [
+        {
+            "session_id": "old_session",
+            "kwargs": {"auto_save_memory_policy": {"preset": "all"}},
+        },
+        {
+            "session_id": "new_session",
+            "kwargs": {"auto_save_memory_policy": {"preset": "all"}},
+        },
+    ]

--- a/tests/test_long_term_memory.py
+++ b/tests/test_long_term_memory.py
@@ -66,6 +66,16 @@ def _session_with_events(events: list[Event]) -> Session:
     )
 
 
+def _user_text_event(text: str) -> Event:
+    return Event(
+        author="user",
+        content=types.Content(
+            role="user",
+            parts=[types.Part(text=text)],
+        ),
+    )
+
+
 def _saved_messages(backend: _RecordingBackend) -> list[dict[str, Any]]:
     return [json.loads(item) for item in backend.saved_call["event_strings"]]
 
@@ -510,7 +520,7 @@ async def test_auto_save_memory_policy_strips_thought_but_keeps_final_text():
 async def test_auto_save_callback_passes_agent_memory_policy():
     save_session_callback._session_save_cache.clear()
     save_session_callback._active_sessions.clear()
-    session = _session_with_events([])
+    session = _session_with_events([_user_text_event("remember this")])
 
     class Memory:
         def __init__(self):
@@ -551,9 +561,9 @@ async def test_auto_save_callback_passes_agent_memory_policy():
 async def test_auto_save_callback_passes_policy_when_session_switches():
     save_session_callback._session_save_cache.clear()
     save_session_callback._active_sessions.clear()
-    old_session = _session_with_events([])
+    old_session = _session_with_events([_user_text_event("old message")])
     old_session.id = "old_session"
-    new_session = _session_with_events([])
+    new_session = _session_with_events([_user_text_event("new message")])
     new_session.id = "new_session"
     save_session_callback._active_sessions[
         (new_session.app_name, new_session.user_id)
@@ -595,4 +605,123 @@ async def test_auto_save_callback_passes_policy_when_session_switches():
             "session_id": "new_session",
             "kwargs": {"auto_save_memory_policy": {"preset": "all"}},
         },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_auto_save_callback_saves_only_new_events_when_resaving_session(
+    monkeypatch,
+):
+    save_session_callback._session_save_cache.clear()
+    save_session_callback._active_sessions.clear()
+    monkeypatch.setattr(save_session_callback, "MIN_TIME_THRESHOLD", 0)
+    monkeypatch.setattr(save_session_callback, "MIN_MESSAGES_THRESHOLD", 10)
+    session = _session_with_events([_user_text_event("first message")])
+
+    class Memory:
+        def __init__(self):
+            self.calls = []
+
+        async def add_session_to_memory(self, session: Session, **kwargs):
+            self.calls.append(
+                [
+                    part.text
+                    for event in session.events
+                    for part in event.content.parts
+                    if part.text
+                ]
+            )
+
+    class SessionService:
+        async def get_session(self, **kwargs):
+            return session
+
+    memory = Memory()
+    callback_context = SimpleNamespace(
+        _invocation_context=SimpleNamespace(
+            agent=SimpleNamespace(
+                long_term_memory=memory,
+                auto_save_memory_policy="all",
+            ),
+            app_name="support_app",
+            user_id="alice",
+            session=session,
+            session_service=SessionService(),
+        )
+    )
+
+    await save_session_callback.save_session_to_long_term_memory(callback_context)
+    session.events.append(_user_text_event("second message"))
+    await save_session_callback.save_session_to_long_term_memory(callback_context)
+
+    assert memory.calls == [["first message"], ["second message"]]
+
+
+@pytest.mark.asyncio
+async def test_auto_save_callback_does_not_resave_old_events_on_session_switch(
+    monkeypatch,
+):
+    save_session_callback._session_save_cache.clear()
+    save_session_callback._active_sessions.clear()
+    monkeypatch.setattr(save_session_callback, "MIN_TIME_THRESHOLD", 0)
+    monkeypatch.setattr(save_session_callback, "MIN_MESSAGES_THRESHOLD", 10)
+    old_session = _session_with_events([_user_text_event("old message")])
+    old_session.id = "old_session"
+    new_session = _session_with_events([_user_text_event("new message")])
+    new_session.id = "new_session"
+
+    class Memory:
+        def __init__(self):
+            self.calls = []
+
+        async def add_session_to_memory(self, session: Session, **kwargs):
+            self.calls.append(
+                (
+                    session.id,
+                    [
+                        part.text
+                        for event in session.events
+                        for part in event.content.parts
+                        if part.text
+                    ],
+                )
+            )
+
+    class SessionService:
+        async def get_session(self, *, session_id: str, **kwargs):
+            return old_session if session_id == old_session.id else new_session
+
+    memory = Memory()
+
+    old_context = SimpleNamespace(
+        _invocation_context=SimpleNamespace(
+            agent=SimpleNamespace(
+                long_term_memory=memory,
+                auto_save_memory_policy="all",
+            ),
+            app_name="support_app",
+            user_id="alice",
+            session=old_session,
+            session_service=SessionService(),
+        )
+    )
+    new_context = SimpleNamespace(
+        _invocation_context=SimpleNamespace(
+            agent=SimpleNamespace(
+                long_term_memory=memory,
+                auto_save_memory_policy="all",
+            ),
+            app_name="support_app",
+            user_id="alice",
+            session=new_session,
+            session_service=SessionService(),
+        )
+    )
+
+    await save_session_callback.save_session_to_long_term_memory(old_context)
+    await save_session_callback.save_session_to_long_term_memory(new_context)
+
+    assert memory.calls == [
+        ("old_session", ["old message"]),
+        ("new_session", ["new message"]),
     ]

--- a/veadk/agent.py
+++ b/veadk/agent.py
@@ -41,7 +41,10 @@ from typing_extensions import Any
 from veadk.config import settings
 from veadk.consts import DEFAULT_AGENT_NAME, DEFAULT_MODEL_EXTRA_CONFIG
 from veadk.knowledgebase import KnowledgeBase
-from veadk.memory.long_term_memory import LongTermMemory
+from veadk.memory.long_term_memory import (
+    LongTermMemory,
+    MemoryAutoSavePolicyInput,
+)
 from veadk.memory.short_term_memory import ShortTermMemory
 from veadk.processors import BaseRunProcessor, NoOpRunProcessor
 from veadk.prompts.agent_default_prompt import (
@@ -94,6 +97,8 @@ class Agent(LlmAgent):
         tracers (list[BaseTracer]): List of tracers used for telemetry and monitoring.
         enable_authz (bool): Whether to enable agent authorization checks.
         auto_save_session (bool): Whether to automatically save sessions to long-term memory.
+        auto_save_memory_policy (MemoryAutoSavePolicyInput): Event filtering policy
+            for automatically saved long-term memory.
         skills (list[str]): List of skills that equip the agent with specific capabilities.
         example_store (Optional[BaseExampleProvider]): Example store for providing example Q/A.
         enable_shadowchar (bool): Whether to enable shadow character for the agent.
@@ -164,6 +169,7 @@ class Agent(LlmAgent):
     enable_authz: bool = False
 
     auto_save_session: bool = False
+    auto_save_memory_policy: MemoryAutoSavePolicyInput = "default"
 
     skills: list[str] = Field(default_factory=list)
 

--- a/veadk/memory/__init__.py
+++ b/veadk/memory/__init__.py
@@ -15,7 +15,11 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from veadk.memory.long_term_memory import LongTermMemory
+    from veadk.memory.long_term_memory import (
+        LongTermMemory,
+        MemoryAutoSavePolicy,
+        MemoryAutoSavePolicyInput,
+    )
     from veadk.memory.short_term_memory import ShortTermMemory
 
 
@@ -29,7 +33,20 @@ def __getattr__(name):
         from veadk.memory.long_term_memory import LongTermMemory
 
         return LongTermMemory
+    if name == "MemoryAutoSavePolicy":
+        from veadk.memory.long_term_memory import MemoryAutoSavePolicy
+
+        return MemoryAutoSavePolicy
+    if name == "MemoryAutoSavePolicyInput":
+        from veadk.memory.long_term_memory import MemoryAutoSavePolicyInput
+
+        return MemoryAutoSavePolicyInput
     raise AttributeError(f"module 'veadk.memory' has no attribute '{name}'")
 
 
-__all__ = ["ShortTermMemory", "LongTermMemory"]
+__all__ = [
+    "ShortTermMemory",
+    "LongTermMemory",
+    "MemoryAutoSavePolicy",
+    "MemoryAutoSavePolicyInput",
+]

--- a/veadk/memory/long_term_memory.py
+++ b/veadk/memory/long_term_memory.py
@@ -38,6 +38,45 @@ from veadk.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+MemoryEventType = Literal[
+    "text",
+    "thought",
+    "function_call",
+    "function_response",
+    "tool_call",
+    "tool_response",
+    "media",
+    "executable_code",
+    "code_execution_result",
+    "transcription",
+    "error",
+]
+MemoryRole = Literal["user", "assistant", "system"]
+MemoryAutoSavePreset = Literal["default", "all", "custom"]
+
+
+class MemoryAutoSavePolicy(BaseModel):
+    """Controls which events automatic long-term-memory saving persists."""
+
+    preset: MemoryAutoSavePreset = "default"
+    include_roles: list[MemoryRole] | None = None
+    exclude_roles: list[MemoryRole] = Field(default_factory=list)
+    include_authors: list[str] | None = None
+    exclude_authors: list[str] = Field(default_factory=list)
+    include_event_types: list[MemoryEventType] | None = None
+    exclude_event_types: list[MemoryEventType] = Field(default_factory=list)
+    text_only: bool = True
+    include_thought: bool = False
+    include_empty_text: bool = False
+
+
+MemoryAutoSavePolicyInput = Union[
+    MemoryAutoSavePolicy,
+    Literal["default", "all", "custom"],
+    dict[str, Any],
+    None,
+]
+
 
 def _get_backend_cls(backend: str) -> type[BaseLongTermMemoryBackend]:
     try:
@@ -195,28 +234,110 @@ class LongTermMemory(BaseMemoryService, BaseModel):
         )
 
     def _filter_and_convert_events(
-        self, events: Iterable[Event], *, include_assistant: bool = False
+        self,
+        events: Iterable[Event],
+        *,
+        include_assistant: bool = False,
+        auto_save_memory_policy: MemoryAutoSavePolicyInput = None,
     ) -> list[str]:
+        policy = self._resolve_auto_save_memory_policy(
+            auto_save_memory_policy,
+            include_assistant=include_assistant,
+        )
         final_events = []
         for event in events:
-            # filter: bad event
-            if not event.content or not event.content.parts:
+            message = self._convert_event_to_memory_message(event, policy)
+            if not message:
                 continue
-
-            # filter: only add user event to memory to enhance retrieve performance
-            if not include_assistant and not event.author == "user":
-                continue
-
-            # filter: discard function call and function response
-            if not event.content.parts[0].text:
-                continue
-
-            # convert: to string-format for storage
-            message = event.content.model_dump(exclude_none=True, mode="json")
-            message["role"] = self._normalize_event_role(event, message)
 
             final_events.append(json.dumps(message, ensure_ascii=False))
         return final_events
+
+    def _resolve_auto_save_memory_policy(
+        self,
+        auto_save_memory_policy: MemoryAutoSavePolicyInput,
+        *,
+        include_assistant: bool,
+    ) -> MemoryAutoSavePolicy:
+        if auto_save_memory_policy is None:
+            return self._base_auto_save_memory_policy(
+                "default", include_assistant=include_assistant
+            )
+
+        if isinstance(auto_save_memory_policy, str):
+            return self._base_auto_save_memory_policy(
+                auto_save_memory_policy,
+                include_assistant=include_assistant,
+            )
+
+        raw_policy = MemoryAutoSavePolicy.model_validate(auto_save_memory_policy)
+        base_policy = self._base_auto_save_memory_policy(
+            raw_policy.preset,
+            include_assistant=include_assistant,
+        )
+        fields_set = getattr(raw_policy, "model_fields_set", set())
+        overrides = {
+            field: getattr(raw_policy, field)
+            for field in fields_set
+            if field != "preset"
+        }
+        if overrides:
+            base_policy = base_policy.model_copy(update=overrides)
+        return base_policy
+
+    def _base_auto_save_memory_policy(
+        self, preset: MemoryAutoSavePreset, *, include_assistant: bool
+    ) -> MemoryAutoSavePolicy:
+        if preset == "all":
+            return MemoryAutoSavePolicy(
+                preset="all",
+                include_roles=["user", "assistant", "system"],
+                include_event_types=None,
+                text_only=False,
+                include_thought=True,
+                include_empty_text=True,
+            )
+        if preset == "custom":
+            return MemoryAutoSavePolicy(preset="custom")
+        return MemoryAutoSavePolicy(
+            preset="default",
+            include_roles=["user", "assistant"] if include_assistant else ["user"],
+            include_event_types=["text"],
+            text_only=True,
+            include_thought=False,
+            include_empty_text=False,
+        )
+
+    def _convert_event_to_memory_message(
+        self, event: Event, policy: MemoryAutoSavePolicy
+    ) -> dict[str, Any] | None:
+        message = (
+            event.content.model_dump(exclude_none=True, mode="json")
+            if event.content
+            else {"parts": []}
+        )
+        role = self._normalize_event_role(event, message)
+        author = str(getattr(event, "author", "") or "")
+
+        if not self._is_role_allowed(role, policy):
+            return None
+        if not self._is_author_allowed(author, policy):
+            return None
+
+        event_types = self._infer_event_types(event)
+        if not self._has_allowed_event_type(event_types, policy):
+            return None
+
+        parts = self._filter_memory_parts(message.get("parts") or [], policy)
+        parts.extend(self._event_metadata_parts(event, policy))
+        if not parts and not policy.include_empty_text:
+            return None
+
+        message["role"] = role
+        message["parts"] = parts
+        if author and policy.preset != "default":
+            message["author"] = author
+        return message
 
     def _normalize_event_role(self, event: Event, message: dict[str, Any]) -> str:
         role = message.get("role")
@@ -225,6 +346,177 @@ class LongTermMemory(BaseMemoryService, BaseModel):
         if role == "system":
             return "system"
         return "assistant"
+
+    def _is_role_allowed(self, role: str, policy: MemoryAutoSavePolicy) -> bool:
+        if policy.include_roles is not None and role not in policy.include_roles:
+            return False
+        return role not in policy.exclude_roles
+
+    def _is_author_allowed(self, author: str, policy: MemoryAutoSavePolicy) -> bool:
+        if policy.include_authors is not None and author not in policy.include_authors:
+            return False
+        return author not in policy.exclude_authors
+
+    def _has_allowed_event_type(
+        self, event_types: set[str], policy: MemoryAutoSavePolicy
+    ) -> bool:
+        if not event_types:
+            return bool(policy.include_empty_text)
+        event_types = event_types - set(policy.exclude_event_types)
+        if not event_types:
+            return False
+        if policy.include_event_types is None:
+            return True
+        return bool(event_types & set(policy.include_event_types))
+
+    def _filter_memory_parts(
+        self, parts: list[Any], policy: MemoryAutoSavePolicy
+    ) -> list[dict[str, Any]]:
+        final_parts = []
+        for part in parts:
+            if not isinstance(part, dict):
+                continue
+            part_types = self._infer_part_event_types(part)
+            if not self._has_allowed_part_type(part_types, policy):
+                continue
+            if "thought" in part_types and not policy.include_thought:
+                part = dict(part)
+                part.pop("thought", None)
+                part.pop("thought_signature", None)
+                if part_types == {"thought"}:
+                    continue
+            final_parts.append(self._sanitize_memory_part(part))
+        return final_parts
+
+    def _has_allowed_part_type(
+        self, part_types: set[str], policy: MemoryAutoSavePolicy
+    ) -> bool:
+        if not part_types:
+            return False
+        if (
+            policy.text_only
+            and policy.include_event_types is None
+            and not part_types <= {"text", "thought"}
+        ):
+            return False
+        if part_types & set(policy.exclude_event_types):
+            return False
+        if policy.include_event_types is None:
+            return True
+        return bool(part_types & set(policy.include_event_types))
+
+    def _infer_event_types(self, event: Event) -> set[str]:
+        event_types = set()
+        content = getattr(event, "content", None)
+        for part in getattr(content, "parts", None) or []:
+            if hasattr(part, "model_dump"):
+                part = part.model_dump(exclude_none=True, mode="json")
+            if isinstance(part, dict):
+                event_types.update(self._infer_part_event_types(part))
+
+        if getattr(event, "input_transcription", None) is not None:
+            event_types.add("transcription")
+        if getattr(event, "output_transcription", None) is not None:
+            event_types.add("transcription")
+        if getattr(event, "error_code", None) or getattr(event, "error_message", None):
+            event_types.add("error")
+        return event_types
+
+    def _infer_part_event_types(self, part: dict[str, Any]) -> set[str]:
+        part_types = set()
+        text = part.get("text")
+        if text:
+            part_types.add("thought" if part.get("thought") else "text")
+        if part.get("function_call") is not None:
+            part_types.add("function_call")
+        if part.get("function_response") is not None:
+            part_types.add("function_response")
+        if part.get("tool_call") is not None:
+            part_types.add("tool_call")
+        if part.get("tool_response") is not None:
+            part_types.add("tool_response")
+        if part.get("inline_data") is not None or part.get("file_data") is not None:
+            part_types.add("media")
+        if part.get("executable_code") is not None:
+            part_types.add("executable_code")
+        if part.get("code_execution_result") is not None:
+            part_types.add("code_execution_result")
+        return part_types
+
+    def _event_metadata_parts(
+        self, event: Event, policy: MemoryAutoSavePolicy
+    ) -> list[dict[str, Any]]:
+        metadata_parts = []
+        if self._is_event_type_allowed("transcription", policy):
+            metadata_parts.extend(
+                self._serialize_event_metadata(
+                    "input_transcription",
+                    getattr(event, "input_transcription", None),
+                )
+            )
+            metadata_parts.extend(
+                self._serialize_event_metadata(
+                    "output_transcription",
+                    getattr(event, "output_transcription", None),
+                )
+            )
+        if self._is_event_type_allowed("error", policy):
+            error_code = getattr(event, "error_code", None)
+            error_message = getattr(event, "error_message", None)
+            if error_code or error_message:
+                text = ": ".join(str(v) for v in (error_code, error_message) if v)
+                metadata_parts.append(
+                    {
+                        "text": text,
+                        "part_metadata": {"event_type": "error"},
+                    }
+                )
+        return metadata_parts
+
+    def _is_event_type_allowed(
+        self, event_type: MemoryEventType, policy: MemoryAutoSavePolicy
+    ) -> bool:
+        if (
+            policy.text_only
+            and policy.include_event_types is None
+            and event_type not in {"text", "thought"}
+        ):
+            return False
+        if event_type in policy.exclude_event_types:
+            return False
+        if event_type == "thought" and not policy.include_thought:
+            return False
+        if policy.include_event_types is None:
+            return True
+        return event_type in policy.include_event_types
+
+    def _serialize_event_metadata(self, name: str, value: Any) -> list[dict[str, Any]]:
+        if value is None:
+            return []
+        if hasattr(value, "model_dump"):
+            value = value.model_dump(exclude_none=True, mode="json")
+        if isinstance(value, str):
+            text = value
+        else:
+            text = json.dumps(value, ensure_ascii=False)
+        if not text:
+            return []
+        return [{"text": text, "part_metadata": {"event_type": name}}]
+
+    def _sanitize_memory_part(self, part: dict[str, Any]) -> dict[str, Any]:
+        sanitized = dict(part)
+        inline_data = sanitized.get("inline_data")
+        if isinstance(inline_data, dict) and "data" in inline_data:
+            sanitized["inline_data"] = self._sanitize_inline_data(inline_data)
+        return sanitized
+
+    def _sanitize_inline_data(self, inline_data: dict[str, Any]) -> dict[str, Any]:
+        sanitized = dict(inline_data)
+        data = sanitized.pop("data", None)
+        if data is not None:
+            sanitized["data_size"] = len(str(data))
+            sanitized["data_omitted"] = True
+        return sanitized
 
     @override
     async def add_session_to_memory(
@@ -264,6 +556,7 @@ class LongTermMemory(BaseMemoryService, BaseModel):
         nested_kwargs = save_kwargs.pop("kwargs", None)
         if isinstance(nested_kwargs, dict):
             save_kwargs.update(nested_kwargs)
+        auto_save_memory_policy = save_kwargs.pop("auto_save_memory_policy", None)
         app_name = self.app_name or getattr(session, "app_name", "")
         include_assistant = (
             self.backend == "openviking"
@@ -272,6 +565,7 @@ class LongTermMemory(BaseMemoryService, BaseModel):
         event_strings = self._filter_and_convert_events(
             session.events,
             include_assistant=include_assistant,
+            auto_save_memory_policy=auto_save_memory_policy,
         )
 
         logger.info(

--- a/veadk/memory/save_session_callback.py
+++ b/veadk/memory/save_session_callback.py
@@ -36,6 +36,10 @@ MIN_TIME_THRESHOLD = getenv(
 )  # Minimum seconds between saves (1 minute)
 
 
+def _copy_session_with_events(session, events):
+    return session.model_copy(update={"events": events})
+
+
 async def save_session_to_long_term_memory(
     callback_context: CallbackContext,
 ) -> None:
@@ -81,21 +85,41 @@ async def save_session_to_long_term_memory(
                 session_id=previous_session_id,
             )
             if old_session:
+                old_cache_key = (app_name, user_id, previous_session_id)
+                old_cache_info = _session_save_cache.get(old_cache_key, {})
+                old_last_event_count = old_cache_info.get("last_event_count", 0)
                 old_events = getattr(old_session, "events", [])
                 old_event_count = len(old_events)
-                await long_term_memory.add_session_to_memory(
-                    old_session,
-                    auto_save_memory_policy=auto_save_memory_policy,
-                )
-                old_cache_key = (app_name, user_id, previous_session_id)
 
-                _session_save_cache[old_cache_key] = {
-                    "last_save_time": current_time,
-                    "last_event_count": old_event_count,
-                }
-                logger.info(
-                    f"Previous session `{old_session.id}` saved to long term memory due to session switch."
-                )
+                if old_last_event_count > old_event_count:
+                    logger.warning(
+                        f"Saved event cursor for previous session `{old_session.id}` "
+                        f"({old_last_event_count}) is greater than current event count "
+                        f"({old_event_count}); resetting cursor to 0."
+                    )
+                    old_last_event_count = 0
+
+                old_new_events = old_events[old_last_event_count:]
+                if old_new_events:
+                    incremental_old_session = _copy_session_with_events(
+                        old_session, old_new_events
+                    )
+                    await long_term_memory.add_session_to_memory(
+                        incremental_old_session,
+                        auto_save_memory_policy=auto_save_memory_policy,
+                    )
+
+                    _session_save_cache[old_cache_key] = {
+                        "last_save_time": current_time,
+                        "last_event_count": old_event_count,
+                    }
+                    logger.info(
+                        f"Previous session `{old_session.id}` saved to long term memory due to session switch."
+                    )
+                else:
+                    logger.info(
+                        f"Skipping save for previous session `{old_session.id}`: no new events."
+                    )
 
         # Update active session
         _active_sessions[user_key] = session_id
@@ -120,10 +144,19 @@ async def save_session_to_long_term_memory(
         cache_key = (app_name, user_id, session_id)
 
         cache_info = _session_save_cache.get(cache_key)
+        last_event_count = 0
 
         if cache_info:
             last_save_time = cache_info.get("last_save_time", 0)
             last_event_count = cache_info.get("last_event_count", 0)
+
+            if last_event_count > current_event_count:
+                logger.warning(
+                    f"Saved event cursor for session `{session_id}` "
+                    f"({last_event_count}) is greater than current event count "
+                    f"({current_event_count}); resetting cursor to 0."
+                )
+                last_event_count = 0
 
             time_elapsed = current_time - last_save_time
             new_events_count = current_event_count - last_event_count
@@ -142,9 +175,15 @@ async def save_session_to_long_term_memory(
         else:
             logger.info(f"First save for session {session_id}.")
 
+        new_events = current_events[last_event_count:]
+        if not new_events:
+            logger.info(f"Skipping save for session {session_id}: no new events.")
+            return None
+
         # Save to long-term memory
+        incremental_session = _copy_session_with_events(session, new_events)
         await long_term_memory.add_session_to_memory(
-            session,
+            incremental_session,
             auto_save_memory_policy=auto_save_memory_policy,
         )
 

--- a/veadk/memory/save_session_callback.py
+++ b/veadk/memory/save_session_callback.py
@@ -56,6 +56,7 @@ async def save_session_to_long_term_memory(
                 "Long-term memory is not initialized in agent, cannot save session to memory."
             )
             return None
+        auto_save_memory_policy = getattr(agent, "auto_save_memory_policy", "default")
 
         app_name = callback_context._invocation_context.app_name
         user_id = callback_context._invocation_context.user_id
@@ -82,7 +83,10 @@ async def save_session_to_long_term_memory(
             if old_session:
                 old_events = getattr(old_session, "events", [])
                 old_event_count = len(old_events)
-                await long_term_memory.add_session_to_memory(old_session)
+                await long_term_memory.add_session_to_memory(
+                    old_session,
+                    auto_save_memory_policy=auto_save_memory_policy,
+                )
                 old_cache_key = (app_name, user_id, previous_session_id)
 
                 _session_save_cache[old_cache_key] = {
@@ -139,7 +143,10 @@ async def save_session_to_long_term_memory(
             logger.info(f"First save for session {session_id}.")
 
         # Save to long-term memory
-        await long_term_memory.add_session_to_memory(session)
+        await long_term_memory.add_session_to_memory(
+            session,
+            auto_save_memory_policy=auto_save_memory_policy,
+        )
 
         # Update cache
         _session_save_cache[cache_key] = {


### PR DESCRIPTION
Summary
Adds configurable auto-save memory policies for long-term memory persistence and fixes auto-save to persist only newly added session events.
Changes
Add auto_save_memory_policy support for automatic session saves.
Forward the policy into long-term memory event filtering without changing backend save kwargs.
Add examples/docs for previewing auto-save memory policy behavior.
Fix duplicate memory writes by saving only session.events[last_event_count:].
Add regression tests for repeated session saves and session-switch saves.
Validation
uv run pre-commit run --files tests/test_long_term_memory.py veadk/memory/save_session_callback.py
.venv/bin/python -m pytest tests/test_long_term_memory.py