### PR TITLE
feat(studio): support Dockerfile environment creation

### DIFF
--- a/frontend/server/environments/dockerfile.py
+++ b/frontend/server/environments/dockerfile.py
@@ -91,9 +91,12 @@ def build_dockerfile(config: EnvironmentInput) -> str:
         "ARG PIP_DEFAULT_TIMEOUT=300",
         "ARG PIP_RETRIES=10",
         "",
-        "# Ubuntu repositories: keep the official hosts, use HTTPS, and tolerate transient builder egress failures.",
+        "# Ubuntu repositories: bootstrap CA certificates before switching the official hosts to HTTPS.",
         'RUN printf \'Acquire::Retries "5";\\nAcquire::ForceIPv4 "true";\\nAcquire::http::Timeout "60";\\nAcquire::https::Timeout "60";\\n\' > /etc/apt/apt.conf.d/80-veadk-network \\',
-        "    && sed -i 's|http://archive.ubuntu.com|https://archive.ubuntu.com|g; s|http://security.ubuntu.com|https://security.ubuntu.com|g' /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true",
+        "    && apt-get update \\",
+        "    && apt-get install -y --no-install-recommends ca-certificates \\",
+        "    && { sed -i 's|http://archive.ubuntu.com|https://archive.ubuntu.com|g; s|http://security.ubuntu.com|https://security.ubuntu.com|g' /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true; } \\",
+        "    && rm -rf /var/lib/apt/lists/*",
         "",
         "ENV PYTHONDONTWRITEBYTECODE=1 \\",
         "    PYTHONUNBUFFERED=1 \\",
@@ -105,7 +108,7 @@ def build_dockerfile(config: EnvironmentInput) -> str:
     if uses_ubuntu_python:
         lines.extend(
             (
-                f"    && apt-get install -y --no-install-recommends ca-certificates python{python_version} python{python_version}-venv \\",
+                f"    && apt-get install -y --no-install-recommends python{python_version} python{python_version}-venv \\",
                 f"    && python{python_version} -m venv /opt/venv \\",
                 "    && rm -rf /var/lib/apt/lists/*",
             )
@@ -113,7 +116,7 @@ def build_dockerfile(config: EnvironmentInput) -> str:
     else:
         lines.extend(
             (
-                "    && apt-get install -y --no-install-recommends build-essential ca-certificates curl libbz2-dev libffi-dev libgdbm-dev liblzma-dev libncursesw5-dev libreadline-dev libsqlite3-dev libssl-dev tk-dev uuid-dev zlib1g-dev \\",
+                "    && apt-get install -y --no-install-recommends build-essential curl libbz2-dev libffi-dev libgdbm-dev liblzma-dev libncursesw5-dev libreadline-dev libsqlite3-dev libssl-dev tk-dev uuid-dev zlib1g-dev \\",
                 f'    && curl --retry 5 --retry-all-errors --connect-timeout 30 -fsSL "${{PYTHON_SOURCE_BASE_URL}}/{python_patch_version}/Python-{python_patch_version}.tgz" -o /tmp/python.tgz \\',
                 "    && mkdir -p /tmp/python-source \\",
                 "    && tar -xzf /tmp/python.tgz --strip-components=1 -C /tmp/python-source \\",

--- a/frontend/src/ui/EnvironmentCenter.css
+++ b/frontend/src/ui/EnvironmentCenter.css
@@ -145,6 +145,93 @@
 .environment-description-input { width: 100%; }
 .environment-description-input { min-height: 76px; }
 
+.environment-creation-method {
+  min-width: 0;
+  margin: 24px 0 0;
+  padding: 0;
+  border: 0;
+}
+
+.environment-creation-method > legend {
+  margin: 0 0 8px 4px;
+  padding: 0;
+  color: hsl(var(--foreground));
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.environment-creation-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.environment-creation-options > * {
+  min-width: 0;
+  min-height: 76px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid hsl(var(--border));
+  border-radius: 10px;
+  background: hsl(var(--panel));
+  transition: border-color 160ms ease, background-color 160ms ease;
+}
+
+.environment-creation-options > *:hover {
+  background: hsl(var(--muted) / 0.45);
+}
+
+.environment-creation-options > *.is-selected {
+  border-color: hsl(var(--foreground) / 0.3);
+  background: hsl(var(--muted) / 0.55);
+}
+
+.environment-creation-option__icon {
+  width: 36px;
+  height: 36px;
+  display: inline-grid;
+  flex: 0 0 36px;
+  place-items: center;
+  border: 1px solid hsl(var(--border));
+  border-radius: 8px;
+  background: hsl(var(--background));
+  color: hsl(var(--muted-foreground));
+}
+
+.environment-creation-options > *.is-selected .environment-creation-option__icon {
+  color: hsl(var(--foreground));
+}
+
+.environment-creation-option__icon svg {
+  width: 19px;
+  height: 19px;
+}
+
+.environment-creation-option__copy {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+  text-align: left;
+}
+
+.environment-creation-option__copy strong {
+  color: hsl(var(--foreground));
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.environment-creation-option__copy > span {
+  color: hsl(var(--muted-foreground));
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.45;
+}
+
 .environment-tabs {
   width: fit-content;
   margin-top: 24px;
@@ -237,6 +324,159 @@
   height: 100%;
   min-height: inherit;
 }
+
+.environment-upload {
+  min-width: 0;
+  margin-top: 24px;
+}
+
+.environment-upload__header {
+  min-width: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 10px;
+}
+
+.environment-upload__header > div { min-width: 0; }
+.environment-upload__header h2 {
+  margin: 0 0 3px;
+  color: hsl(var(--foreground));
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.environment-upload__header p {
+  margin: 0;
+  color: hsl(var(--muted-foreground));
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.environment-upload-dropzone {
+  position: relative;
+  min-height: 112px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 20px;
+  border: 1px dashed hsl(var(--border));
+  border-radius: 10px;
+  background: hsl(var(--panel));
+  color: hsl(var(--foreground));
+  transition: border-color 160ms ease, background-color 160ms ease;
+}
+
+.environment-upload-dropzone:hover,
+.environment-upload-dropzone.is-dragging {
+  border-color: hsl(var(--foreground) / 0.4);
+  background: hsl(var(--muted) / 0.5);
+}
+
+.environment-upload-dropzone.is-ready {
+  border-style: solid;
+}
+
+.environment-upload-dropzone:focus-within {
+  outline: 2px solid hsl(var(--ring) / 0.55);
+  outline-offset: 2px;
+}
+
+.environment-upload-dropzone > input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.environment-upload-dropzone > input:disabled { cursor: wait; }
+
+.environment-upload-dropzone__icon {
+  width: 36px;
+  height: 36px;
+  display: inline-grid;
+  flex: 0 0 36px;
+  place-items: center;
+  border: 1px solid hsl(var(--border));
+  border-radius: 8px;
+  background: hsl(var(--background));
+  color: hsl(var(--muted-foreground));
+}
+
+.environment-upload-dropzone__icon svg {
+  width: 19px;
+  height: 19px;
+}
+
+.environment-upload-dropzone__copy {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.environment-upload-dropzone__copy strong,
+.environment-upload-dropzone__copy span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.environment-upload-dropzone__copy strong {
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.environment-upload-dropzone__copy span {
+  color: hsl(var(--muted-foreground));
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.environment-upload__error {
+  margin: 8px 0 0;
+  color: hsl(var(--destructive));
+  font-size: 12px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.environment-upload__preview {
+  min-width: 0;
+  margin-top: 20px;
+}
+
+.environment-upload__preview > div:first-child {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.environment-upload__preview h3 {
+  margin: 0;
+  color: hsl(var(--foreground));
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.environment-upload__preview span {
+  color: hsl(var(--muted-foreground));
+  font-size: 11px;
+  line-height: 1.4;
+  font-variant-numeric: tabular-nums;
+}
+
+.environment-upload__editor { min-height: 440px; }
 
 .environment-build-dialog__backdrop {
   position: fixed;
@@ -387,8 +627,11 @@
   .environment-editor { padding: 20px 16px 0; }
   .environment-editor__header { align-items: stretch; flex-direction: column; gap: 16px; }
   .environment-editor__actions { justify-content: flex-end; }
+  .environment-creation-options,
   .environment-language-options,
   .environment-option-grid { grid-template-columns: minmax(0, 1fr); }
+  .environment-upload__header { flex-direction: column; }
+  .environment-upload-dropzone { justify-content: flex-start; min-height: 96px; padding: 16px; }
   .environment-dockerfile__header { align-items: flex-start; flex-direction: column; }
   .environment-dockerfile__editor { min-height: 440px; }
   .environment-build-dialog__backdrop { align-items: end; padding: 0; }
@@ -415,5 +658,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .environment-back { transition: none; }
+  .environment-back,
+  .environment-creation-options > *,
+  .environment-upload-dropzone { transition: none; }
 }

--- a/frontend/src/ui/EnvironmentCenter.tsx
+++ b/frontend/src/ui/EnvironmentCenter.tsx
@@ -5,11 +5,13 @@ import {
   useMemo,
   useRef,
   useState,
+  type ChangeEvent,
+  type DragEvent,
   type FormEvent,
   type SVGProps,
 } from "react";
 import { createPortal } from "react-dom";
-import { ExternalLink, X } from "lucide-react";
+import { ExternalLink, FileUp, SlidersHorizontal, X } from "lucide-react";
 import { Badge } from "@openai/apps-sdk-ui/components/Badge";
 import { Button } from "@openai/apps-sdk-ui/components/Button";
 import { EmptyMessage } from "@openai/apps-sdk-ui/components/EmptyMessage";
@@ -72,6 +74,11 @@ import {
 } from "./environmentModel";
 import { TextShimmer } from "./text-shimmer/TextShimmer";
 import { SkillSourcePicker } from "./SkillSourcePicker";
+import {
+  dockerfileByteSize,
+  readDockerfileUpload,
+  validateDockerfileUpload,
+} from "./environmentDockerfileUpload";
 import type { CloudProvider } from "../adk/cloudProvider";
 import "./EnvironmentCenter.css";
 
@@ -80,6 +87,7 @@ type EnvironmentView =
   | { kind: "editor"; environmentId: string | null };
 
 type EnvironmentEditorTab = "configuration" | "dockerfile";
+type EnvironmentCreationMethod = "custom" | "dockerfile";
 
 const TOOL_LOGOS: Readonly<Record<string, string>> = {
   opencli: opencliLogo,
@@ -384,17 +392,45 @@ function EnvironmentEditor({
   onCancel: () => void;
   onSave: (draft: EnvironmentDraft) => Promise<void>;
 }) {
-  const [draft, setDraft] = useState<EnvironmentDraft>(() => environmentDraft(environment));
+  const initialEnvironmentDraft = environmentDraft(environment);
+  const hasCustomDockerfile = initialEnvironmentDraft.dockerfile !== undefined;
+  const [draft, setDraft] = useState<EnvironmentDraft>(() => ({
+    ...initialEnvironmentDraft,
+    dockerfile: hasCustomDockerfile ? undefined : initialEnvironmentDraft.dockerfile,
+  }));
+  const [creationMethod, setCreationMethod] = useState<EnvironmentCreationMethod>(
+    hasCustomDockerfile ? "dockerfile" : "custom",
+  );
   const [activeTab, setActiveTab] = useState<EnvironmentEditorTab>("configuration");
+  const [uploadedDockerfile, setUploadedDockerfile] = useState(
+    hasCustomDockerfile ? environment?.dockerfile ?? "" : "",
+  );
+  const [uploadedFileName, setUploadedFileName] = useState(
+    hasCustomDockerfile ? "已保存的 Dockerfile" : "",
+  );
+  const [uploadError, setUploadError] = useState("");
+  const [readingFile, setReadingFile] = useState(false);
+  const [draggingFile, setDraggingFile] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const fileReadSequence = useRef(0);
   const generatedDockerfile = useMemo(
     () => buildEnvironmentDockerfile(draft),
     [draft.operatingSystem, draft.language, draft.optionIds],
   );
-  const dockerfile = draft.dockerfile ?? generatedDockerfile;
+  const customDockerfile = draft.dockerfile ?? generatedDockerfile;
   const isEditing = Boolean(environment);
   const formId = "environment-editor-form";
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState("");
+  const uploadIsValid = Boolean(uploadedDockerfile.trim()) && !uploadError;
+  const canSubmit = Boolean(draft.name.trim())
+    && !saving
+    && !readingFile
+    && (creationMethod === "custom" || uploadIsValid);
+
+  useEffect(() => () => {
+    fileReadSequence.current += 1;
+  }, []);
 
   const toggleOption = (optionId: string, selected: boolean) => {
     setDraft((current) => ({
@@ -405,9 +441,62 @@ function EnvironmentEditor({
     }));
   };
 
+  const loadDockerfile = async (file: File) => {
+    const sequence = fileReadSequence.current + 1;
+    fileReadSequence.current = sequence;
+    setReadingFile(true);
+    setUploadError("");
+    try {
+      const result = await readDockerfileUpload(file);
+      if (fileReadSequence.current !== sequence) return;
+      setUploadedDockerfile(result.content);
+      setUploadedFileName(file.name || "Dockerfile");
+      setUploadError(result.error);
+    } catch (cause) {
+      if (fileReadSequence.current !== sequence) return;
+      setUploadedDockerfile("");
+      setUploadedFileName(file.name || "Dockerfile");
+      setUploadError(`无法读取 Dockerfile：${cause instanceof Error ? cause.message : String(cause)}`);
+    } finally {
+      if (fileReadSequence.current === sequence) setReadingFile(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
+
+  const handleDockerfileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) void loadDockerfile(file);
+  };
+
+  const handleDockerfileDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setDraggingFile(false);
+    if (saving || readingFile) return;
+    if (event.dataTransfer.files.length !== 1) {
+      setUploadError("请一次只上传一个 Dockerfile。");
+      return;
+    }
+    const file = event.dataTransfer.files[0];
+    if (file) void loadDockerfile(file);
+  };
+
+  const updateUploadedDockerfile = (value: string) => {
+    setUploadedDockerfile(value);
+    setUploadError(validateDockerfileUpload(value));
+  };
+
+  const clearUploadedDockerfile = () => {
+    fileReadSequence.current += 1;
+    setReadingFile(false);
+    setUploadedDockerfile("");
+    setUploadedFileName("");
+    setUploadError("");
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!draft.name.trim() || saving) return;
+    if (!canSubmit) return;
     setSaving(true);
     setSaveError("");
     try {
@@ -415,7 +504,9 @@ function EnvironmentEditor({
         ...draft,
         name: draft.name.trim(),
         description: draft.description.trim(),
-        dockerfile,
+        optionIds: creationMethod === "dockerfile" ? [] : draft.optionIds,
+        selectedSkills: creationMethod === "dockerfile" ? [] : draft.selectedSkills,
+        dockerfile: creationMethod === "dockerfile" ? uploadedDockerfile : customDockerfile,
       });
     } catch (cause) {
       setSaveError(cause instanceof Error ? cause.message : String(cause));
@@ -432,12 +523,12 @@ function EnvironmentEditor({
           </button>
           <div>
             <h1 id="environment-editor-title">{isEditing ? "配置环境" : "新建环境"}</h1>
-            <p>选择操作系统、语言、工具和技能，生成可编辑的 Dockerfile</p>
+            <p>上传 Dockerfile，或通过可视化配置生成运行环境</p>
           </div>
         </div>
         <div className="environment-editor__actions">
           <Button color="secondary" variant="soft" size="sm" onClick={onCancel} disabled={saving}>取消</Button>
-          <Button color="info" size="sm" type="submit" form={formId} disabled={!draft.name.trim() || saving}>
+          <Button color="info" size="sm" type="submit" form={formId} disabled={!canSubmit}>
             {saving ? "正在保存" : isEditing ? "保存并构建" : "创建并构建"}
           </Button>
         </div>
@@ -471,20 +562,57 @@ function EnvironmentEditor({
           </label>
         </div>
 
-        <SegmentedControl
-          className="environment-tabs"
-          value={activeTab}
-          aria-label="环境编辑方式"
-          onChange={(value) => setActiveTab(value as EnvironmentEditorTab)}
-        >
-          <SegmentedControl.Option value="configuration">配置</SegmentedControl.Option>
-          <SegmentedControl.Option value="dockerfile">描述文件</SegmentedControl.Option>
-        </SegmentedControl>
+        <fieldset className="environment-creation-method">
+          <legend>创建方式</legend>
+          <RadioGroup<EnvironmentCreationMethod>
+            className="environment-creation-options"
+            value={creationMethod}
+            aria-label="环境创建方式"
+            onChange={(value) => {
+              setCreationMethod(value);
+              setSaveError("");
+            }}
+          >
+            <RadioGroup.Item
+              value="custom"
+              block
+              className={creationMethod === "custom" ? "is-selected" : ""}
+            >
+              <span className="environment-creation-option__icon"><SlidersHorizontal aria-hidden /></span>
+              <span className="environment-creation-option__copy">
+                <strong>自定义配置</strong>
+                <span>选择系统、Python、工具和技能</span>
+              </span>
+            </RadioGroup.Item>
+            <RadioGroup.Item
+              value="dockerfile"
+              block
+              className={creationMethod === "dockerfile" ? "is-selected" : ""}
+            >
+              <span className="environment-creation-option__icon"><FileUp aria-hidden /></span>
+              <span className="environment-creation-option__copy">
+                <strong>上传 Dockerfile</strong>
+                <span>直接使用已有构建描述文件</span>
+              </span>
+            </RadioGroup.Item>
+          </RadioGroup>
+        </fieldset>
 
         {saveError ? <p className="environment-form-error" role="alert">{saveError}</p> : null}
 
-        {activeTab === "configuration" ? (
-          <div className="environment-configuration">
+        {creationMethod === "custom" ? (
+          <>
+            <SegmentedControl
+              className="environment-tabs"
+              value={activeTab}
+              aria-label="自定义环境编辑内容"
+              onChange={(value) => setActiveTab(value as EnvironmentEditorTab)}
+            >
+              <SegmentedControl.Option value="configuration">配置</SegmentedControl.Option>
+              <SegmentedControl.Option value="dockerfile">描述文件</SegmentedControl.Option>
+            </SegmentedControl>
+            {activeTab === "configuration" ? (
+              <div className="environment-configuration">
             <section className="environment-section" aria-labelledby="environment-operating-system-title">
               <h2 id="environment-operating-system-title">操作系统</h2>
               <RadioGroup<EnvironmentOperatingSystem>
@@ -572,33 +700,96 @@ function EnvironmentEditor({
                 </div>
               </section>
             ))}
-          </div>
-        ) : (
-          <section className="environment-dockerfile" aria-labelledby="environment-dockerfile-title">
-            <div className="environment-dockerfile__header">
-              <div>
-                <h2 id="environment-dockerfile-title">Dockerfile</h2>
-                <p>可直接编辑；配置页中的软件变更不会覆盖自定义内容。</p>
               </div>
-              {draft.dockerfile !== undefined ? (
-                <Button
-                  type="button"
-                  color="secondary"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setDraft((current) => ({ ...current, dockerfile: undefined }))}
-                >
-                  恢复生成内容
+            ) : (
+              <section className="environment-dockerfile" aria-labelledby="environment-dockerfile-title">
+                <div className="environment-dockerfile__header">
+                  <div>
+                    <h2 id="environment-dockerfile-title">Dockerfile</h2>
+                    <p>可直接编辑；配置页中的软件变更不会覆盖自定义内容。</p>
+                  </div>
+                  {draft.dockerfile !== undefined ? (
+                    <Button
+                      type="button"
+                      color="secondary"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setDraft((current) => ({ ...current, dockerfile: undefined }))}
+                    >
+                      恢复生成内容
+                    </Button>
+                  ) : null}
+                </div>
+                <Textarea
+                  className="environment-dockerfile__editor"
+                  value={customDockerfile}
+                  aria-label="Dockerfile 内容"
+                  spellCheck={false}
+                  onChange={(event) => setDraft((current) => ({ ...current, dockerfile: event.target.value }))}
+                />
+              </section>
+            )}
+          </>
+        ) : (
+          <section className="environment-upload" aria-labelledby="environment-upload-title">
+            <div className="environment-upload__header">
+              <div>
+                <h2 id="environment-upload-title">上传 Dockerfile</h2>
+                <p id="environment-upload-help">支持任意文件名，文件上限 128 KiB。上传后可继续编辑内容。</p>
+              </div>
+              {uploadedDockerfile ? (
+                <Button type="button" color="secondary" variant="ghost" size="sm" onClick={clearUploadedDockerfile} disabled={saving}>
+                  移除文件
                 </Button>
               ) : null}
             </div>
-            <Textarea
-              className="environment-dockerfile__editor"
-              value={dockerfile}
-              aria-label="Dockerfile 内容"
-              spellCheck={false}
-              onChange={(event) => setDraft((current) => ({ ...current, dockerfile: event.target.value }))}
-            />
+            <div
+              className={`environment-upload-dropzone${draggingFile ? " is-dragging" : ""}${uploadedDockerfile ? " is-ready" : ""}`}
+              onDragEnter={(event) => {
+                event.preventDefault();
+                if (!saving && !readingFile) setDraggingFile(true);
+              }}
+              onDragOver={(event) => event.preventDefault()}
+              onDragLeave={(event) => {
+                if (!event.currentTarget.contains(event.relatedTarget as Node | null)) setDraggingFile(false);
+              }}
+              onDrop={handleDockerfileDrop}
+            >
+              <input
+                ref={fileInputRef}
+                type="file"
+                aria-label="Dockerfile 文件"
+                aria-describedby="environment-upload-help"
+                disabled={saving || readingFile}
+                onChange={handleDockerfileChange}
+              />
+              <span className="environment-upload-dropzone__icon"><FileUp aria-hidden /></span>
+              <span className="environment-upload-dropzone__copy">
+                <strong>{readingFile ? "正在读取 Dockerfile" : uploadedFileName || "选择 Dockerfile 或拖拽到这里"}</strong>
+                <span>
+                  {uploadedDockerfile
+                    ? `${dockerfileByteSize(uploadedDockerfile).toLocaleString("zh-CN")} 字节，点击可替换`
+                    : "Dockerfile 通常无扩展名"}
+                </span>
+              </span>
+            </div>
+            {uploadError ? <p className="environment-upload__error" role="alert">{uploadError}</p> : null}
+            {uploadedDockerfile ? (
+              <div className="environment-upload__preview">
+                <div>
+                  <h3>内容预览</h3>
+                  <span>{dockerfileByteSize(uploadedDockerfile).toLocaleString("zh-CN")} / 131,072 字节</span>
+                </div>
+                <Textarea
+                  className="environment-dockerfile__editor environment-upload__editor"
+                  value={uploadedDockerfile}
+                  aria-label="上传的 Dockerfile 内容"
+                  aria-invalid={Boolean(uploadError)}
+                  spellCheck={false}
+                  onChange={(event) => updateUploadedDockerfile(event.target.value)}
+                />
+              </div>
+            ) : null}
           </section>
         )}
       </form>

--- a/frontend/src/ui/environmentDockerfileUpload.ts
+++ b/frontend/src/ui/environmentDockerfileUpload.ts
@@ -1,0 +1,44 @@
+export const MAX_DOCKERFILE_BYTES = 128 * 1024;
+
+export interface DockerfileUploadResult {
+  content: string;
+  error: string;
+}
+
+export function normalizeDockerfileContent(content: string): string {
+  return content.replace(/^\uFEFF/, "").replace(/\r\n?/g, "\n");
+}
+
+export function dockerfileByteSize(content: string): number {
+  return new TextEncoder().encode(content).byteLength;
+}
+
+export function validateDockerfileUpload(
+  content: string,
+  byteSize = dockerfileByteSize(content),
+): string {
+  if (byteSize > MAX_DOCKERFILE_BYTES) {
+    return "Dockerfile 不能超过 128 KiB。";
+  }
+  if (!content.trim()) {
+    return "Dockerfile 内容不能为空。";
+  }
+  if (!/^\s*FROM\s+\S+/im.test(content)) {
+    return "Dockerfile 缺少 FROM 指令。";
+  }
+  return "";
+}
+
+export async function readDockerfileUpload(file: File): Promise<DockerfileUploadResult> {
+  if (file.size > MAX_DOCKERFILE_BYTES) {
+    return {
+      content: "",
+      error: "Dockerfile 不能超过 128 KiB。",
+    };
+  }
+  const content = normalizeDockerfileContent(await file.text());
+  return {
+    content,
+    error: validateDockerfileUpload(content, file.size),
+  };
+}

--- a/frontend/src/ui/environmentModel.ts
+++ b/frontend/src/ui/environmentModel.ts
@@ -153,9 +153,12 @@ export function buildEnvironmentDockerfile(environment: EnvironmentDraft): strin
     "ARG PIP_DEFAULT_TIMEOUT=300",
     "ARG PIP_RETRIES=10",
     "",
-    "# Ubuntu repositories: keep the official hosts, use HTTPS, and tolerate transient builder egress failures.",
+    "# Ubuntu repositories: bootstrap CA certificates before switching the official hosts to HTTPS.",
     "RUN printf 'Acquire::Retries \"5\";\\nAcquire::ForceIPv4 \"true\";\\nAcquire::http::Timeout \"60\";\\nAcquire::https::Timeout \"60\";\\n' > /etc/apt/apt.conf.d/80-veadk-network \\",
-    "    && sed -i 's|http://archive.ubuntu.com|https://archive.ubuntu.com|g; s|http://security.ubuntu.com|https://security.ubuntu.com|g' /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true",
+    "    && apt-get update \\",
+    "    && apt-get install -y --no-install-recommends ca-certificates \\",
+    "    && { sed -i 's|http://archive.ubuntu.com|https://archive.ubuntu.com|g; s|http://security.ubuntu.com|https://security.ubuntu.com|g' /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true; } \\",
+    "    && rm -rf /var/lib/apt/lists/*",
     "",
     "ENV PYTHONDONTWRITEBYTECODE=1 \\",
     "    PYTHONUNBUFFERED=1 \\",
@@ -166,13 +169,13 @@ export function buildEnvironmentDockerfile(environment: EnvironmentDraft): strin
   ];
   if (usesUbuntuPython) {
     lines.push(
-      `    && apt-get install -y --no-install-recommends ca-certificates python${pythonVersion} python${pythonVersion}-venv \\`,
+      `    && apt-get install -y --no-install-recommends python${pythonVersion} python${pythonVersion}-venv \\`,
       `    && python${pythonVersion} -m venv /opt/venv \\`,
       "    && rm -rf /var/lib/apt/lists/*",
     );
   } else {
     lines.push(
-      "    && apt-get install -y --no-install-recommends build-essential ca-certificates curl libbz2-dev libffi-dev libgdbm-dev liblzma-dev libncursesw5-dev libreadline-dev libsqlite3-dev libssl-dev tk-dev uuid-dev zlib1g-dev \\",
+      "    && apt-get install -y --no-install-recommends build-essential curl libbz2-dev libffi-dev libgdbm-dev liblzma-dev libncursesw5-dev libreadline-dev libsqlite3-dev libssl-dev tk-dev uuid-dev zlib1g-dev \\",
       `    && curl --retry 5 --retry-all-errors --connect-timeout 30 -fsSL "\${PYTHON_SOURCE_BASE_URL}/${pythonPatchVersion}/Python-${pythonPatchVersion}.tgz" -o /tmp/python.tgz \\`,
       "    && mkdir -p /tmp/python-source \\",
       "    && tar -xzf /tmp/python.tgz --strip-components=1 -C /tmp/python-source \\",

--- a/frontend/tests/environmentCenter.test.mjs
+++ b/frontend/tests/environmentCenter.test.mjs
@@ -13,6 +13,10 @@ const environmentStyles = readFileSync(
   new URL("../src/ui/EnvironmentCenter.css", import.meta.url),
   "utf8",
 );
+const dockerfileUploadSource = readFileSync(
+  new URL("../src/ui/environmentDockerfileUpload.ts", import.meta.url),
+  "utf8",
+);
 const clientSource = readFileSync(
   new URL("../src/adk/client.ts", import.meta.url),
   "utf8",
@@ -89,6 +93,46 @@ test("covers environment categories, editor feedback, and responsive layout", ()
   assert.match(environmentStyles, /\.environment-editor__header\s*\{\s*align-items: center;/);
   assert.match(environmentStyles, /\.environment-form[\s\S]*?height: 100%/);
   assert.match(environmentStyles, /\.environment-dockerfile__editor > textarea[\s\S]*?min-height: inherit/);
+});
+
+test("offers Dockerfile upload and custom configuration as explicit creation methods", () => {
+  assert.match(environmentSource, /type EnvironmentCreationMethod = "custom" \| "dockerfile"/);
+  assert.match(environmentSource, /aria-label="环境创建方式"/);
+  assert.match(environmentSource, /value="custom"[\s\S]*?自定义配置/);
+  assert.match(environmentSource, /value="dockerfile"[\s\S]*?上传 Dockerfile/);
+  assert.match(environmentSource, /type="file"/);
+  assert.match(environmentSource, /onDrop=\{handleDockerfileDrop\}/);
+  assert.match(environmentSource, /aria-label="Dockerfile 文件"/);
+  assert.match(environmentSource, /上传后可继续编辑内容/);
+  assert.match(environmentStyles, /\.environment-creation-options/);
+  assert.match(environmentStyles, /\.environment-upload-dropzone\.is-dragging/);
+  assert.match(environmentStyles, /\.environment-upload-dropzone:focus-within/);
+});
+
+test("validates Dockerfile uploads before the environment is created", async () => {
+  const server = await createServer({
+    appType: "custom",
+    logLevel: "silent",
+    optimizeDeps: { noDiscovery: true },
+    server: { middlewareMode: true },
+  });
+  try {
+    const upload = await server.ssrLoadModule("/src/ui/environmentDockerfileUpload.ts");
+    assert.equal(upload.validateDockerfileUpload("", 0), "Dockerfile 内容不能为空。");
+    assert.equal(
+      upload.validateDockerfileUpload("RUN echo hello", 14),
+      "Dockerfile 缺少 FROM 指令。",
+    );
+    assert.equal(
+      upload.validateDockerfileUpload("FROM ubuntu:24.04", upload.MAX_DOCKERFILE_BYTES + 1),
+      "Dockerfile 不能超过 128 KiB。",
+    );
+    assert.equal(upload.validateDockerfileUpload("# syntax=docker/dockerfile:1\nFROM ubuntu:24.04"), "");
+    assert.equal(upload.normalizeDockerfileContent("\uFEFFFROM ubuntu:24.04\r\n"), "FROM ubuntu:24.04\n");
+    assert.match(dockerfileUploadSource, /file\.text\(\)/);
+  } finally {
+    await server.close();
+  }
 });
 
 test("persists environments and starts image builds through the Studio API", () => {

--- a/frontend/tests/environmentCenter.test.mjs
+++ b/frontend/tests/environmentCenter.test.mjs
@@ -194,6 +194,11 @@ test("generates a Dockerfile from language and selected tools", async () => {
     assert.match(dockerfile, /https:\/\/security\.ubuntu\.com/);
     assert.match(dockerfile, /Acquire::Retries \"5\"/);
     assert.match(dockerfile, /Acquire::ForceIPv4 \"true\"/);
+    assert.ok(
+      dockerfile.indexOf("apt-get install -y --no-install-recommends ca-certificates")
+        < dockerfile.indexOf("https://archive.ubuntu.com"),
+      "CA certificates must be installed before Ubuntu mirrors switch to HTTPS",
+    );
     assert.match(dockerfile, /Python-3\.12\.11\.tgz/);
     assert.match(dockerfile, /\.\/configure --prefix=\/opt\/python/);
     assert.doesNotMatch(dockerfile, /astral\.sh|github\.com\/astral-sh/);

--- a/tests/frontend/server/environments/test_environments.py
+++ b/tests/frontend/server/environments/test_environments.py
@@ -320,6 +320,9 @@ def test_all_os_language_combinations_generate_buildable_commented_dockerfiles(
     assert "https://security.ubuntu.com" in dockerfile
     assert 'Acquire::Retries "5"' in dockerfile
     assert 'Acquire::ForceIPv4 "true"' in dockerfile
+    assert dockerfile.index(
+        "apt-get install -y --no-install-recommends ca-certificates"
+    ) < dockerfile.index("https://archive.ubuntu.com")
     assert "# VeADK:" in dockerfile
     assert "# lxml-html-clean:" in dockerfile
     assert (


### PR DESCRIPTION
## Summary

- add explicit custom configuration and Dockerfile upload modes when creating Studio environments
- support file selection, drag-and-drop, replacement, removal, and editable Dockerfile preview
- validate empty files, missing `FROM` instructions, and the 128 KiB upload limit before submission
- reuse the existing environment API and TOS → CP → CR build pipeline for uploaded Dockerfiles
- bootstrap CA certificates before switching generated Ubuntu Dockerfiles to HTTPS package sources

## Validation

- frontend test suite: 827 passed
- backend environment tests: 32 passed
- pre-commit hooks passed
- Playwright visual review at 1440×900 and 390×844, including custom, empty upload, valid upload, and invalid upload states
- Volcengine upload-mode E2E: TOS download, CP build, CR push, and final `available` state passed
- BytePlus upload-mode E2E: TOS download, CP build, CR push, and final `available` state passed
- Volcengine custom-mode E2E: rebuilt the reported environment with the corrected CA bootstrap, pushed the image to CR, and confirmed its workspace reached `1/1 available`

## Note

`npm run build` remains blocked locally by two pre-existing TypeScript errors on `main` in `ResourceCollection.tsx` (timer handle type mismatch at lines 362 and 388). This change does not modify that file.
