### PR TITLE
fix: use BytePlus Studio release bucket

### DIFF
--- a/tests/cli/test_studio_deploy_target.py
+++ b/tests/cli/test_studio_deploy_target.py
@@ -893,9 +893,27 @@ def test_safe_exception_detail_preserves_real_agentkit_api_error_shape() -> None
         "expected_project",
         "expected_update_bucket",
         "update_bucket_env",
+        "provider",
     ),
     [
-        ([], "cn-beijing", "cn-beijing", "default", "veadk-studio", None),
+        (
+            [],
+            "cn-beijing",
+            "cn-beijing",
+            "default",
+            "veadk-studio",
+            None,
+            "volcengine",
+        ),
+        (
+            [],
+            "ap-southeast-1",
+            "ap-southeast-1",
+            "default",
+            "veadk-studio-byteplus",
+            None,
+            "byteplus",
+        ),
         (
             [
                 "--region",
@@ -910,6 +928,7 @@ def test_safe_exception_detail_preserves_real_agentkit_api_error_shape() -> None
             "studio-project",
             "custom-studio-releases",
             "environment-studio-releases",
+            "volcengine",
         ),
         (
             [],
@@ -918,6 +937,7 @@ def test_safe_exception_detail_preserves_real_agentkit_api_error_shape() -> None
             "default",
             "environment-studio-releases",
             "environment-studio-releases",
+            "volcengine",
         ),
     ],
 )
@@ -929,6 +949,7 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
     expected_project: str,
     expected_update_bucket: str,
     update_bucket_env: str | None,
+    provider: str,
 ) -> None:
     captured: dict[str, object] = {}
     credential_tool_ids: list[str] = []
@@ -985,7 +1006,7 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
         [
             "deploy",
             "--provider",
-            "volcengine",
+            provider,
             "--user-pool-id",
             "pool-id",
             "--allowed-client-id",
@@ -1016,6 +1037,12 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
             "sk",
             "--volcengine-session-token",
             "sts-token",
+            "--byteplus-access-key",
+            "ak",
+            "--byteplus-secret-key",
+            "sk",
+            "--byteplus-session-token",
+            "sts-token",
             "--allow-dangerous-login",
             *target_args,
         ],
@@ -1030,12 +1057,12 @@ def test_studio_deploy_passes_region_and_project_to_cloud_engine(
         "secret_key": "sk",
         "session_token": "sts-token",
         "region": expected_identity_region,
-        "provider": "volcengine",
+        "provider": provider,
         "enable_vefaas_iam_fallback": False,
     }
-    assert captured["provider"] == "volcengine"
-    assert veadk_environments["CLOUD_PROVIDER"] == "volcengine"
-    assert veadk_environments["AGENTKIT_CLOUD_PROVIDER"] == "volcengine"
+    assert captured["provider"] == provider
+    assert veadk_environments["CLOUD_PROVIDER"] == provider
+    assert veadk_environments["AGENTKIT_CLOUD_PROVIDER"] == provider
     assert veadk_environments["VEIDENTITY_REGION"] == expected_identity_region
     assert "VEADK_STUDIO_ADMINS" not in veadk_environments
     assert "VEADK_STUDIO_DEVELOPERS" not in veadk_environments

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -11513,10 +11513,12 @@ def _resolve_studio_cloud_credentials(
 )
 @click.option(
     "--studio-update-bucket",
-    default="veadk-studio",
-    show_default=True,
+    default=None,
     envvar="VEADK_STUDIO_UPDATE_BUCKET",
-    help="TOS bucket containing immutable Studio release bundles.",
+    help=(
+        "TOS bucket containing immutable Studio release bundles. Defaults to "
+        "veadk-studio-byteplus on BytePlus and veadk-studio on Volcengine."
+    ),
 )
 @click.option(
     "--studio-update-prefix",
@@ -11562,7 +11564,7 @@ def frontend_deploy(
     sandbox_chat_codex_snapshot_tool_id: str | None,
     sandbox_chat_openclaw_snapshot_tool_id: str | None,
     sandbox_chat_hermes_snapshot_tool_id: str | None,
-    studio_update_bucket: str,
+    studio_update_bucket: str | None,
     studio_update_prefix: str,
 ) -> None:
     """Deploy the SSO web frontend to VeFaaS.
@@ -11606,6 +11608,9 @@ def frontend_deploy(
         provider_id = "byteplus"
     else:
         provider_id = cloud_provider_from_env()
+    studio_update_bucket = studio_update_bucket or (
+        "veadk-studio-byteplus" if provider_id == "byteplus" else "veadk-studio"
+    )
     studio_environment_resource_environment = _studio_environment_resource_environment(
         cp_workspace=environment_cp_workspace,
         cr_repository=environment_cr_repository,


### PR DESCRIPTION
## Summary
- default BytePlus Studio deployments to the BytePlus-local release bucket
- preserve explicit update bucket overrides
- cover the provider-specific default in CLI tests

## Validation
- `uv run pre-commit run --files veadk/cli/cli_frontend.py tests/cli/test_studio_deploy_target.py`
- `uv run pytest tests/cli/test_studio_deploy_target.py -q`