### PR TITLE
fix(studio): preserve JSON runtime request headers

### DIFF
--- a/tests/cli/test_frontend_evaluation_feedback.py
+++ b/tests/cli/test_frontend_evaluation_feedback.py
@@ -130,12 +130,14 @@ def test_studio_findskill_route_uses_studio_skill_catalog(
     ],
     ids=["agent-info", "legacy-runtime-fallback", "first-feedback-dataset"],
 )
+@pytest.mark.parametrize("rating", ["good", "bad"])
 def test_message_feedback_writes_dataset_and_session_state(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     agent_info_status: int,
     expected_agent_name: str,
     initially_empty: bool,
+    rating: str,
 ) -> None:
     app = _create_frontend_app(monkeypatch, tmp_path)
     openapi_calls: list[dict[str, Any]] = []
@@ -201,6 +203,15 @@ def test_message_feedback_writes_dataset_and_session_state(
                     status_code=agent_info_status,
                 )
             if method == "PATCH" and "/sessions/session-1" in url:
+                json_headers = [
+                    (name.lower(), value)
+                    for name, value in kwargs["headers"].items()
+                    if name.lower() in {"accept", "content-type"}
+                ]
+                assert json_headers == [
+                    ("accept", "application/json"),
+                    ("content-type", "application/json"),
+                ]
                 session_patches.append(kwargs["json"])
                 return _FakeResponse({}, status_code=404)
             raise AssertionError((method, url))
@@ -225,7 +236,7 @@ def test_message_feedback_writes_dataset_and_session_state(
                             "EvaluationSets": [
                                 {
                                     "Id": "set-1",
-                                    "Name": f"{expected_agent_name}_good_case",
+                                    "Name": f"{expected_agent_name}_{rating}_case",
                                     "WorkspaceId": "workspace-1",
                                 }
                             ]
@@ -268,16 +279,18 @@ def test_message_feedback_writes_dataset_and_session_state(
                 "userId": "user-1",
                 "sessionId": "session-1",
                 "eventId": "assistant-event",
-                "rating": "good",
+                "rating": rating,
                 "comment": annotation_comment,
             },
         )
 
     assert response.status_code == 200
-    assert response.json()["rating"] == "good"
+    assert response.json()["rating"] == rating
     assert response.json()["comment"] == annotation_comment
     assert response.json()["evaluationItemId"] == "item-1"
-    assert response.json()["evaluationSetName"] == (f"{expected_agent_name}_good_case")
+    assert response.json()["evaluationSetName"] == (
+        f"{expected_agent_name}_{rating}_case"
+    )
     assert response.json()["statePersistence"] == "browser"
     expected_actions = [
         "ListEvaluationSets",
@@ -296,7 +309,7 @@ def test_message_feedback_writes_dataset_and_session_state(
     else:
         assert openapi_calls[1]["params"]["WorkspaceId"] == "workspace-1"
     state = session_patches[0]["state_delta"]["veadk_feedback:assistant-event"]
-    assert state["rating"] == "good"
+    assert state["rating"] == rating
     assert state["comment"] == annotation_comment
     assert state["evaluationItemId"] == "item-1"
     create_item_call = next(
@@ -310,8 +323,9 @@ def test_message_feedback_writes_dataset_and_session_state(
     assert fields["feedback_comment"] == annotation_comment
 
 
+@pytest.mark.parametrize("rating", ["good", "bad"])
 def test_message_feedback_byteplus_is_noop(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, rating: str
 ) -> None:
     app = _create_frontend_app(
         monkeypatch,
@@ -363,7 +377,7 @@ def test_message_feedback_byteplus_is_noop(
                 "userId": "user-1",
                 "sessionId": "session-1",
                 "eventId": "assistant-event",
-                "rating": "good",
+                "rating": rating,
             },
         )
 

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -9107,10 +9107,17 @@ def _run_frontend_server(
             region,
             runtime,
         )
-        headers = _runtime_request_headers(
-            request,
-            apikey=apikey,
-            auth_type=auth_type,
+        # Starlette exposes incoming header names in lowercase. Wrap the
+        # forwarded mapping before overriding JSON headers so httpx replaces
+        # them case-insensitively instead of emitting duplicate values such as
+        # ``application/json, application/json``. FastAPI treats that combined
+        # media type as non-JSON and passes the body to Pydantic as a string.
+        headers = httpx.Headers(
+            _runtime_request_headers(
+                request,
+                apikey=apikey,
+                auth_type=auth_type,
+            )
         )
         headers["Accept"] = "application/json"
         if payload is not None:


### PR DESCRIPTION
## Summary

- normalize forwarded Runtime JSON headers with `httpx.Headers` before overriding `Accept` and `Content-Type`
- prevent case-variant duplicate headers from becoming `application/json, application/json` and causing Session PATCH bodies to be parsed as strings
- cover both good and bad feedback for Volcengine and preserve BytePlus no-op behavior

## Validation

- `pre-commit run --files veadk/cli/cli_frontend.py tests/cli/test_frontend_evaluation_feedback.py`
- `pytest -q tests/cli/test_frontend_evaluation_feedback.py tests/integrations/agentkit/evaluation/test_client.py tests/frontend/server/evaluation_automation/test_datasets.py` (25 passed)
- `node --test frontend/tests/messageFeedback.test.mjs` (5 passed)
- local Studio against a Volcengine Runtime: good, bad, and uncheck returned HTTP 200 with runtime state persistence
- local Studio with BytePlus provider: good and bad remained explicit no-op responses without feedback persistence