### PR TITLE
fix(studio): show scheduler update progress

### DIFF
--- a/frontend/src/adk/client.ts
+++ b/frontend/src/adk/client.ts
@@ -3333,6 +3333,19 @@ export interface StudioReleaseOption {
   changelog: string[];
 }
 
+export type StudioUpdateProgressStage =
+  | "idle"
+  | "permissions"
+  | "resolving"
+  | "downloading"
+  | "preparing"
+  | "provisioning"
+  | "scheduler"
+  | "submitting"
+  | "publishing"
+  | "complete"
+  | "error";
+
 export interface StudioUpdateStatus {
   enabled: boolean;
   currentVersion: string;
@@ -3342,15 +3355,7 @@ export interface StudioUpdateStatus {
   available: boolean;
   state: "disabled" | "idle" | "updating" | "error";
   message: string;
-  progressStage:
-    | "idle"
-    | "resolving"
-    | "downloading"
-    | "preparing"
-    | "submitting"
-    | "publishing"
-    | "complete"
-    | "error";
+  progressStage: StudioUpdateProgressStage;
   progressMessage: string;
   targetVersion: string;
   startedAt: number;

--- a/frontend/src/ui/StudioUpdateControl.tsx
+++ b/frontend/src/ui/StudioUpdateControl.tsx
@@ -4,6 +4,7 @@ import {
   getStudioUpdateStatus,
   getStudioUpdatePermissions,
   startStudioUpdate,
+  type StudioUpdateProgressStage,
   type StudioUpdatePermissionStatus,
   type StudioUpdateStatus,
 } from "../adk/client";
@@ -28,18 +29,28 @@ type UpdatePhase =
   | "error";
 type PendingStudioUpdate = { targetVersion: string; startedAt: number };
 type LogCopyState = "idle" | "copied" | "error";
+type VisibleUpdateStage = Exclude<
+  StudioUpdateProgressStage,
+  "idle" | "complete" | "error"
+>;
 
-const UPDATE_STEPS = [
-  { id: "permissions", label: "预检 OTA 所需权限" },
-  { id: "resolving", label: "读取目标版本信息" },
-  { id: "downloading", label: "下载并校验完整更新包" },
-  { id: "preparing", label: "准备 VeFaaS Function 代码" },
-  { id: "provisioning", label: "检查并补齐 Studio 云资源" },
-  { id: "submitting", label: "提交 Function 更新" },
-  { id: "publishing", label: "发布新 Revision 并重启服务" },
-] as const;
+const UPDATE_STEP_LABELS = {
+  permissions: "预检 OTA 所需权限",
+  resolving: "读取目标版本信息",
+  downloading: "下载并校验完整更新包",
+  preparing: "准备 VeFaaS Function 代码",
+  provisioning: "检查并补齐 Studio 云资源",
+  scheduler: "更新定时任务调度服务",
+  submitting: "提交 Function 更新",
+  publishing: "发布新 Revision 并重启服务",
+} satisfies Record<VisibleUpdateStage, string>;
+
+const UPDATE_STEPS = (
+  Object.entries(UPDATE_STEP_LABELS) as Array<[VisibleUpdateStage, string]>
+).map(([id, label]) => ({ id, label }));
 
 const UPDATE_STAGE_LABELS: Record<string, string> = {
+  ...UPDATE_STEP_LABELS,
   permissions: "预检 OTA 权限",
   resolving: "读取版本信息",
   downloading: "下载更新包",
@@ -451,6 +462,13 @@ export function StudioUpdateControl({
     : (status.errorLog || status.progressMessage || message)
         .split("\n")
         .filter(Boolean);
+  const currentUpdateStepIndex = UPDATE_STEPS.findIndex(
+    (item) => item.id === status.progressStage,
+  );
+  const unknownProgressStage =
+    phase === "submitting" &&
+    status.progressStage !== "idle" &&
+    currentUpdateStepIndex < 0;
 
   const copyUpdateLog = async (lines: string[]) => {
     try {
@@ -666,17 +684,29 @@ export function StudioUpdateControl({
                   </div>
                 </div>
                 <ol className="studio-update-progress" aria-label="Studio 更新进度">
+                  {unknownProgressStage && (
+                    <li className="is-active" aria-current="step">
+                      <span className="studio-update-progress-dot" aria-hidden />
+                      <div>
+                        <span>
+                          {UPDATE_STAGE_LABELS[status.progressStage] || "正在处理更新"}
+                        </span>
+                        <TextShimmer as="small">
+                          {status.progressMessage || message || "正在处理"}
+                        </TextShimmer>
+                      </div>
+                    </li>
+                  )}
                   {UPDATE_STEPS.map((step, index) => {
-                    const currentIndex = UPDATE_STEPS.findIndex(
-                      (item) => item.id === status.progressStage,
-                    );
-                    const completed = phase === "published" || index < currentIndex;
+                    const completed =
+                      phase === "published" || index < currentUpdateStepIndex;
                     const active =
                       phase === "submitting" && step.id === status.progressStage;
                     return (
                       <li
                         key={step.id}
                         className={completed ? "is-complete" : active ? "is-active" : ""}
+                        aria-current={active ? "step" : undefined}
                       >
                         <span className="studio-update-progress-dot" aria-hidden />
                         <div>

--- a/frontend/tests/studioUpdate.test.mjs
+++ b/frontend/tests/studioUpdate.test.mjs
@@ -165,7 +165,14 @@ test("Studio exposes detailed update stages that can be reopened", () => {
   assert.match(controlSource, /下载并校验完整更新包/);
   assert.match(controlSource, /准备 VeFaaS Function 代码/);
   assert.match(controlSource, /检查并补齐 Studio 云资源/);
+  assert.match(
+    controlSource,
+    /检查并补齐 Studio 云资源[\s\S]*?更新定时任务调度服务[\s\S]*?提交 Function 更新/,
+  );
   assert.match(controlSource, /发布新 Revision 并重启服务/);
+  assert.match(clientSource, /\| "scheduler"/);
+  assert.match(controlSource, /unknownProgressStage/);
+  assert.match(controlSource, /aria-current=\{active \? "step" : undefined\}/);
   assert.match(controlSource, /setDialogOpen\(true\)/);
   assert.match(controlSource, /关闭此窗口不会停止更新/);
   assert.match(controlSource, /后台运行/);


### PR DESCRIPTION
## Summary
- add the scheduler stage to the Studio OTA progress timeline
- align the frontend progress-stage type with all backend stages
- keep an active fallback visible for future unknown stages
- add regression coverage for stage order and accessibility state

## Tests
- pre-commit run --files frontend/src/adk/client.ts frontend/src/ui/StudioUpdateControl.tsx frontend/tests/studioUpdate.test.mjs
- npm test (827 tests passed)
- npm exec tsc -- --noEmit
- uv run pytest tests/cli/test_studio_self_update.py -q (35 passed)

## Visual validation
- Playwright: scheduler state at 1600x900 and 390x844
- Playwright: unknown-stage fallback at 1280x800