### PR TITLE
feat: add BytePlus Studio release server

### DIFF
--- a/.github/workflows/publish-studio-release.yaml
+++ b/.github/workflows/publish-studio-release.yaml
@@ -212,18 +212,45 @@ jobs:
           smoke_studio byteplus 18877
           smoke_studio volcengine 18878
 
-  publish:
+  release-context:
     if: >-
       github.event_name == 'workflow_dispatch' &&
       github.repository == 'volcengine/veadk-python' &&
       github.ref == 'refs/heads/main'
     needs: verify
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - id: release
+        name: Allocate shared release version
+        run: echo "version=$(TZ=Asia/Shanghai date +%Y%m%d%H%M%S)" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish Studio Release (${{ matrix.provider }})
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.repository == 'volcengine/veadk-python' &&
+      github.ref == 'refs/heads/main'
+    needs: [verify, release-context]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - provider: volcengine
+            url_secret: STUDIO_RELEASE_SERVER_URL
+            key_secret: STUDIO_RELEASE_SERVER_API_KEY
+          - provider: byteplus
+            url_secret: BYTEPLUS_STUDIO_RELEASE_SERVER_URL
+            key_secret: BYTEPLUS_STUDIO_RELEASE_SERVER_API_KEY
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     environment: studio-release
     env:
-      RELEASE_SERVER_URL: ${{ secrets.STUDIO_RELEASE_SERVER_URL }}
-      RELEASE_SERVER_API_KEY: ${{ secrets.STUDIO_RELEASE_SERVER_API_KEY }}
+      RELEASE_PROVIDER: ${{ matrix.provider }}
+      RELEASE_SERVER_URL: ${{ secrets[matrix.url_secret] }}
+      RELEASE_SERVER_API_KEY: ${{ secrets[matrix.key_secret] }}
+      RELEASE_VERSION: ${{ needs.release-context.outputs.version }}
 
     steps:
       - name: Validate release server configuration
@@ -264,12 +291,14 @@ jobs:
 
           job_id = (
               f"{os.environ['GITHUB_RUN_ID']}-"
-              f"{os.environ['GITHUB_RUN_ATTEMPT']}"
+              f"{os.environ['GITHUB_RUN_ATTEMPT']}-"
+              f"{os.environ['RELEASE_PROVIDER']}"
           )
           payload_data = {
               "repository": os.environ["GITHUB_REPOSITORY"],
               "gitSha": os.environ["GITHUB_SHA"],
               "requestId": job_id,
+              "version": os.environ["RELEASE_VERSION"],
               "changelog": [os.environ["STUDIO_CHANGELOG"]],
           }
           payload = json.dumps(payload_data).encode()

--- a/frontend/service/studio_release_server/builder.py
+++ b/frontend/service/studio_release_server/builder.py
@@ -44,6 +44,7 @@ from frontend.service.studio_release_server.tos_store import (
     DependencyStore,
     SourceStore,
     resolve_credentials,
+    tos_endpoint,
 )
 
 _MAX_SOURCE_ARCHIVE_BYTES = 200 * 1024 * 1024
@@ -209,7 +210,9 @@ class StudioReleaseBuilder:
                 raise RuntimeError("uv is not installed in the release server package.")
             tools_seconds = time.monotonic() - tools_started
 
-            version = datetime.now(ZoneInfo("Asia/Shanghai")).strftime("%Y%m%d%H%M%S")
+            version = request.version or datetime.now(
+                ZoneInfo("Asia/Shanghai")
+            ).strftime("%Y%m%d%H%M%S")
             output_dir = workspace / "dist"
             publish_started = time.monotonic()
             on_progress("building", "正在构建 Studio Bundle 并发布到 TOS")
@@ -603,7 +606,7 @@ class StudioReleaseBuilder:
         frontend_assets: Path | None,
         dependency_wheels: Path | None,
     ) -> None:
-        credentials = resolve_credentials()
+        credentials = resolve_credentials(self._settings.provider)
         command = [
             sys.executable,
             str(Path(__file__).with_name("publisher.py")),
@@ -619,6 +622,8 @@ class StudioReleaseBuilder:
             self._settings.bucket,
             "--region",
             self._settings.region,
+            "--provider",
+            self._settings.provider,
             "--prefix",
             self._settings.release_prefix,
         ]
@@ -638,12 +643,15 @@ class StudioReleaseBuilder:
         if node_bin is not None:
             path_entries.insert(0, str(node_bin))
         path_entries.append(env.get("PATH", ""))
+        credential_prefix = (
+            "BYTEPLUS" if self._settings.provider == "byteplus" else "VOLCENGINE"
+        )
         env.update(
             {
                 "PATH": os.pathsep.join(path_entries),
-                "VOLCENGINE_ACCESS_KEY": credentials.access_key,
-                "VOLCENGINE_SECRET_KEY": credentials.secret_key,
-                "VOLCENGINE_SESSION_TOKEN": credentials.session_token,
+                f"{credential_prefix}_ACCESS_KEY": credentials.access_key,
+                f"{credential_prefix}_SECRET_KEY": credentials.secret_key,
+                f"{credential_prefix}_SESSION_TOKEN": credentials.session_token,
                 "TZ": "Asia/Shanghai",
                 "PIP_INDEX_URL": _PYPI_SIMPLE_INDEX,
                 "UV_CACHE_DIR": str(
@@ -676,12 +684,12 @@ class StudioReleaseBuilder:
     def _verify_latest(self, expected: dict[str, object]) -> None:
         import tos
 
-        credentials = resolve_credentials()
+        credentials = resolve_credentials(self._settings.provider)
         client = tos.TosClientV2(
             credentials.access_key,
             credentials.secret_key,
             security_token=credentials.session_token or None,
-            endpoint=f"tos-{self._settings.region}.volces.com",
+            endpoint=tos_endpoint(self._settings.region, self._settings.provider),
             region=self._settings.region,
         )
         response = client.get_object(

--- a/frontend/service/studio_release_server/deploy.py
+++ b/frontend/service/studio_release_server/deploy.py
@@ -28,12 +28,17 @@ import tempfile
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-import veadk.config
-from veadk.cli.studio_release import STUDIO_RELEASE_REGION
 from veadk.cloud.cloud_agent_engine import CloudAgentEngine
+from veadk.utils.cloud_provider import (
+    CloudProvider,
+    default_region,
+    iam_openapi_host,
+    normalize_cloud_provider,
+)
 
 _APPLICATION_NAME = "veadk-studio-release-server"
 _FUNCTION_NAME = f"{_APPLICATION_NAME}-fn"
@@ -42,8 +47,8 @@ _GATEWAY_SERVICE_NAME = "veadk-studio-release-server"
 _GATEWAY_UPSTREAM_NAME = "veadk-studio-release-server"
 _GATEWAY_ROUTE_NAME = "veadk-studio-release-server"
 _GATEWAY_TIMEOUT_MILLISECONDS = 30 * 60 * 1000
-_BUCKET = "veadk-studio"
-_REGION = STUDIO_RELEASE_REGION
+_VOLCENGINE_BUCKET = "veadk-studio"
+_BYTEPLUS_BUCKET = "veadk-studio-byteplus"
 _RELEASE_PREFIX = "veadk/studio/main"
 _JOB_PREFIX = "veadk/studio/release-server/jobs"
 _REPOSITORY = "volcengine/veadk-python"
@@ -59,6 +64,9 @@ _NODE_ARCHIVE_SHA256 = (
     "325c0f1261e0c61bcae369a1274028e9cfb7ab7949c05512c5b1e630f7e80e12"
 )
 _MAX_NODE_ARCHIVE_BYTES = 128 * 1024 * 1024
+_FUNCTION_CPU_MILLI = 16_000
+_FUNCTION_MEMORY_MB = 32_768
+_RESOURCE_NOTE = "【fyz勿删！】VeADK Studio 发布使用"
 
 _TRUST_POLICY = {
     "Statement": [
@@ -100,13 +108,24 @@ def _role_trn(result: dict[str, Any]) -> str:
     return str(role.get("Trn") or role.get("trn") or "")
 
 
-def _ensure_runtime_role(access_key: str, secret_key: str) -> str:
+def _ensure_runtime_role(
+    access_key: str,
+    secret_key: str,
+    *,
+    provider: CloudProvider,
+    session_token: str = "",
+) -> str:
     """Create or refresh the minimal VeFaaS role used for TOS publishing."""
     from volcengine.iam.IamService import IamService
 
     iam = IamService()
     iam.set_ak(access_key)
     iam.set_sk(secret_key)
+    iam.set_host(iam_openapi_host(provider))
+    if provider == "byteplus":
+        iam.set_scheme("https")
+    if session_token:
+        iam.set_session_token(session_token)
     policy_document = json.dumps(_TOS_POLICY)
     try:
         _result(
@@ -124,7 +143,7 @@ def _ensure_runtime_role(access_key: str, secret_key: str) -> str:
                     {
                         "PolicyName": _POLICY_NAME,
                         "PolicyDocument": policy_document,
-                        "Description": "Publish AgentKit Studio releases to TOS",
+                        "Description": _RESOURCE_NOTE,
                     }
                 )
             )
@@ -141,7 +160,7 @@ def _ensure_runtime_role(access_key: str, secret_key: str) -> str:
                 {
                     "RoleName": _ROLE_NAME,
                     "TrustPolicyDocument": json.dumps(_TRUST_POLICY),
-                    "Description": "AgentKit Studio release server runtime role",
+                    "Description": _RESOURCE_NOTE,
                 }
             )
         )
@@ -253,11 +272,18 @@ def _stage_node_archive(service_destination: Path) -> None:
     (service_destination / _NODE_ARCHIVE_NAME).write_bytes(content)
 
 
-def _runtime_environment(api_key: str) -> dict[str, str]:
+def _runtime_environment(
+    api_key: str,
+    *,
+    bucket: str,
+    provider: CloudProvider,
+    region: str,
+) -> dict[str, str]:
     return {
         "STUDIO_RELEASE_SERVER_API_KEY": api_key,
-        "STUDIO_RELEASE_BUCKET": _BUCKET,
-        "STUDIO_RELEASE_REGION": _REGION,
+        "STUDIO_RELEASE_BUCKET": bucket,
+        "STUDIO_RELEASE_REGION": region,
+        "STUDIO_RELEASE_PROVIDER": provider,
         "STUDIO_RELEASE_PREFIX": _RELEASE_PREFIX,
         "STUDIO_RELEASE_JOB_PREFIX": _JOB_PREFIX,
         "STUDIO_RELEASE_REPOSITORY": _REPOSITORY,
@@ -271,7 +297,7 @@ def _find_named(items: list[Any], name: str) -> Any | None:
     return matches[0] if matches else None
 
 
-def _find_function_id(service: Any) -> str:
+def _find_function(service: Any) -> Any | None:
     from volcenginesdkvefaas import ListFunctionsRequest
 
     page_number = 1
@@ -286,8 +312,117 @@ def _find_function_id(service: Any) -> str:
         if page_number * page_size >= total:
             break
         page_number += 1
-    function = _find_named(functions, _FUNCTION_NAME)
+    return _find_named(functions, _FUNCTION_NAME)
+
+
+def _find_function_id(service: Any) -> str:
+    function = _find_function(service)
     return str(getattr(function, "id", "") or "")
+
+
+def _create_release_function(
+    service: Any,
+    deployment_root: Path,
+    runtime_environment: dict[str, str],
+    role_trn: str,
+) -> str:
+    """Create the build worker with the same resources as the production server."""
+    from volcenginesdkvefaas import CreateFunctionRequest
+    from volcenginesdkvefaas.models.env_for_create_function_input import (
+        EnvForCreateFunctionInput,
+    )
+    from volcenginesdkvefaas.models.tag_for_create_function_input import (
+        TagForCreateFunctionInput,
+    )
+
+    response = service.client.create_function(
+        CreateFunctionRequest(
+            command="./run.sh",
+            cpu_milli=_FUNCTION_CPU_MILLI,
+            description=_RESOURCE_NOTE,
+            envs=[
+                EnvForCreateFunctionInput(key=key, value=value)
+                for key, value in runtime_environment.items()
+            ],
+            initializer_sec=120,
+            max_concurrency=100,
+            memory_mb=_FUNCTION_MEMORY_MB,
+            name=_FUNCTION_NAME,
+            port=8000,
+            project_name="default",
+            request_timeout=1800,
+            role=role_trn,
+            runtime="native-python3.12/v1",
+            tags=[
+                TagForCreateFunctionInput(key="provider", value="veadk"),
+                TagForCreateFunctionInput(key="note", value="勿删"),
+            ],
+        )
+    )
+    function_id = str(response.id)
+    _retry_code_upload(
+        lambda: service._upload_and_mount_code(function_id, str(deployment_root))
+    )
+    return function_id
+
+
+def _retry_code_upload(operation: Callable[[], None]) -> None:
+    """Retry transient presigned-URL failures without masking other errors."""
+    for attempt in range(1, 4):
+        try:
+            operation()
+            return
+        except ValueError as error:
+            if "Function code upload request failed" not in str(error) or attempt == 3:
+                raise
+            time.sleep(2**attempt)
+
+
+def _verify_function_resources(function: Any) -> None:
+    cpu = int(getattr(function, "cpu", 0) or 0)
+    memory = int(getattr(function, "memory_mb", 0) or 0)
+    if (cpu, memory) != (_FUNCTION_CPU_MILLI, _FUNCTION_MEMORY_MB):
+        raise RuntimeError(
+            f"Release Function resources are {cpu}m/{memory}MiB; expected "
+            f"{_FUNCTION_CPU_MILLI}m/{_FUNCTION_MEMORY_MB}MiB."
+        )
+
+
+def _tos_client(
+    access_key: str,
+    secret_key: str,
+    session_token: str,
+    *,
+    provider: CloudProvider,
+    region: str,
+) -> Any:
+    import tos
+
+    domain = "bytepluses.com" if provider == "byteplus" else "volces.com"
+    return tos.TosClientV2(
+        access_key,
+        secret_key,
+        security_token=session_token or None,
+        endpoint=f"tos-{region}.{domain}",
+        region=region,
+    )
+
+
+def _release_bucket(provider: CloudProvider) -> str:
+    return _BYTEPLUS_BUCKET if provider == "byteplus" else _VOLCENGINE_BUCKET
+
+
+def _ensure_release_bucket(client: Any, bucket: str) -> None:
+    """Create the private release bucket and apply a do-not-delete marker."""
+    import tos
+
+    buckets = list(getattr(client.list_buckets(), "buckets", []) or [])
+    if not any(getattr(item, "name", "") == bucket for item in buckets):
+        client.create_bucket(bucket=bucket)
+    client.put_bucket_tagging(
+        bucket=bucket,
+        tag_set=[tos.models2.Tag(key="note", value="勿删")],
+    )
 
 
 def _release_function(service: Any, function_id: str) -> None:
@@ -319,6 +454,95 @@ def _https_endpoint(gateway_service: Any) -> str:
     return ""
 
 
+def _create_serverless_gateway(apig: Any) -> str:
+    from volcenginesdkapig import (
+        CreateGatewayRequest,
+        ListGatewaysRequest,
+        ResourceSpecForCreateGatewayInput,
+    )
+
+    response = apig.apig_client.create_gateway(
+        CreateGatewayRequest(
+            comments=_RESOURCE_NOTE,
+            name=_GATEWAY_NAME,
+            region=apig.region,
+            type="serverless",
+            resource_spec=ResourceSpecForCreateGatewayInput(
+                replicas=2,
+                instance_spec_code="1c2g",
+                clb_spec_code="small_1",
+                public_network_billing_type="traffic",
+                network_type={
+                    "EnablePublicNetwork": True,
+                    "EnablePrivateNetwork": False,
+                },
+            ),
+        ),
+        async_req=True,
+    ).get()
+    gateway_id = str(response.id)
+    for _ in range(120):
+        gateways = apig.apig_client.list_gateways(
+            ListGatewaysRequest(page_number=1, page_size=100),
+            async_req=True,
+        ).get()
+        gateway = _find_named(
+            list(getattr(gateways, "items", []) or []),
+            _GATEWAY_NAME,
+        )
+        if gateway is not None:
+            state = getattr(gateway, "status", None) or getattr(
+                gateway, "message", None
+            )
+            if state == "Running":
+                return gateway_id
+            if state in {"Failed", "Error"}:
+                raise RuntimeError(f"Gateway creation failed: {state}")
+        time.sleep(5)
+    raise RuntimeError("API gateway did not become ready in 10 minutes.")
+
+
+def _create_gateway_service(apig: Any, gateway_id: str) -> str:
+    from volcenginesdkapig import (
+        AuthSpecForCreateGatewayServiceInput,
+        CreateGatewayServiceRequest,
+    )
+
+    response = apig.apig_client.create_gateway_service(
+        CreateGatewayServiceRequest(
+            auth_spec=AuthSpecForCreateGatewayServiceInput(enable=False),
+            comments=_RESOURCE_NOTE,
+            gateway_id=gateway_id,
+            protocol=["HTTP", "HTTPS"],
+            service_name=_GATEWAY_SERVICE_NAME,
+        ),
+        async_req=True,
+    ).get()
+    return str(response.id)
+
+
+def _create_gateway_upstream(apig: Any, function_id: str, gateway_id: str) -> str:
+    from volcenginesdkapig import (
+        CreateUpstreamRequest,
+        UpstreamSpecForCreateUpstreamInput,
+        VeFaasForCreateUpstreamInput,
+    )
+
+    response = apig.apig_client.create_upstream(
+        CreateUpstreamRequest(
+            comments=_RESOURCE_NOTE,
+            gateway_id=gateway_id,
+            name=_GATEWAY_UPSTREAM_NAME,
+            source_type="VeFaas",
+            upstream_spec=UpstreamSpecForCreateUpstreamInput(
+                ve_faas=VeFaasForCreateUpstreamInput(function_id=function_id)
+            ),
+        ),
+        async_req=True,
+    ).get()
+    return str(response.id)
+
+
 def _ensure_gateway_binding(service: Any, function_id: str) -> str:
     """Expose one Function through a service on the fixed serverless gateway."""
     from volcenginesdkapig import (
@@ -343,15 +567,16 @@ def _ensure_gateway_binding(service: Any, function_id: str) -> str:
     gateways = list(getattr(gateway_response, "items", []) or [])
     gateway = _find_named(gateways, _GATEWAY_NAME)
     if gateway is None:
-        raise RuntimeError(f"Serverless gateway {_GATEWAY_NAME} does not exist.")
-    if getattr(gateway, "type", None) != "serverless":
-        raise RuntimeError(f"Gateway {_GATEWAY_NAME} is not serverless.")
-    gateway_state = getattr(gateway, "status", None) or getattr(
-        gateway, "message", None
-    )
-    if gateway_state != "Running":
-        raise RuntimeError(f"Gateway {_GATEWAY_NAME} is not running.")
-    gateway_id = str(gateway.id)
+        gateway_id = _create_serverless_gateway(apig)
+    else:
+        if getattr(gateway, "type", None) != "serverless":
+            raise RuntimeError(f"Gateway {_GATEWAY_NAME} is not serverless.")
+        gateway_state = getattr(gateway, "status", None) or getattr(
+            gateway, "message", None
+        )
+        if gateway_state != "Running":
+            raise RuntimeError(f"Gateway {_GATEWAY_NAME} is not running.")
+        gateway_id = str(gateway.id)
 
     service_response = apig.apig_client.list_gateway_services(
         ListGatewayServicesRequest(
@@ -366,7 +591,7 @@ def _ensure_gateway_binding(service: Any, function_id: str) -> str:
         _GATEWAY_SERVICE_NAME,
     )
     if gateway_service is None:
-        service_id = apig.create_gateway_service(gateway_id, _GATEWAY_SERVICE_NAME)
+        service_id = _create_gateway_service(apig, gateway_id)
     else:
         service_id = str(gateway_service.id)
 
@@ -383,9 +608,7 @@ def _ensure_gateway_binding(service: Any, function_id: str) -> str:
         _GATEWAY_UPSTREAM_NAME,
     )
     if upstream is None:
-        upstream_id = apig.create_vefaas_upstream(
-            function_id, gateway_id, _GATEWAY_UPSTREAM_NAME
-        )
+        upstream_id = _create_gateway_upstream(apig, function_id, gateway_id)
     else:
         upstream_payload = upstream.to_dict()
         if function_id not in json.dumps(upstream_payload):
@@ -475,39 +698,54 @@ def _ensure_gateway_binding(service: Any, function_id: str) -> str:
     raise RuntimeError("API gateway service did not become ready in 5 minutes.")
 
 
-def _deploy(source_root: Path, api_key: str, role_trn: str) -> tuple[str, str, str]:
+def _deploy(
+    source_root: Path,
+    api_key: str,
+    role_trn: str,
+    *,
+    provider: CloudProvider,
+    region: str,
+    access_key: str,
+    secret_key: str,
+    session_token: str,
+) -> tuple[str, str, str]:
     """Create or update the Function and bind it to an existing gateway."""
-    engine = CloudAgentEngine(region=_REGION)
+    engine = CloudAgentEngine(
+        volcengine_access_key=access_key,
+        volcengine_secret_key=secret_key,
+        volcengine_session_token=session_token,
+        region=region,
+        provider=provider,
+    )
     service = engine._vefaas_service
-    runtime_environment = _runtime_environment(api_key)
+    runtime_environment = _runtime_environment(
+        api_key,
+        bucket=_release_bucket(provider),
+        provider=provider,
+        region=region,
+    )
     with tempfile.TemporaryDirectory(prefix="studio_release_server_") as tmp:
         deployment_root = Path(tmp)
         _stage_deployment(source_root, deployment_root)
         app_id = service.find_app_id_by_name(_APPLICATION_NAME)
-        function_id = _find_function_id(service)
+        function = _find_function(service)
+        function_id = str(getattr(function, "id", "") or "")
         if function_id:
-            service._replace_application_code_bundle(
-                function_id=function_id,
-                path=str(deployment_root),
-                environment_overrides=runtime_environment,
+            _verify_function_resources(function)
+            _retry_code_upload(
+                lambda: service._replace_application_code_bundle(
+                    function_id=function_id,
+                    path=str(deployment_root),
+                    environment_overrides=runtime_environment,
+                )
             )
         else:
-            original_environment = dict(veadk.config.veadk_environments)
-            original_role = os.environ.get("IAM_ROLE")
-            try:
-                veadk.config.veadk_environments.clear()
-                veadk.config.veadk_environments.update(runtime_environment)
-                os.environ["IAM_ROLE"] = role_trn
-                _, function_id = service._create_function(
-                    _FUNCTION_NAME, str(deployment_root)
-                )
-            finally:
-                veadk.config.veadk_environments.clear()
-                veadk.config.veadk_environments.update(original_environment)
-                if original_role is None:
-                    os.environ.pop("IAM_ROLE", None)
-                else:
-                    os.environ["IAM_ROLE"] = original_role
+            function_id = _create_release_function(
+                service,
+                deployment_root,
+                runtime_environment,
+                role_trn,
+            )
         _release_function(service, function_id)
         endpoint = _ensure_gateway_binding(service, function_id)
         return endpoint, app_id or "", function_id
@@ -564,6 +802,11 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--source-root", type=Path, default=Path.cwd())
     parser.add_argument(
+        "--provider",
+        choices=("volcengine", "byteplus"),
+        default="volcengine",
+    )
+    parser.add_argument(
         "--skip-github-secrets",
         action="store_true",
         help="Deploy without changing repository secrets.",
@@ -574,25 +817,57 @@ def _parser() -> argparse.ArgumentParser:
 def main() -> None:
     args = _parser().parse_args()
     source_root = args.source_root.resolve()
-    access_key = os.getenv("VOLCENGINE_ACCESS_KEY", "").strip()
-    secret_key = os.getenv("VOLCENGINE_SECRET_KEY", "").strip()
+    provider = normalize_cloud_provider(args.provider)
+    region = default_region(provider)
+    credential_prefix = "BYTEPLUS" if provider == "byteplus" else "VOLCENGINE"
+    access_key = os.getenv(f"{credential_prefix}_ACCESS_KEY", "").strip()
+    secret_key = os.getenv(f"{credential_prefix}_SECRET_KEY", "").strip()
+    session_token = os.getenv(f"{credential_prefix}_SESSION_TOKEN", "").strip()
     if not access_key or not secret_key:
         raise ValueError(
-            "VOLCENGINE_ACCESS_KEY and VOLCENGINE_SECRET_KEY are required."
+            f"{credential_prefix}_ACCESS_KEY and {credential_prefix}_SECRET_KEY "
+            "are required."
         )
     if not args.skip_github_secrets:
         _validate_github_secret_access()
-    role_trn = _ensure_runtime_role(access_key, secret_key)
+    _ensure_release_bucket(
+        _tos_client(
+            access_key,
+            secret_key,
+            session_token,
+            provider=provider,
+            region=region,
+        ),
+        _release_bucket(provider),
+    )
+    role_trn = _ensure_runtime_role(
+        access_key,
+        secret_key,
+        provider=provider,
+        session_token=session_token,
+    )
     api_key = secrets.token_urlsafe(48)
-    endpoint, app_id, function_id = _deploy(source_root, api_key, role_trn)
+    endpoint, app_id, function_id = _deploy(
+        source_root,
+        api_key,
+        role_trn,
+        provider=provider,
+        region=region,
+        access_key=access_key,
+        secret_key=secret_key,
+        session_token=session_token,
+    )
     _wait_for_health(endpoint, api_key)
     if not args.skip_github_secrets:
-        _set_github_secret("STUDIO_RELEASE_SERVER_URL", endpoint)
-        _set_github_secret("STUDIO_RELEASE_SERVER_API_KEY", api_key)
+        secret_prefix = "BYTEPLUS_" if provider == "byteplus" else ""
+        _set_github_secret(f"{secret_prefix}STUDIO_RELEASE_SERVER_URL", endpoint)
+        _set_github_secret(f"{secret_prefix}STUDIO_RELEASE_SERVER_API_KEY", api_key)
     print(
         json.dumps(
             {
                 "applicationName": _APPLICATION_NAME,
+                "provider": provider,
+                "region": region,
                 "applicationId": app_id,
                 "functionId": function_id,
                 "endpoint": endpoint,

--- a/frontend/service/studio_release_server/deploy.py
+++ b/frontend/service/studio_release_server/deploy.py
@@ -454,6 +454,20 @@ def _https_endpoint(gateway_service: Any) -> str:
     return ""
 
 
+def _find_reusable_serverless_gateway(gateways: list[Any]) -> Any | None:
+    """Return an existing running serverless gateway when quota blocks a new one."""
+    return next(
+        (
+            gateway
+            for gateway in gateways
+            if getattr(gateway, "type", None) == "serverless"
+            and (getattr(gateway, "status", None) or getattr(gateway, "message", None))
+            == "Running"
+        ),
+        None,
+    )
+
+
 def _create_serverless_gateway(apig: Any) -> str:
     from volcenginesdkapig import (
         CreateGatewayRequest,
@@ -567,7 +581,11 @@ def _ensure_gateway_binding(service: Any, function_id: str) -> str:
     gateways = list(getattr(gateway_response, "items", []) or [])
     gateway = _find_named(gateways, _GATEWAY_NAME)
     if gateway is None:
-        gateway_id = _create_serverless_gateway(apig)
+        gateway = _find_reusable_serverless_gateway(gateways)
+        if gateway is None:
+            gateway_id = _create_serverless_gateway(apig)
+        else:
+            gateway_id = str(gateway.id)
     else:
         if getattr(gateway, "type", None) != "serverless":
             raise RuntimeError(f"Gateway {_GATEWAY_NAME} is not serverless.")

--- a/frontend/service/studio_release_server/models.py
+++ b/frontend/service/studio_release_server/models.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import os
 import re
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -28,6 +28,7 @@ _JOB_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.-]{1,100}$")
 _REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 ReleaseState = Literal["queued", "running", "succeeded", "failed"]
+ReleaseProvider = Literal["volcengine", "byteplus"]
 
 
 @dataclass(frozen=True)
@@ -40,6 +41,7 @@ class ReleaseServerSettings:
     release_prefix: str
     job_prefix: str
     repository: str
+    provider: ReleaseProvider = "volcengine"
 
     def __post_init__(self) -> None:
         if len(self.api_key) < 32:
@@ -48,6 +50,8 @@ class ReleaseServerSettings:
             raise ValueError("STUDIO_RELEASE_BUCKET is required.")
         if not self.region:
             raise ValueError("STUDIO_RELEASE_REGION is required.")
+        if self.provider not in {"volcengine", "byteplus"}:
+            raise ValueError("STUDIO_RELEASE_PROVIDER is invalid.")
         for value, name in (
             (self.release_prefix, "STUDIO_RELEASE_PREFIX"),
             (self.job_prefix, "STUDIO_RELEASE_JOB_PREFIX"),
@@ -76,6 +80,10 @@ class ReleaseServerSettings:
             repository=os.getenv(
                 "STUDIO_RELEASE_REPOSITORY", "volcengine/veadk-python"
             ).strip(),
+            provider=cast(
+                ReleaseProvider,
+                os.getenv("STUDIO_RELEASE_PROVIDER", "volcengine").strip(),
+            ),
         )
 
 
@@ -89,6 +97,7 @@ class ReleaseRequest(BaseModel):
     request_id: str = Field(alias="requestId")
     changelog: tuple[str, ...] = ()
     source_key: str = Field(default="", alias="sourceKey")
+    version: str = ""
 
     @field_validator("repository")
     @classmethod
@@ -131,6 +140,14 @@ class ReleaseRequest(BaseModel):
             or any(part in {"", ".", ".."} for part in value.split("/"))
         ):
             raise ValueError("sourceKey is invalid")
+        return value
+
+    @field_validator("version")
+    @classmethod
+    def _validate_version(cls, value: str) -> str:
+        value = value.strip()
+        if value and not re.fullmatch(r"\d{14}", value):
+            raise ValueError("version must use YYYYMMDDHHMMSS format")
         return value
 
 

--- a/frontend/service/studio_release_server/publisher.py
+++ b/frontend/service/studio_release_server/publisher.py
@@ -160,6 +160,7 @@ class StudioReleaseStore:
         secret_key: str,
         session_token: str,
         prefix: str,
+        provider: str = "volcengine",
     ) -> None:
         import tos
 
@@ -169,7 +170,11 @@ class StudioReleaseStore:
             access_key,
             secret_key,
             security_token=session_token or None,
-            endpoint=f"tos-{region}.volces.com",
+            endpoint=(
+                f"tos-{region}.bytepluses.com"
+                if provider == "byteplus"
+                else f"tos-{region}.volces.com"
+            ),
             region=region,
         )
 
@@ -531,6 +536,11 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--git-sha", required=True)
     parser.add_argument("--bucket", required=True)
     parser.add_argument("--region", required=True)
+    parser.add_argument(
+        "--provider",
+        choices=("volcengine", "byteplus"),
+        default="volcengine",
+    )
     parser.add_argument("--prefix", required=True)
     parser.add_argument("--changelog", action="append", default=[])
     parser.add_argument("--frontend-assets", type=Path)
@@ -550,13 +560,15 @@ def main() -> None:
         dependency_wheels=args.dependency_wheels,
         env=os.environ,
     )
+    credential_prefix = "BYTEPLUS" if args.provider == "byteplus" else "VOLCENGINE"
     store = StudioReleaseStore(
         bucket=args.bucket,
         region=args.region,
-        access_key=os.getenv("VOLCENGINE_ACCESS_KEY", ""),
-        secret_key=os.getenv("VOLCENGINE_SECRET_KEY", ""),
-        session_token=os.getenv("VOLCENGINE_SESSION_TOKEN", ""),
+        access_key=os.getenv(f"{credential_prefix}_ACCESS_KEY", ""),
+        secret_key=os.getenv(f"{credential_prefix}_SECRET_KEY", ""),
+        session_token=os.getenv(f"{credential_prefix}_SESSION_TOKEN", ""),
         prefix=args.prefix,
+        provider=args.provider,
     )
     store.publish(bundle, manifest)
     print(

--- a/frontend/service/studio_release_server/tos_store.py
+++ b/frontend/service/studio_release_server/tos_store.py
@@ -49,17 +49,20 @@ class VolcengineCredentials:
     session_token: str
 
 
-def resolve_credentials() -> VolcengineCredentials:
+def resolve_credentials(provider: str = "volcengine") -> VolcengineCredentials:
     """Prefer explicit credentials locally, otherwise use VeFaaS IAM."""
-    access_key = os.getenv("VOLCENGINE_ACCESS_KEY", "").strip()
-    secret_key = os.getenv("VOLCENGINE_SECRET_KEY", "").strip()
+    if provider not in {"volcengine", "byteplus"}:
+        raise ValueError(f"Unsupported Studio release provider: {provider}")
+    prefix = "BYTEPLUS" if provider == "byteplus" else "VOLCENGINE"
+    access_key = os.getenv(f"{prefix}_ACCESS_KEY", "").strip()
+    secret_key = os.getenv(f"{prefix}_SECRET_KEY", "").strip()
     if bool(access_key) != bool(secret_key):
-        raise ValueError("VOLCENGINE_ACCESS_KEY and VOLCENGINE_SECRET_KEY must match.")
+        raise ValueError(f"{prefix}_ACCESS_KEY and {prefix}_SECRET_KEY must match.")
     if access_key and secret_key:
         return VolcengineCredentials(
             access_key=access_key,
             secret_key=secret_key,
-            session_token=os.getenv("VOLCENGINE_SESSION_TOKEN", "").strip(),
+            session_token=os.getenv(f"{prefix}_SESSION_TOKEN", "").strip(),
         )
     if not _IAM_CREDENTIAL_PATH.is_file():
         raise FileNotFoundError(
@@ -71,6 +74,12 @@ def resolve_credentials() -> VolcengineCredentials:
         secret_key=str(payload["secret_access_key"]),
         session_token=str(payload["session_token"]),
     )
+
+
+def tos_endpoint(region: str, provider: str) -> str:
+    """Return the provider-specific TOS endpoint for a release bucket."""
+    domain = "bytepluses.com" if provider == "byteplus" else "volces.com"
+    return f"tos-{region}.{domain}"
 
 
 class JobStore(Protocol):
@@ -168,12 +177,12 @@ class TosJobStore:
     def _new_client(self) -> Any:
         import tos
 
-        credentials = resolve_credentials()
+        credentials = resolve_credentials(self._settings.provider)
         return tos.TosClientV2(
             credentials.access_key,
             credentials.secret_key,
             security_token=credentials.session_token or None,
-            endpoint=f"tos-{self._settings.region}.volces.com",
+            endpoint=tos_endpoint(self._settings.region, self._settings.provider),
             region=self._settings.region,
         )
 
@@ -239,12 +248,12 @@ class TosSourceStore:
     def _new_client(self) -> Any:
         import tos
 
-        credentials = resolve_credentials()
+        credentials = resolve_credentials(self._settings.provider)
         return tos.TosClientV2(
             credentials.access_key,
             credentials.secret_key,
             security_token=credentials.session_token or None,
-            endpoint=f"tos-{self._settings.region}.volces.com",
+            endpoint=tos_endpoint(self._settings.region, self._settings.provider),
             region=self._settings.region,
         )
 
@@ -368,12 +377,12 @@ class TosDependencyStore:
     def _new_client(self) -> Any:
         import tos
 
-        credentials = resolve_credentials()
+        credentials = resolve_credentials(self._settings.provider)
         return tos.TosClientV2(
             credentials.access_key,
             credentials.secret_key,
             security_token=credentials.session_token or None,
-            endpoint=f"tos-{self._settings.region}.volces.com",
+            endpoint=tos_endpoint(self._settings.region, self._settings.provider),
             region=self._settings.region,
         )
 
@@ -387,4 +396,5 @@ __all__ = [
     "TosSourceStore",
     "VolcengineCredentials",
     "resolve_credentials",
+    "tos_endpoint",
 ]

--- a/tests/test_studio_release_server.py
+++ b/tests/test_studio_release_server.py
@@ -1247,6 +1247,26 @@ def test_release_server_retries_transient_code_upload(
     assert attempts == 3
 
 
+def test_release_server_reuses_running_serverless_gateway() -> None:
+    gateways = [
+        SimpleNamespace(
+            id="provisioning-serverless",
+            type="serverless",
+            status="Creating",
+        ),
+        SimpleNamespace(id="running-dedicated", type="dedicated", status="Running"),
+        SimpleNamespace(
+            id="running-serverless",
+            type="serverless",
+            status="Running",
+        ),
+    ]
+
+    gateway = release_deploy._find_reusable_serverless_gateway(gateways)
+
+    assert gateway.id == "running-serverless"
+
+
 def test_release_bucket_is_private_and_tagged_do_not_delete(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_studio_release_server.py
+++ b/tests/test_studio_release_server.py
@@ -50,7 +50,10 @@ from frontend.service.studio_release_server import app as release_app
 from frontend.service.studio_release_server import builder as release_builder
 from frontend.service.studio_release_server import deploy as release_deploy
 from frontend.service.studio_release_server import publisher as release_publisher
-from frontend.service.studio_release_server.tos_store import TosDependencyStore
+from frontend.service.studio_release_server.tos_store import (
+    TosDependencyStore,
+    TosJobStore,
+)
 
 
 class _InlineExecutor(Executor):
@@ -172,14 +175,15 @@ class _MemoryDependencyStore:
         return (wheel,)
 
 
-def _settings() -> ReleaseServerSettings:
+def _settings(*, provider: str = "volcengine") -> ReleaseServerSettings:
     return ReleaseServerSettings(
         api_key="release-key-with-at-least-thirty-two-characters",
         bucket="veadk-studio",
-        region="cn-beijing",
+        region="ap-southeast-1" if provider == "byteplus" else "cn-beijing",
         release_prefix="veadk/studio/main",
         job_prefix="veadk/studio/release-server/jobs",
         repository="volcengine/veadk-python",
+        provider=provider,  # type: ignore[arg-type]
     )
 
 
@@ -190,6 +194,38 @@ def _request(request_id: str = "12345-1") -> ReleaseRequest:
         requestId=request_id,
         changelog=("发布 Studio 更新",),
     )
+
+
+def test_release_request_accepts_one_shared_version_for_all_providers() -> None:
+    request = ReleaseRequest(
+        repository="volcengine/veadk-python",
+        gitSha="a" * 40,
+        requestId="shared-version",
+        version="20260828123045",
+    )
+
+    assert request.version == "20260828123045"
+    with pytest.raises(ValueError, match="YYYYMMDDHHMMSS"):
+        ReleaseRequest(
+            repository="volcengine/veadk-python",
+            gitSha="a" * 40,
+            requestId="invalid-version",
+            version="latest",
+        )
+
+
+def test_release_server_settings_load_byteplus_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("STUDIO_RELEASE_SERVER_API_KEY", "x" * 32)
+    monkeypatch.setenv("STUDIO_RELEASE_BUCKET", "veadk-studio")
+    monkeypatch.setenv("STUDIO_RELEASE_REGION", "ap-southeast-1")
+    monkeypatch.setenv("STUDIO_RELEASE_PROVIDER", "byteplus")
+
+    settings = ReleaseServerSettings.from_env()
+
+    assert settings.provider == "byteplus"
+    assert settings.region == "ap-southeast-1"
 
 
 def _service() -> ReleaseService:
@@ -436,7 +472,7 @@ def test_builder_passes_only_publisher_runtime_environment(
     monkeypatch.setattr(
         release_builder,
         "resolve_credentials",
-        lambda: SimpleNamespace(
+        lambda _provider: SimpleNamespace(
             access_key="release-ak",
             secret_key="release-sk",
             session_token="release-sts",
@@ -476,6 +512,95 @@ def test_builder_passes_only_publisher_runtime_environment(
     assert captured["command"][1].endswith("studio_release_server/publisher.py")
     assert "veadk.cli.studio_release" not in captured["command"]
     assert str(tmp_path) not in captured["env"].get("PYTHONPATH", "").split(os.pathsep)
+
+
+def test_byteplus_builder_uses_local_tos_endpoint_and_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        release_builder,
+        "resolve_credentials",
+        lambda provider: SimpleNamespace(
+            access_key=f"{provider}-ak",
+            secret_key=f"{provider}-sk",
+            session_token="",
+        ),
+    )
+
+    def _run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        captured["command"] = command
+        captured["env"] = kwargs["env"]
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(release_builder.subprocess, "run", _run)
+    builder = StudioReleaseBuilder(_settings(provider="byteplus"))
+    builder._run_publisher(
+        request=_request(),
+        source_root=tmp_path,
+        output_dir=tmp_path / "dist",
+        version="20260828123045",
+        node_bin=None,
+        uv=Path("/bin/uv"),
+        frontend_assets=None,
+        dependency_wheels=tmp_path,
+    )
+
+    assert captured["command"][captured["command"].index("--provider") + 1] == (
+        "byteplus"
+    )
+    assert captured["env"]["BYTEPLUS_ACCESS_KEY"] == "byteplus-ak"
+    assert captured["env"]["BYTEPLUS_SECRET_KEY"] == "byteplus-sk"
+
+
+def test_byteplus_runtime_store_uses_byteplus_tos_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        "frontend.service.studio_release_server.tos_store.resolve_credentials",
+        lambda provider: SimpleNamespace(
+            access_key=f"{provider}-ak",
+            secret_key=f"{provider}-sk",
+            session_token="",
+        ),
+    )
+
+    def _client(*args: Any, **kwargs: Any) -> object:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr("tos.TosClientV2", _client)
+
+    TosJobStore(_settings(provider="byteplus"))._new_client()
+
+    assert captured["args"][:2] == ("byteplus-ak", "byteplus-sk")
+    assert captured["kwargs"]["endpoint"] == ("tos-ap-southeast-1.bytepluses.com")
+
+
+def test_standalone_publisher_uses_byteplus_tos_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _client(*args: Any, **kwargs: Any) -> object:
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr("tos.TosClientV2", _client)
+
+    release_publisher.StudioReleaseStore(
+        bucket="veadk-studio",
+        region="ap-southeast-1",
+        provider="byteplus",
+        access_key="ak",
+        secret_key="sk",
+        session_token="",
+        prefix="veadk/studio/main",
+    )
+
+    assert captured["kwargs"]["endpoint"] == ("tos-ap-southeast-1.bytepluses.com")
 
 
 def test_builder_sizes_node_heap_from_cgroup_memory(tmp_path: Path) -> None:
@@ -1059,3 +1184,102 @@ def test_release_server_readiness_uses_rotated_api_key(
 
     assert requests[0].full_url == "https://release.example.com/readyz"
     assert dict(requests[0].header_items())["X-api-key"] == "rotated-key"
+
+
+def test_release_server_runtime_environment_records_provider() -> None:
+    environment = release_deploy._runtime_environment(
+        "x" * 32,
+        bucket="veadk-studio-byteplus",
+        provider="byteplus",
+        region="ap-southeast-1",
+    )
+
+    assert environment["STUDIO_RELEASE_PROVIDER"] == "byteplus"
+    assert environment["STUDIO_RELEASE_REGION"] == "ap-southeast-1"
+    assert environment["STUDIO_RELEASE_BUCKET"] == "veadk-studio-byteplus"
+
+
+def test_release_server_function_matches_production_resources(tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+
+    class _Client:
+        def create_function(self, request: Any) -> Any:
+            captured["request"] = request
+            return SimpleNamespace(id="release-function-id")
+
+    class _Service:
+        client = _Client()
+
+        def _upload_and_mount_code(self, function_id: str, path: str) -> None:
+            captured["upload"] = (function_id, path)
+
+    function_id = release_deploy._create_release_function(
+        _Service(),
+        tmp_path,
+        {"STUDIO_RELEASE_PROVIDER": "byteplus"},
+        "trn:role",
+    )
+
+    request = captured["request"]
+    assert function_id == "release-function-id"
+    assert request.cpu_milli == 16_000
+    assert request.memory_mb == 32_768
+    assert request.request_timeout == 1800
+    assert "勿删" in request.description
+    assert captured["upload"] == ("release-function-id", str(tmp_path))
+
+
+def test_release_server_retries_transient_code_upload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+
+    def _upload() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise ValueError("Function code upload request failed.")
+
+    monkeypatch.setattr(release_deploy.time, "sleep", lambda _seconds: None)
+
+    release_deploy._retry_code_upload(_upload)
+
+    assert attempts == 3
+
+
+def test_release_bucket_is_private_and_tagged_do_not_delete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class _Client:
+        def list_buckets(self) -> Any:
+            return SimpleNamespace(buckets=[])
+
+        def create_bucket(self, **kwargs: Any) -> None:
+            captured["create"] = kwargs
+
+        def put_bucket_tagging(self, **kwargs: Any) -> None:
+            captured["tags"] = kwargs
+
+    release_deploy._ensure_release_bucket(_Client(), "veadk-studio-byteplus")
+
+    assert captured["create"] == {"bucket": "veadk-studio-byteplus"}
+    assert captured["tags"]["tag_set"][0].to_dict() == {
+        "Key": "note",
+        "Value": "勿删",
+    }
+
+
+def test_release_workflow_publishes_one_version_to_both_providers() -> None:
+    workflow = (
+        Path(__file__).parents[1]
+        / ".github"
+        / "workflows"
+        / "publish-studio-release.yaml"
+    ).read_text(encoding="utf-8")
+
+    assert "provider: volcengine" in workflow
+    assert "provider: byteplus" in workflow
+    assert "BYTEPLUS_STUDIO_RELEASE_SERVER_URL" in workflow
+    assert '"version": os.environ["RELEASE_VERSION"]' in workflow


### PR DESCRIPTION
## Summary

- make the Studio release service provider-aware for Volcengine and BytePlus TOS
- provision a BytePlus release bucket, IAM role, 16 vCPU / 32 GiB Function, and serverless API Gateway with do-not-delete metadata
- publish one shared release version to both providers from GitHub Actions

## Validation

- `uv run pre-commit run --files ...`
- `uv run pytest tests/test_studio_release_server.py tests/cli/test_studio_release.py tests/cli/test_studio_self_update.py tests/test_cloud.py -q` (118 passed)
- pyright on the changed release-server modules (0 errors)