### PR TITLE
fix(studio): align resource toolbar on narrow screens

### DIFF
--- a/frontend/src/ui/ResourceCollection.css
+++ b/frontend/src/ui/ResourceCollection.css
@@ -908,6 +908,12 @@
     gap: 10px;
   }
 
+  .resource-toolbar__actions {
+    width: 100%;
+    justify-content: flex-start;
+    margin-left: 0;
+  }
+
   .resource-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }

--- a/frontend/tests/resourceCollection.test.mjs
+++ b/frontend/tests/resourceCollection.test.mjs
@@ -131,6 +131,13 @@ test("nested resource collections do not clip the shared card hover ring", () =>
   );
 });
 
+test("stacked resource toolbars align their action row to the content edge", () => {
+  assert.match(
+    resourceStyles,
+    /@media \(min-width: 721px\) and \(max-width: 1180px\) \{[\s\S]*?\.resource-toolbar__actions\s*\{[\s\S]*?width: 100%;[\s\S]*?justify-content: flex-start;[\s\S]*?margin-left: 0;/,
+  );
+});
+
 test("shared reveal actions expose domain-specific icons without forking card markup", () => {
   assert.match(resourceSource, /icon\?: "arrow" \| "play" \| "plus"/);
   assert.match(resourceSource, /icon === "play"[\s\S]*?<PlaySm/);


### PR DESCRIPTION
## Summary

- align stacked resource toolbar actions with the content edge on narrow desktop viewports
- let resource-page search controls use the available row width without the previous right offset
- add a regression test for the shared responsive toolbar rule

## Validation

- `uv run pre-commit run --files frontend/src/ui/ResourceCollection.css frontend/tests/resourceCollection.test.mjs`
- `cd frontend && npm test` (873 passed)
- Playwright visual checks at 1440x900, 1024x768, and 390x844
- verified Volcengine and BytePlus resource states