### PR TITLE
feat: add self-hosted sandbox runtime provider and K8s example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,6 +205,8 @@ cython_debug/
 .trae
 .claude
 .agents
+.adk/
+**/.adk/
 # AgentKit deploy config (contains account-specific secrets)
 agentkit.yaml
 agentkit*.yaml

--- a/docs/content/docs/framework/agent/runtime.en.mdx
+++ b/docs/content/docs/framework/agent/runtime.en.mdx
@@ -63,6 +63,31 @@ agent = Agent(
 
 Codex-native lifecycle notifications and ADK Function/MCP tool calls are converted into ADK Events. Runtime logs use stable `codex_*` event names and attribution fields such as `invocation_id`, `call_id`, `tool`, `status`, and `duration_ms`. Tool arguments, tool results, API tokens, credentials, and backend addresses are not logged. Token usage is exposed through `codex_event_type=token_usage` events and the corresponding log entry.
 
+## Choose where each tool runs
+
+`RuntimeProvider` leaves the Agent's model reasoning loop unchanged and only decides where individual tool calls execute. `DispatchRuntimeProvider` can send selected tools to a remote runtime while falling back to their original ADK implementation for all other tools:
+
+```python title="agent.py"
+from veadk import Agent, Runner
+from veadk.runtime import DispatchRuntimeProvider
+
+async def dispatch_task(tool_call):
+    return await remote_client.dispatch(
+        tool_call.name,
+        tool_call.arguments,
+        dispatch_id=tool_call.id,
+    )
+
+agent = Agent(name="assistant", tools=[bash, read_file])
+runtime_provider = DispatchRuntimeProvider(
+    dispatch_task,
+    dispatchable_tools=None,  # dispatch every non-MCP tool
+)
+runner = Runner(agent=agent, plugins=[runtime_provider])
+```
+
+In this example, every non-MCP tool only goes through `dispatch_task` and its local function is not invoked a second time. MCP tools retain their original ADK implementation. Pass a set of names to dispatch only those non-MCP tools. The dispatcher may be synchronous or asynchronous.
+
 ## Request processing
 
 Insert shared, cross-cutting processing into every run — auth, logging, retries, performance monitoring — without touching business logic. Pass a processor to `run_processor`, for example to enforce login via identity auth:

--- a/docs/content/docs/framework/agent/runtime.mdx
+++ b/docs/content/docs/framework/agent/runtime.mdx
@@ -63,6 +63,31 @@ agent = Agent(
 
 Codex 原生生命周期和 ADK Function/MCP 工具调用都会转换为 ADK Event。运行日志使用稳定的 `codex_*` 事件名，并包含 `invocation_id`、`call_id`、`tool`、`status`、`duration_ms` 等可归因字段。日志不会记录工具参数、工具结果、API Token、凭证或后端地址；Token Usage 通过 `codex_event_type=token_usage` 事件及对应日志提供。
 
+## 按工具选择执行位置
+
+`RuntimeProvider` 不替换智能体的模型推理循环，只决定单次工具调用在哪里执行。`DispatchRuntimeProvider` 可以把指定工具派发到远端，其余工具回退到原本的 ADK 本地实现：
+
+```python title="agent.py"
+from veadk import Agent, Runner
+from veadk.runtime import DispatchRuntimeProvider
+
+async def dispatch_task(tool_call):
+    return await remote_client.dispatch(
+        tool_call.name,
+        tool_call.arguments,
+        dispatch_id=tool_call.id,
+    )
+
+agent = Agent(name="assistant", tools=[bash, read_file])
+runtime_provider = DispatchRuntimeProvider(
+    dispatch_task,
+    dispatchable_tools=None,  # 派发所有非 MCP 工具
+)
+runner = Runner(agent=agent, plugins=[runtime_provider])
+```
+
+上例中所有非 MCP 工具只会经过 `dispatch_task`，不会再次执行本地函数；MCP 工具保留原本的 ADK 实现。传入具体工具名集合时，只派发集合中的非 MCP 工具。派发函数可以是同步或异步函数。
+
 ## 请求处理
 
 在不侵入业务逻辑的前提下，可为每次执行插入统一的横切处理——鉴权、日志、重试、性能监控等。把处理器传入 `run_processor` 即可，例如接入身份认证做登录态校验：

--- a/docs/content/docs/framework/memory/short-term/index.en.mdx
+++ b/docs/content/docs/framework/memory/short-term/index.en.mdx
@@ -31,6 +31,7 @@ stm = ShortTermMemory(backend="sqlite", local_database_path="./stm.db")
 | `db_kwargs` | `dict` | `{}` | Extra args forwarded to the underlying database session service/driver (e.g. connection pool settings). |
 | `local_database_path` | `str` | `/tmp/veadk_local_database.db` | Local DB file path, used only by `sqlite`. |
 | `after_load_memory_callback` | `Callable \| None` | `None` | Callback invoked after a session is loaded; receives the loaded `Session`. |
+| `after_create_session_callback` | `Callable \| None` | `None` | Synchronous or asynchronous callback invoked after a new session is created; receives the new `Session` and is not invoked when an existing session is reused. |
 
 <Callout type="warn">
 If a username or password in the connection string contains special characters such as `@` or `:`, URL-encode it with `urllib.parse.quote_plus` first (e.g. `p@ssword` → `p%40ssword`), otherwise parsing fails.
@@ -101,6 +102,19 @@ You rarely create or manage a `Session` directly; instead you use `session_servi
 5. **Clean up** `delete_session()`: delete a `Session` and its associated data.
 
 Under a database backend, `ShortTermMemory.create_session()` first lists and reuses an existing session with the same `session_id` to avoid duplicates.
+
+To provision resources, record an audit event, or synchronize an external system after a session is first created, register `after_create_session_callback`:
+
+```python
+async def after_create_session(session):
+    await provision_external_resources(session.id)
+
+stm = ShortTermMemory(
+    after_create_session_callback=after_create_session,
+)
+```
+
+The callback runs only when a new session is actually created. If it raises an exception, that exception is propagated to the caller and agent execution does not continue.
 
 ## Context compaction
 

--- a/docs/content/docs/framework/memory/short-term/index.mdx
+++ b/docs/content/docs/framework/memory/short-term/index.mdx
@@ -31,6 +31,7 @@ stm = ShortTermMemory(backend="sqlite", local_database_path="./stm.db")
 | `db_kwargs` | `dict` | `{}` | 透传给底层数据库会话服务/驱动的额外参数（如连接池配置）。 |
 | `local_database_path` | `str` | `/tmp/veadk_local_database.db` | 仅 `sqlite` 使用的本地数据库文件路径。 |
 | `after_load_memory_callback` | `Callable \| None` | `None` | 读取会话后触发的回调，入参为加载到的 `Session`。 |
+| `after_create_session_callback` | `Callable \| None` | `None` | 新会话创建成功后触发的同步或异步回调，入参为新建的 `Session`；复用已有会话时不触发。 |
 
 <Callout type="warn">
 当连接串里的用户名或密码包含 `@`、`:` 等特殊字符时，请先用 `urllib.parse.quote_plus` 编码（例如 `p@ssword` → `p%40ssword`），否则解析会出错。
@@ -101,6 +102,19 @@ asyncio.run(main())
 5. **清理会话** `delete_session()`：删除 `Session` 及其关联数据。
 
 `ShortTermMemory.create_session()` 在数据库后端下会先列出并复用同 `session_id` 的已有会话，避免重复创建。
+
+如果需要在会话首次创建后执行资源准备、审计或外部系统同步，可以注册 `after_create_session_callback`：
+
+```python
+async def after_create_session(session):
+    await provision_external_resources(session.id)
+
+stm = ShortTermMemory(
+    after_create_session_callback=after_create_session,
+)
+```
+
+回调只在真正创建新会话时执行。如果回调抛出异常，异常会传递给调用方，Agent 不会继续执行。
 
 ## 上下文压缩
 

--- a/examples/16_self_host_sandbox/.env.example
+++ b/examples/16_self_host_sandbox/.env.example
@@ -1,0 +1,18 @@
+# Copy this file to `.env` and fill in your values:
+# cp examples/16_self_host_sandbox/.env.example examples/16_self_host_sandbox/.env
+
+# --- Managed Runtime connection ---
+# BOE Runtime 7hw8g3yr exposes its Managed Sessions gateway through this URL.
+ANTHROPIC_BASE_URL=https://<runtime-apig-domain>.apigateway-cn-beijing.volceapi.com
+ANTHROPIC_ENVIRONMENT_ID=env_your_runtime_environment_id
+ANTHROPIC_ENVIRONMENT_KEY=your_runtime_environment_key
+SANDBOX_AGENT_ID=agent_your_managed_agent_id
+X_TOP_ACCOUNT_ID=your_volcengine_account_id
+
+# --- Web Server Configuration ---
+PORT=8067
+# Comma-separated origins when the Dev UI is accessed through another origin.
+# ALLOW_ORIGINS=http://localhost:3000,https://your-dev-proxy.example.com
+
+# Maximum time to wait for a remote Runtime turn, including tool execution.
+# SANDBOX_TIMEOUT_SECONDS=300

--- a/examples/16_self_host_sandbox/Dockerfile
+++ b/examples/16_self_host_sandbox/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.12-slim-bookworm
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    PORT=8067
+
+WORKDIR /app
+
+# Install this checkout so the image contains the same VeADK implementation as
+# the example. The sandbox extra supplies the Anthropic managed-session client.
+COPY --from=ghcr.io/astral-sh/uv:0.11.28 /uv /uvx /bin/
+COPY pyproject.toml uv.lock README.md LICENSE ./
+COPY veadk ./veadk
+COPY frontend ./frontend
+RUN uv sync --frozen --no-dev --extra sandbox
+
+COPY examples/16_self_host_sandbox ./examples/16_self_host_sandbox
+RUN chmod +x ./examples/16_self_host_sandbox/run.sh \
+    && useradd --create-home --uid 10001 veadk \
+    && chown -R veadk:veadk /app
+
+USER veadk
+EXPOSE 8067
+
+CMD ["bash", "examples/16_self_host_sandbox/run.sh", "--web", "--host", "0.0.0.0", "--port", "8067"]
+

--- a/examples/16_self_host_sandbox/Dockerfile.dockerignore
+++ b/examples/16_self_host_sandbox/Dockerfile.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.venv
+**/.env
+**/.env.*
+!**/.env.example
+**/__pycache__
+**/*.py[cod]
+**/.pytest_cache
+**/.ruff_cache
+**/node_modules
+docs
+tests
+

--- a/examples/16_self_host_sandbox/README.md
+++ b/examples/16_self_host_sandbox/README.md
@@ -1,0 +1,141 @@
+# 16. Self-Hosted Sandbox Agent Demo
+
+This example runs the conversation and model loop in `veadk web`. Each new VeADK Web session creates exactly one remote Managed Session. Only VeADK-generated `agent.tool_use` events are sent to the Self-Hosted Runtime dispatcher, which creates a TAE Tool session for the configured Sandbox.
+
+---
+
+## 🎯 Architecture
+
+```text
+       [ User Prompt ]
+              │
+              ▼
+   ┌───────────────────────┐
+   │      VeADK Web        │
+   │ model + agent loop    │
+   └──────────┬────────────┘
+              │ POST agent.tool_use
+              ▼
+   ┌───────────────────────────┐
+   │ Runtime 7hw8g3yr          │
+   │ dispatcher only           │
+   └──────────┬────────────────┘
+              │ creates one tool session
+              ▼
+   ┌────────────────────────────────────────┐
+   │ TAE Sandbox Tool m3m24zxs              │
+   │ executes the Runtime's tool calls      │
+   └────────────────────────────────────────┘
+```
+
+---
+
+## 🚀 Quick Start
+
+### 1. Configure Environment Variables
+
+Copy the example environment configuration file and update it with your credentials:
+
+```bash
+cp examples/16_self_host_sandbox/.env.example examples/16_self_host_sandbox/.env
+```
+
+Alternatively, export variables directly:
+
+```bash
+export ANTHROPIC_BASE_URL="https://<runtime-gateway>"
+export ANTHROPIC_ENVIRONMENT_ID="env_01SLqXHseguCmohifEqeUAYu"
+export ANTHROPIC_ENVIRONMENT_KEY="your-runtime-token"
+export SANDBOX_AGENT_ID="agent_your_managed_agent_id"
+export X_TOP_ACCOUNT_ID="your-account-id"
+```
+
+The local VeADK process needs its normal model configuration. Model reasoning happens in VeADK; only tool execution is delegated to the remote Runtime and Sandbox.
+
+
+### 2. Run the Demo
+
+#### Option A: Web UI Mode (`veadk web`)
+
+Run the visual web debugging interface in your browser (defaults to port **8067**, configurable via `PORT` in `.env` or `--port`):
+
+```bash
+# Via run.sh helper (automatically switches to agents dir and applies port 8067)
+bash examples/16_self_host_sandbox/run.sh --web
+
+# Or directly in the agents directory
+cd examples/16_self_host_sandbox/agents
+veadk web --port 8067
+```
+
+
+
+
+#### Option B: CLI Mode
+
+```bash
+# Run with run.sh helper
+bash examples/16_self_host_sandbox/run.sh
+
+# Or using uv
+uv run --extra sandbox python examples/16_self_host_sandbox/main.py
+
+# Or select an existing local-to-remote session mapping
+python examples/16_self_host_sandbox/main.py \
+  --session-id "my-local-session" \
+  --prompt "Create a Python script in /workspace and run it with pytest."
+```
+
+
+`ShortTermMemory.after_create_session_callback` creates one remote Managed Session
+for each newly created VeADK session. VeADK handles the user message and model
+loop locally. `DispatchRuntimeProvider` intercepts each model tool call, posts an
+`agent.tool_use`, waits for its matching tool result, and returns that result to
+the local VeADK model loop.
+
+## Docker and Kubernetes deployment
+
+Use the repository root as the Docker build context:
+
+```bash
+docker build \
+  -f examples/16_self_host_sandbox/Dockerfile \
+  -t <registry>/veadk-self-host-sandbox:<tag> \
+  .
+docker push <registry>/veadk-self-host-sandbox:<tag>
+```
+
+Replace the image and Ingress host in `k8s.yaml` for the target environment. Then
+create an allowlisted Secret from the local `.env` and deploy the workload:
+
+```bash
+set -a
+source examples/16_self_host_sandbox/.env
+set +a
+
+kubectl create secret generic veadk-self-host-sandbox-env \
+  --from-literal=ANTHROPIC_BASE_URL="$ANTHROPIC_BASE_URL" \
+  --from-literal=ANTHROPIC_ENVIRONMENT_ID="$ANTHROPIC_ENVIRONMENT_ID" \
+  --from-literal=ANTHROPIC_ENVIRONMENT_KEY="$ANTHROPIC_ENVIRONMENT_KEY" \
+  --from-literal=SANDBOX_AGENT_ID="$SANDBOX_AGENT_ID" \
+  --from-literal=X_TOP_ACCOUNT_ID="$X_TOP_ACCOUNT_ID" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl apply -f examples/16_self_host_sandbox/k8s.yaml
+kubectl rollout status deployment/veadk-self-host-sandbox
+```
+
+Do not create the Secret from the entire `.env`. The Deployment only injects
+the allowlisted Runtime connection values above.
+
+## Development verification
+
+The repository virtual environment may omit test dependencies when it was
+created for runtime use only. Install the development dependency group before
+running the focused dispatch tests:
+
+```bash
+uv sync --group dev --extra sandbox
+uv run pytest -q tests/runtime/test_self_host_sandbox_client.py \
+  tests/runtime/test_self_host_sandbox_agent.py
+```

--- a/examples/16_self_host_sandbox/README.zh.md
+++ b/examples/16_self_host_sandbox/README.zh.md
@@ -1,0 +1,138 @@
+# 16. 自建沙箱 Agent 示例 (Self-Hosted Sandbox)
+
+本示例由 `veadk web` 处理用户消息和模型循环。每个新建的 VeADK Web Session 只创建一个远端 Managed Session；仅将 VeADK 模型产生的 `agent.tool_use` 发送给 Self-Hosted Runtime dispatcher，再由它为配置的 TAE Sandbox 创建 Tool Session。
+
+---
+
+## 🎯 架构拓扑
+
+```text
+       【用户指令】: "在沙箱中写个快速排序并运行测试"
+              │
+              ▼
+   ┌───────────────────────┐
+   │      VeADK Web        │
+   │   模型与 Agent 循环     │
+   └──────────┬────────────┘
+              │ POST agent.tool_use
+              ▼
+   ┌───────────────────────────┐
+   │ Runtime 7hw8g3yr          │
+   │ 仅负责 dispatcher          │
+   └──────────┬────────────────┘
+              │ 为每个 Session 创建 Tool Session
+              ▼
+   ┌────────────────────────────────────────┐
+   │ TAE Sandbox Tool m3m24zxs              │
+   │ 执行 Runtime 产生的工具调用              │
+   └────────────────────────────────────────┘
+```
+
+---
+
+## 🚀 运行方法
+ 
+### 1. 配置环境变量
+
+复制环境配置文件示例并填入对应的配置与密钥：
+
+```bash
+cp examples/16_self_host_sandbox/.env.example examples/16_self_host_sandbox/.env
+```
+
+或直接在终端中导出环境变量：
+
+```bash
+export ANTHROPIC_BASE_URL="https://<runtime-gateway>"
+export ANTHROPIC_ENVIRONMENT_ID="env_01SLqXHseguCmohifEqeUAYu"
+export ANTHROPIC_ENVIRONMENT_KEY="your-runtime-token"
+export SANDBOX_AGENT_ID="agent_your_managed_agent_id"
+export X_TOP_ACCOUNT_ID="your-account-id"
+```
+
+本地 VeADK 进程需要正常的模型配置。模型推理由 VeADK 完成，只有 Tool 执行委托给远端 Runtime 与 Sandbox。
+
+
+### 2. 启动示例
+
+#### 方式一：Web 界面交互模式（`veadk web`）
+
+在浏览器中启动可视化 Web 调试交互界面（默认端口为 **8067**，支持在 `.env` 中通过 `PORT` 或 `--port` 自定义）：
+
+```bash
+# 方式 A：通过 run.sh 快捷启动（自动切换到 agents 目录并使用 8067 端口）
+bash examples/16_self_host_sandbox/run.sh --web
+
+# 方式 B：进入 agents 目录直接运行
+cd examples/16_self_host_sandbox/agents
+veadk web --port 8067
+```
+
+
+
+
+#### 方式二：CLI 命令行模式
+
+```bash
+# 使用 run.sh 运行
+bash examples/16_self_host_sandbox/run.sh
+
+# 或使用 uv
+uv run --extra sandbox python examples/16_self_host_sandbox/main.py
+
+# 或指定一个本地到远端的 Session 映射 ID
+python examples/16_self_host_sandbox/main.py \
+  --session-id "my-local-session" \
+  --prompt "请在 /workspace 下创建一个 quick_sort.py 并运行验证"
+```
+
+
+每个新建的 VeADK Session 都通过 `POST /v1/sessions` 创建一个远端 Managed
+Session。用户消息和模型循环留在 VeADK；`DispatchRuntimeProvider` 拦截模型生成的
+Tool call，以 `agent.tool_use` 发送给 Runtime，等待匹配的 Tool result 后交还给本地
+VeADK 模型继续生成最终回复。
+
+## Docker 与 Kubernetes 部署
+
+Docker 构建上下文必须使用仓库根目录：
+
+```bash
+docker build \
+  -f examples/16_self_host_sandbox/Dockerfile \
+  -t <registry>/veadk-self-host-sandbox:<tag> \
+  .
+docker push <registry>/veadk-self-host-sandbox:<tag>
+```
+
+将 `k8s.yaml` 中的镜像和 Ingress 域名替换成目标环境的值。然后从本地 `.env`
+显式创建白名单 Secret，再部署工作负载：
+
+```bash
+set -a
+source examples/16_self_host_sandbox/.env
+set +a
+
+kubectl create secret generic veadk-self-host-sandbox-env \
+  --from-literal=ANTHROPIC_BASE_URL="$ANTHROPIC_BASE_URL" \
+  --from-literal=ANTHROPIC_ENVIRONMENT_ID="$ANTHROPIC_ENVIRONMENT_ID" \
+  --from-literal=ANTHROPIC_ENVIRONMENT_KEY="$ANTHROPIC_ENVIRONMENT_KEY" \
+  --from-literal=SANDBOX_AGENT_ID="$SANDBOX_AGENT_ID" \
+  --from-literal=X_TOP_ACCOUNT_ID="$X_TOP_ACCOUNT_ID" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl apply -f examples/16_self_host_sandbox/k8s.yaml
+kubectl rollout status deployment/veadk-self-host-sandbox
+```
+
+不要使用整个 `.env` 创建 Secret；Deployment 只注入上述白名单内的 Runtime 连接配置。
+
+## 开发验证
+
+如果仓库虚拟环境仅安装了运行时依赖，其中可能没有 `pytest`。请先同步开发依赖组，
+再运行 Tool dispatch 的定向测试：
+
+```bash
+uv sync --group dev --extra sandbox
+uv run pytest -q tests/runtime/test_self_host_sandbox_client.py \
+  tests/runtime/test_self_host_sandbox_agent.py
+```

--- a/examples/16_self_host_sandbox/agents/__init__.py
+++ b/examples/16_self_host_sandbox/agents/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agents package for Self-Hosted Sandbox example."""

--- a/examples/16_self_host_sandbox/agents/self_host_sandbox_agent/__init__.py
+++ b/examples/16_self_host_sandbox/agents/self_host_sandbox_agent/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Self-Hosted Sandbox Agent package."""
+
+from .agent import agent, root_agent
+
+__all__ = ["agent", "root_agent"]

--- a/examples/16_self_host_sandbox/agents/self_host_sandbox_agent/agent.py
+++ b/examples/16_self_host_sandbox/agents/self_host_sandbox_agent/agent.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VeADK agent whose tool calls run through a Self-Hosted Sandbox Runtime."""
+
+import asyncio
+import logging
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[2]
+if str(EXAMPLE_DIR) not in sys.path:
+    sys.path.insert(0, str(EXAMPLE_DIR))
+load_dotenv(EXAMPLE_DIR / ".env", override=False)
+
+from sandbox_client import SelfHostSandboxClient  # noqa: E402
+from veadk import Agent  # noqa: E402
+from veadk.memory.short_term_memory import ShortTermMemory  # noqa: E402
+from veadk.runtime import DispatchRuntimeProvider, ToolCall  # noqa: E402
+
+logger = logging.getLogger("veadk.sandbox_agent")
+
+
+class SandboxSessionManager:
+    """Bind exactly one remote Managed Session to each VeADK session."""
+
+    def __init__(self) -> None:
+        self._clients: dict[str, SelfHostSandboxClient] = {}
+        self._lock = threading.Lock()
+
+    def _new_client(self) -> SelfHostSandboxClient:
+        client = SelfHostSandboxClient()
+        client.session_id = None
+        return client
+
+    def get(self, veadk_session_id: str) -> SelfHostSandboxClient:
+        key = veadk_session_id or "__default__"
+        with self._lock:
+            client = self._clients.get(key)
+            if client is None:
+                client = self._new_client()
+                self._clients[key] = client
+            return client
+
+    def bind(self, veadk_session_id: str, client: SelfHostSandboxClient) -> None:
+        key = veadk_session_id or "__default__"
+        with self._lock:
+            self._clients[key] = client
+
+    def create_remote_session(self, veadk_session_id: str) -> str:
+        client = self.get(veadk_session_id)
+        if not client.session_id:
+            client.create_session(
+                title=f"VeADK Self-Hosted Sandbox Session {veadk_session_id}"
+            )
+        return client.session_id or ""
+
+    def release(self, veadk_session_id: str) -> None:
+        key = veadk_session_id or "__default__"
+        with self._lock:
+            client = self._clients.pop(key, None)
+        if client:
+            client.post_status_idle()
+
+
+sandbox_sessions = SandboxSessionManager()
+sandbox_client = sandbox_sessions.get("__default__")
+
+
+def bash(command: str, timeout: float = 120) -> dict:
+    """Execute a shell command in the remote sandbox."""
+    raise RuntimeError("Remote tools must be intercepted by DispatchRuntimeProvider")
+
+
+def read_file(
+    file_path: str, offset: int | None = None, limit: int | None = None
+) -> dict:
+    """Read a text file in the remote sandbox."""
+    raise RuntimeError("Remote tools must be intercepted by DispatchRuntimeProvider")
+
+
+def write_file(file_path: str, content: str) -> dict:
+    """Create or overwrite a text file in the remote sandbox."""
+    raise RuntimeError("Remote tools must be intercepted by DispatchRuntimeProvider")
+
+
+def edit_file(
+    file_path: str, old_string: str, new_string: str, replace_all: bool = False
+) -> dict:
+    """Replace an exact string in a remote sandbox file."""
+    raise RuntimeError("Remote tools must be intercepted by DispatchRuntimeProvider")
+
+
+def list_files(path: str = "/workspace", max_depth: int = 4) -> dict:
+    """List files below a directory in the remote sandbox."""
+    raise RuntimeError("Remote tools must be intercepted by DispatchRuntimeProvider")
+
+
+def search_files(
+    pattern: str,
+    path: str = "/workspace",
+    glob: str | None = None,
+    case_insensitive: bool = False,
+) -> dict:
+    """Search files in the remote sandbox."""
+    raise RuntimeError("Remote tools must be intercepted by DispatchRuntimeProvider")
+
+
+def python(code: str, workdir: str = "/workspace", timeout: float = 120) -> dict:
+    """Run Python code in the remote sandbox."""
+    raise RuntimeError("Remote tools must be intercepted by DispatchRuntimeProvider")
+
+
+async def after_create_session(session: Any) -> None:
+    veadk_session_id = str(getattr(session, "id", "") or "")
+    remote_id = await asyncio.to_thread(
+        sandbox_sessions.create_remote_session, veadk_session_id
+    )
+    logger.info(
+        "Remote Managed Session created: veadk=%s remote=%s",
+        veadk_session_id,
+        remote_id,
+    )
+
+
+async def dispatch_task(tool_call: ToolCall) -> dict:
+    client = sandbox_sessions.get(tool_call.session_id)
+    return await asyncio.to_thread(
+        client.dispatch_tool,
+        tool_call.name,
+        tool_call.arguments,
+        dispatch_id=tool_call.id,
+    )
+
+
+dispatch_runtime = DispatchRuntimeProvider(dispatch_task, dispatchable_tools=None)
+short_term_memory = ShortTermMemory(after_create_session_callback=after_create_session)
+
+# veadk web calls the service directly, so preserve the per-session callback
+# when the UI creates a session outside Runner.create_session().
+_create_local_session = short_term_memory.session_service.create_session
+
+
+async def _create_session_with_remote(*args: Any, **kwargs: Any) -> Any:
+    session = await _create_local_session(*args, **kwargs)
+    if session is not None:
+        await after_create_session(session)
+    return session
+
+
+short_term_memory.session_service.create_session = _create_session_with_remote
+
+agent = Agent(
+    name="self_host_sandbox_agent",
+    description="An engineering agent dispatching tool calls to a Self-Hosted Worker.",
+    instruction=(
+        f"You are an autonomous engineering assistant connected to Runtime 7hw8g3yr "
+        f"(Environment: {sandbox_client.environment_id}). Handle user conversation and "
+        "model reasoning in VeADK. Use the provided tools for every sandbox operation; "
+        "tool calls are dispatched through Runtime 7hw8g3yr to TAE Sandbox m3m24zxs."
+    ),
+    tools=[bash, read_file, write_file, edit_file, list_files, search_files, python],
+    short_term_memory=short_term_memory,
+    before_tool_callback=dispatch_runtime.before_tool_callback,
+)
+
+root_agent = agent

--- a/examples/16_self_host_sandbox/k8s.yaml
+++ b/examples/16_self_host_sandbox/k8s.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: veadk-self-host-sandbox
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: veadk-self-host-sandbox
+  template:
+    metadata:
+      labels:
+        app: veadk-self-host-sandbox
+    spec:
+      imagePullSecrets:
+        - name: cr-zn-datapath-cn-beijing
+      containers:
+        - name: veadk-web
+          image: zn-datapath-cn-beijing.cr.volces.com/sandbox/veadk-self-host-sandbox:20260828-105455
+          imagePullPolicy: Always
+          env:
+            - name: ANTHROPIC_BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: veadk-self-host-sandbox-env
+                  key: ANTHROPIC_BASE_URL
+            - name: ANTHROPIC_ENVIRONMENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: veadk-self-host-sandbox-env
+                  key: ANTHROPIC_ENVIRONMENT_ID
+            - name: ANTHROPIC_ENVIRONMENT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: veadk-self-host-sandbox-env
+                  key: ANTHROPIC_ENVIRONMENT_KEY
+            - name: SANDBOX_AGENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: veadk-self-host-sandbox-env
+                  key: SANDBOX_AGENT_ID
+            - name: X_TOP_ACCOUNT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: veadk-self-host-sandbox-env
+                  key: X_TOP_ACCOUNT_ID
+          ports:
+            - name: http
+              containerPort: 8067
+          readinessProbe:
+            httpGet:
+              path: /list-apps
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /list-apps
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 4
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: veadk-self-host-sandbox
+  namespace: default
+spec:
+  selector:
+    app: veadk-self-host-sandbox
+  ports:
+    - name: http
+      port: 8067
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: veadk-self-host-sandbox
+  namespace: default
+  annotations:
+    ingress.vke.volcengine.com/apig-instance-name: apig-instance-demo
+spec:
+  ingressClassName: apig
+  rules:
+    - host: example2.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: veadk-self-host-sandbox
+                port:
+                  number: 8067

--- a/examples/16_self_host_sandbox/main.py
+++ b/examples/16_self_host_sandbox/main.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run the VeADK agent with remotely dispatched sandbox tools."""
+
+import argparse
+import asyncio
+import uuid
+
+from agents.self_host_sandbox_agent.agent import agent
+from veadk import Runner
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--prompt",
+        default=(
+            "Use the bash tool to run: printf 'veadk-self-host-ok'. "
+            "Then reply with the exact output."
+        ),
+    )
+    parser.add_argument("--session-id", default=None)
+    args = parser.parse_args()
+
+    session_id = args.session_id or f"veadk-{uuid.uuid4()}"
+    runner = Runner(agent=agent, app_name="self_host_sandbox_demo")
+    output = await runner.run(messages=args.prompt, session_id=session_id)
+    print(output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/16_self_host_sandbox/requirements.txt
+++ b/examples/16_self_host_sandbox/requirements.txt
@@ -1,0 +1,4 @@
+# Dependencies for Self-Hosted Sandbox Example
+anthropic>=0.40.0
+python-dotenv>=1.0.0
+httpx[socks]>=0.27.0

--- a/examples/16_self_host_sandbox/run.sh
+++ b/examples/16_self_host_sandbox/run.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Ensure veadk and example root are in PYTHONPATH
+export PYTHONPATH="$REPO_ROOT:$SCRIPT_DIR:${PYTHONPATH:-}"
+
+# Load .env if present
+if [ -f "$SCRIPT_DIR/.env" ]; then
+    # Treat .env as defaults. Explicit caller-provided values are useful for
+    # testing another Runtime without rewriting a credential file on disk.
+    declare -A EXPLICIT_ENV=()
+    for key in \
+        ANTHROPIC_BASE_URL ANTHROPIC_ENVIRONMENT_ID ANTHROPIC_ENVIRONMENT_KEY \
+        SANDBOX_AGENT_ID X_TOP_ACCOUNT_ID SANDBOX_TIMEOUT_SECONDS PORT; do
+        if [[ -v $key ]]; then
+            EXPLICIT_ENV[$key]="${!key}"
+        fi
+    done
+    set -a
+    source "$SCRIPT_DIR/.env"
+    set +a
+    for key in "${!EXPLICIT_ENV[@]}"; do
+        printf -v "$key" '%s' "${EXPLICIT_ENV[$key]}"
+        export "$key"
+    done
+else
+    echo "⚠️  未检测到 $SCRIPT_DIR/.env 配置文件。"
+    if [ -f "$SCRIPT_DIR/.env.example" ]; then
+        echo "💡 提示：请先执行 'cp $SCRIPT_DIR/.env.example $SCRIPT_DIR/.env' 并配置相应密钥。"
+    fi
+fi
+
+PORT="${PORT:-8067}"
+
+# Check if web mode is requested
+if [ "${1:-}" = "--web" ]; then
+    shift
+    PORT_ARGS=()
+    CORS_ARGS=()
+    if [[ ! " $* " =~ " --port " ]]; then
+        PORT_ARGS=(--port "$PORT")
+    fi
+    if [[ ! " $* " =~ " --allow_origins " ]] && [ -n "${ALLOW_ORIGINS:-}" ]; then
+        IFS=',' read -r -a CONFIGURED_ORIGINS <<< "$ALLOW_ORIGINS"
+        for origin in "${CONFIGURED_ORIGINS[@]}"; do
+            CORS_ARGS+=(--allow_origins "$origin")
+        done
+    fi
+    echo "🌐 正在启动 VeADK Web 调试界面 (端口: ${PORT})..."
+    # Switch into agents directory so veadk web detects self_host_sandbox_agent
+    cd "$SCRIPT_DIR/agents"
+    if [ -x "$REPO_ROOT/.venv/bin/veadk" ]; then
+        exec "$REPO_ROOT/.venv/bin/veadk" web "${PORT_ARGS[@]}" "${CORS_ARGS[@]}" "$@"
+    elif command -v uv >/dev/null 2>&1; then
+        exec uv run --directory "$REPO_ROOT" --extra sandbox veadk web "${PORT_ARGS[@]}" "${CORS_ARGS[@]}" "$@"
+    elif command -v veadk >/dev/null 2>&1; then
+        exec veadk web "${PORT_ARGS[@]}" "${CORS_ARGS[@]}" "$@"
+    else
+        exec python3 -m veadk.cli.cli web "${PORT_ARGS[@]}" "${CORS_ARGS[@]}" "$@"
+    fi
+fi
+
+cd "$SCRIPT_DIR"
+
+# Prioritize local repo virtualenv if present, otherwise invoke via uv or system python
+if [ -x "$REPO_ROOT/.venv/bin/python" ]; then
+    exec "$REPO_ROOT/.venv/bin/python" "$SCRIPT_DIR/main.py" "$@"
+elif command -v uv >/dev/null 2>&1; then
+    exec uv run --directory "$REPO_ROOT" --extra sandbox python "$SCRIPT_DIR/main.py" "$@"
+else
+    exec python3 "$SCRIPT_DIR/main.py" "$@"
+fi

--- a/examples/16_self_host_sandbox/sandbox_client.py
+++ b/examples/16_self_host_sandbox/sandbox_client.py
@@ -1,0 +1,479 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Self-Hosted Sandbox client using official Anthropic Python SDK (client.beta.sessions & events).
+
+Endpoints managed via Anthropic SDK:
+1. client.beta.sessions.create:
+   Creates a session and enqueues work into the WorkQueue for the worker.
+2. client.beta.sessions.events.send:
+   Publishes ``agent.tool_use`` and ``session.status_idle`` events.
+3. client.beta.sessions.events.list:
+   Retrieves session events to wait for ``user.tool_result`` from workers.
+"""
+
+import base64
+import html
+import json
+import logging
+import os
+import re
+import shlex
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+
+import anthropic
+
+logger = logging.getLogger("veadk.sandbox")
+
+
+class SelfHostSandboxClient:
+    """Client for Managed Agents Self-Hosted Sandbox backed by official Anthropic SDK."""
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        environment_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        bearer_token: Optional[str] = None,
+        account_id: Optional[str] = None,
+        remote_bash_tool_name: Optional[str] = None,
+        timeout: int = 120,
+    ):
+        self.base_url = (
+            base_url
+            or os.getenv("ANTHROPIC_BASE_URL")
+            or os.getenv("SANDBOX_BASE_URL", "")
+        ).rstrip("/")
+        self.environment_id = (
+            environment_id
+            or os.getenv("ANTHROPIC_ENVIRONMENT_ID")
+            or os.getenv("SANDBOX_ENVIRONMENT_ID", "env_01SLqXHseguCmohifEqeUAYu")
+        )
+        self.agent_id = agent_id or os.getenv(
+            "SANDBOX_AGENT_ID", "agent_011CSd8hFhXGpz33bM1pBw7y"
+        )
+        self.session_id = session_id or os.getenv("SANDBOX_SESSION_ID")
+
+        raw_token = (
+            bearer_token
+            or os.getenv("ANTHROPIC_ENVIRONMENT_KEY")
+            or os.getenv("ANTHROPIC_API_KEY")
+            or os.getenv("SANDBOX_BEARER_TOKEN")
+            or os.getenv("SANDBOX_API_KEY", "")
+        )
+        if raw_token.startswith("Bearer "):
+            raw_token = raw_token[7:].strip()
+        self.bearer_token = raw_token
+        self.account_id = account_id or os.getenv("X_TOP_ACCOUNT_ID", "")
+        self.remote_bash_tool_name = remote_bash_tool_name or os.getenv(
+            "SANDBOX_BASH_TOOL_NAME", "bash"
+        )
+        self.timeout = int(os.getenv("SANDBOX_TIMEOUT_SECONDS", str(timeout)))
+
+        if not self.base_url:
+            raise ValueError(
+                "ANTHROPIC_BASE_URL (or SANDBOX_BASE_URL) must be configured in .env or arguments."
+            )
+        if not self.bearer_token:
+            raise ValueError(
+                "ANTHROPIC_ENVIRONMENT_KEY (or SANDBOX_BEARER_TOKEN) must be configured in .env or arguments."
+            )
+
+        # The Runtime gateway needs the Managed Agents beta flag and, when
+        # supplied, the Volcengine top-account routing header.
+        default_headers = {
+            "anthropic-beta": "managed-agents-2026-04-01",
+        }
+        if self.account_id:
+            default_headers["X-Top-Account-Id"] = str(self.account_id)
+
+        self.client = anthropic.Anthropic(
+            base_url=self.base_url,
+            auth_token=self.bearer_token,
+            default_headers=default_headers,
+            timeout=float(self.timeout),
+        )
+
+    def create_session(
+        self,
+        title: str = "VeADK Self-Hosted Sandbox Session",
+    ) -> Dict[str, Any]:
+        """POST /v1/sessions via Anthropic SDK (client.beta.sessions.create).
+
+        Creates a session and enqueues a work item into managed_selfhost_work_items.
+        """
+        sess = self.client.beta.sessions.create(
+            agent=self.agent_id,
+            environment_id=self.environment_id,
+            title=title,
+        )
+        self.session_id = sess.id
+        logger.info(
+            "Session %s created on remote Runtime via Anthropic SDK.", self.session_id
+        )
+        if hasattr(sess, "model_dump"):
+            return sess.model_dump(warnings=False)
+        return {
+            "id": sess.id,
+            "environment_id": self.environment_id,
+            "agent": self.agent_id,
+        }
+
+    def post_events(self, events: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """POST /v1/sessions/{session_id}/events via Anthropic SDK (client.beta.sessions.events.send).
+
+        Dispatches tool calls and tool results into the Session event stream.
+        """
+        if not self.session_id:
+            self.create_session()
+
+        response = self.client.beta.sessions.events.send(
+            session_id=self.session_id,
+            events=events,
+        )
+        if hasattr(response, "model_dump"):
+            return response.model_dump(warnings=False)
+        return {"status": "ok"}
+
+    def send_tool_result(
+        self, tool_use_id: str, content: str, is_error: bool = False
+    ) -> Dict[str, Any]:
+        """Send tool execution result to POST /v1/sessions/{session_id}/events."""
+        event = {
+            "type": "user.tool_result",
+            "tool_use_id": tool_use_id,
+            "content": [{"type": "text", "text": content}],
+            "is_error": is_error,
+        }
+        return self.post_events([event])
+
+    def list_events(
+        self,
+        *,
+        limit: int = 100,
+        order: str = "asc",
+    ) -> List[Dict[str, Any]]:
+        """Read and normalize events from GET /v1/sessions/{id}/events via Anthropic SDK."""
+        if not self.session_id:
+            raise RuntimeError("Cannot read events before a Session is created.")
+
+        page = self.client.beta.sessions.events.list(
+            session_id=self.session_id,
+            limit=limit,
+            order=order,
+        )
+        events: List[Dict[str, Any]] = []
+        for item in page.data:
+            if hasattr(item, "model_dump"):
+                d = item.model_dump(warnings=False)
+            elif isinstance(item, dict):
+                d = dict(item)
+            else:
+                d = {
+                    "id": getattr(item, "id", None),
+                    "type": getattr(item, "type", None),
+                    "name": getattr(item, "name", None),
+                    "input": getattr(item, "input", None),
+                    "content": getattr(item, "content", None),
+                    "is_error": getattr(item, "is_error", False),
+                    "tool_use_id": getattr(item, "tool_use_id", None),
+                }
+            events.append(d)
+        return events
+
+    def post_status_idle(self, stop_reason: str = "end_turn") -> None:
+        """Publish a ``session.status_idle`` event so workers know the turn ended and can release their lease."""
+        if not self.session_id:
+            return
+        try:
+            self.post_events(
+                [
+                    {
+                        "type": "session.status_idle",
+                        "stop_reason": {
+                            "type": stop_reason,
+                        },
+                    }
+                ]
+            )
+            logging.info(
+                "Session %s marked status_idle (%s).", self.session_id, stop_reason
+            )
+        except Exception as e:
+            logging.warning(
+                "Failed to post session.status_idle for %s: %s", self.session_id, e
+            )
+
+    def dispatch_tool(
+        self,
+        tool_name: str,
+        arguments: Dict[str, Any],
+        *,
+        dispatch_id: str = "",
+    ) -> Dict[str, Any]:
+        """Convert a VeADK tool to bash and publish an ``agent.tool_use``."""
+        command, timeout = self._tool_to_bash(tool_name, arguments)
+        return self.execute_command(
+            command,
+            timeout=timeout,
+            dispatch_id=dispatch_id,
+        )
+
+    def _tool_to_bash(
+        self, tool_name: str, arguments: Dict[str, Any]
+    ) -> tuple[str, float]:
+        """Translate supported non-MCP tools into one remote bash invocation."""
+        timeout = self._positive_timeout(arguments.get("timeout", self.timeout))
+        if tool_name == "bash":
+            cmd = self._required_string(arguments, "command", tool_name)
+            return html.unescape(cmd), timeout
+
+        if tool_name == "read_file":
+            file_path = self._required_string(arguments, "file_path", tool_name)
+            offset = arguments.get("offset")
+            limit = arguments.get("limit")
+            quoted_path = shlex.quote(file_path)
+            if offset is None and limit is None:
+                return f"cat -- {quoted_path}", timeout
+            start = self._positive_integer(
+                offset if offset is not None else 1, "offset"
+            )
+            if limit is None:
+                condition = f"NR >= {start}"
+            else:
+                line_limit = self._positive_integer(limit, "limit")
+                condition = f"NR >= {start} && NR < {start + line_limit}"
+            awk_program = f'{condition} {{printf "%d\\t%s\\n", NR, $0}}'
+            return f"awk {shlex.quote(awk_program)} {quoted_path}", timeout
+
+        if tool_name == "write_file":
+            file_path = self._required_string(arguments, "file_path", tool_name)
+            content = self._required_string(
+                arguments, "content", tool_name, allow_empty=True
+            )
+            encoded = base64.b64encode(content.encode("utf-8")).decode("ascii")
+            quoted_path = shlex.quote(file_path)
+            command = (
+                f"mkdir -p $(dirname -- {quoted_path}) && "
+                f"printf %s {shlex.quote(encoded)} | base64 -d > {quoted_path}"
+            )
+            return command, timeout
+
+        if tool_name == "edit_file":
+            payload = {
+                "file_path": self._required_string(arguments, "file_path", tool_name),
+                "old_string": self._required_string(arguments, "old_string", tool_name),
+                "new_string": self._required_string(
+                    arguments, "new_string", tool_name, allow_empty=True
+                ),
+                "replace_all": bool(arguments.get("replace_all", False)),
+            }
+            encoded = base64.b64encode(
+                json.dumps(payload, ensure_ascii=False).encode("utf-8")
+            ).decode("ascii")
+            script = (
+                "import base64,json,pathlib,sys;"
+                "d=json.loads(base64.b64decode(sys.argv[1]));"
+                "p=pathlib.Path(d['file_path']);s=p.read_text();o=d['old_string'];"
+                "n=s.count(o);"
+                "(_ for _ in ()).throw(ValueError('old_string not found')) if n==0 else None;"
+                "(_ for _ in ()).throw(ValueError(f'old_string appears {n} times')) "
+                "if n>1 and not d['replace_all'] else None;"
+                "p.write_text(s.replace(o,d['new_string'],-1 if d['replace_all'] else 1))"
+            )
+            return (
+                f"python3 -c {shlex.quote(script)} {shlex.quote(encoded)}",
+                timeout,
+            )
+
+        if tool_name == "list_files":
+            path = str(arguments.get("path") or "/workspace")
+            depth = self._positive_integer(arguments.get("max_depth", 4), "max_depth")
+            return (
+                f"find {shlex.quote(path)} -maxdepth {depth} -type f | sort | head -n 500",
+                timeout,
+            )
+
+        if tool_name == "search_files":
+            pattern = self._required_string(arguments, "pattern", tool_name)
+            path = str(arguments.get("path") or "/workspace")
+            glob = arguments.get("glob")
+            rg_flags = "-n --no-heading"
+            grep_flags = "-RIn"
+            if arguments.get("case_insensitive"):
+                rg_flags += " -i"
+                grep_flags += " -i"
+            if glob:
+                rg_flags += f" --glob {shlex.quote(str(glob))}"
+                grep_flags += f" --include {shlex.quote(str(glob))}"
+            quoted_pattern = shlex.quote(pattern)
+            quoted_path = shlex.quote(path)
+            return (
+                "if command -v rg >/dev/null 2>&1; then "
+                f"rg {rg_flags} -- {quoted_pattern} {quoted_path}; "
+                "else "
+                f"grep {grep_flags} -- {quoted_pattern} {quoted_path}; fi",
+                timeout,
+            )
+
+        if tool_name == "python":
+            code = self._required_string(arguments, "code", tool_name, allow_empty=True)
+            workdir = str(arguments.get("workdir") or "/workspace")
+            return (
+                f"cd {shlex.quote(workdir)} && python3 -c {shlex.quote(code)}",
+                timeout,
+            )
+
+        raise ValueError(
+            f"Unsupported non-MCP tool {tool_name!r}; add an explicit bash adapter"
+        )
+
+    def execute_command(
+        self,
+        command: str,
+        *,
+        timeout: float | None = None,
+        dispatch_id: str = "",
+    ) -> Dict[str, Any]:
+        """Publish ``agent.tool_use`` and wait for the Worker's tool result."""
+        if not self.session_id:
+            self.create_session()
+
+        timeout_seconds = timeout or float(self.timeout)
+        command = html.unescape(command)
+        tool_use_id = dispatch_id or f"toolu_{uuid.uuid4().hex}"
+        self.post_events(
+            [
+                {
+                    "type": "agent.tool_use",
+                    "id": tool_use_id,
+                    "name": self.remote_bash_tool_name,
+                    "input": {
+                        "command": command,
+                        "timeout_ms": int(timeout_seconds * 1000),
+                        "timeout": int(timeout_seconds * 1000),
+                    },
+                }
+            ]
+        )
+        return self._wait_for_tool_result(
+            timeout=timeout_seconds,
+            tool_use_id=tool_use_id,
+            dispatch_id=dispatch_id or tool_use_id,
+        )
+
+    def _wait_for_tool_result(
+        self,
+        *,
+        timeout: float,
+        tool_use_id: str,
+        dispatch_id: str,
+    ) -> Dict[str, Any]:
+        deadline = time.monotonic() + timeout
+
+        while time.monotonic() < deadline:
+            events = self.list_events(limit=100, order="asc")
+            for event in events:
+                event_type = str(event.get("type") or "")
+                if event_type not in {"agent.tool_result", "user.tool_result"}:
+                    continue
+                result_tool_use_id = str(event.get("tool_use_id") or "")
+                if result_tool_use_id == tool_use_id:
+                    return self._normalize_bash_result(
+                        event,
+                        tool_use_id=tool_use_id,
+                        dispatch_id=dispatch_id,
+                    )
+            time.sleep(0.5)
+
+        raise TimeoutError(
+            f"Timed out after {timeout:g}s waiting for tool result {tool_use_id}."
+        )
+
+    @staticmethod
+    def _required_string(
+        arguments: Dict[str, Any],
+        key: str,
+        tool_name: str,
+        *,
+        allow_empty: bool = False,
+    ) -> str:
+        value = arguments.get(key)
+        if not isinstance(value, str) or (not allow_empty and not value.strip()):
+            raise ValueError(f"{tool_name} requires a valid {key}")
+        return value
+
+    @staticmethod
+    def _positive_integer(value: Any, name: str) -> int:
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"{name} must be a positive integer")
+        return value
+
+    @staticmethod
+    def _positive_timeout(value: Any) -> float:
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+            raise ValueError("timeout must be greater than zero")
+        return float(value)
+
+    def _normalize_bash_result(
+        self,
+        event: Dict[str, Any],
+        *,
+        tool_use_id: str,
+        dispatch_id: str,
+    ) -> Dict[str, Any]:
+        content = self._content_text(event.get("content"))
+        match = re.match(r"^exit=(-?\d+)\n([\s\S]*)$", content)
+        if match:
+            exit_code = int(match.group(1))
+            stdout = match.group(2)
+        else:
+            exit_code = 1 if event.get("is_error") else 0
+            stdout = content
+        return {
+            "dispatch_id": dispatch_id,
+            "tool_use_id": tool_use_id,
+            "environment_id": self.environment_id,
+            "session_id": self.session_id,
+            "status": "failed" if exit_code else "completed",
+            "exit_code": exit_code,
+            "stdout": stdout,
+            "stderr": "",
+        }
+
+    @staticmethod
+    def _event_seq(event: Dict[str, Any]) -> int:
+        try:
+            return int(event.get("_seq", 0) or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _content_text(content: Any) -> str:
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = []
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    parts.append(str(block.get("text") or ""))
+                elif isinstance(block, str):
+                    parts.append(block)
+            return "\n".join(part for part in parts if part)
+        if content is None:
+            return ""
+        return json.dumps(content, ensure_ascii=False)

--- a/examples/self_host_sandbox_demo.py
+++ b/examples/self_host_sandbox_demo.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VeADK Agent with Official Managed Agents & Self-Hosted Sandbox Protocol.
+
+Uses the 100% standard Managed Agents REST & SSE protocol:
+1. POST /v1/sessions (or /api/sessions): Creates a Session bound to `agent` and `environment_id`.
+   The server automatically enqueues the Session into the environment's Work Queue.
+2. GET /v1/sessions/{id}/events/stream: Streams events (agent.message, agent.tool_use, etc.).
+3. POST /v1/sessions/{id}/events: Sends user messages or tool results back.
+
+Usage:
+    python examples/self_host_sandbox_demo.py \
+        --base-url "http://localhost:8080" \
+        --agent-id "agent_011CSd8hFhXGpz33bM1pBw7y" \
+        --env-id "env_01SLqXHseguCmohifEqeUAYu" \
+        --api-key "your-api-key" \
+        --prompt "请在沙箱 /workspace 下写一个快速排序 quick_sort.py 并运行验证"
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Generator, Optional
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
+)
+logger = logging.getLogger("veadk.managed_agents_sandbox")
+
+
+# ─────────────────────────────────────────────────────────────
+# 1. Standard Managed Agents API Client
+# ─────────────────────────────────────────────────────────────
+class ManagedAgentsStandardClient:
+    """Standard client implementing the Anthropic / OMA Managed Agents HTTP & SSE protocol."""
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ):
+        self.base_url = (
+            base_url
+            or os.getenv("ANTHROPIC_BASE_URL")
+            or os.getenv("SANDBOX_BASE_URL")
+            or "http://127.0.0.1:8080"
+        ).rstrip("/")
+        self.api_key = (
+            api_key
+            or os.getenv("ANTHROPIC_API_KEY")
+            or os.getenv("SANDBOX_API_KEY")
+            or "dummy_key"
+        )
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Content-Type": "application/json",
+            "x-api-key": self.api_key,
+            "X-Builder-Environment-Key": self.api_key,
+            "anthropic-beta": "managed-agents-2026-04-01",
+        }
+
+    def create_session(
+        self,
+        agent_id: str,
+        environment_id: str,
+        initial_prompt: str,
+        title: str = "VeADK Session",
+    ) -> Dict[str, Any]:
+        """Standard POST /v1/sessions (or /api/sessions).
+
+        Creating a session with an environment_id automatically triggers the server
+        to enqueue a WorkItem for the self-hosted worker.
+        """
+        payload = {
+            "agent": agent_id,
+            "environment_id": environment_id,
+            "title": title,
+            "initial_events": [
+                {
+                    "type": "user.message",
+                    "content": [{"type": "text", "text": initial_prompt}],
+                }
+            ],
+        }
+
+        # Try /v1/sessions first, fallback to /api/sessions
+        for path in ["/v1/sessions", "/api/sessions"]:
+            url = f"{self.base_url}{path}"
+            data = json.dumps(payload).encode("utf-8")
+            req = urllib.request.Request(
+                url, data=data, headers=self._headers(), method="POST"
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    return json.loads(resp.read().decode("utf-8"))
+            except urllib.error.HTTPError as e:
+                if e.code == 404 and path == "/v1/sessions":
+                    continue
+                err_text = e.read().decode("utf-8") if e.fp else str(e)
+                raise RuntimeError(
+                    f"Failed to create session at {url} (HTTP {e.code}): {err_text}"
+                ) from e
+            except urllib.error.URLError as e:
+                raise ConnectionError(
+                    f"Cannot connect to Managed Agents Server at {url}: {e}"
+                ) from e
+
+        raise RuntimeError("Failed to reach sessions endpoint on server")
+
+    def stream_session_events(
+        self, session_id: str
+    ) -> Generator[Dict[str, Any], None, None]:
+        """Standard GET /v1/sessions/{id}/events/stream (SSE)."""
+        for path in [
+            f"/v1/sessions/{session_id}/events/stream",
+            f"/api/sessions/{session_id}/events/stream",
+        ]:
+            url = f"{self.base_url}{path}"
+            req = urllib.request.Request(
+                url, headers={**self._headers(), "Accept": "text/event-stream"}
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=300) as resp:
+                    for line in resp:
+                        line_str = line.decode("utf-8").strip()
+                        if line_str.startswith("data:"):
+                            data_str = line_str[5:].strip()
+                            if data_str and data_str != "[DONE]":
+                                try:
+                                    yield json.loads(data_str)
+                                except json.JSONDecodeError:
+                                    pass
+                    return
+            except urllib.error.HTTPError as e:
+                if e.code == 404 and "/v1/" in path:
+                    continue
+                err_text = e.read().decode("utf-8") if e.fp else str(e)
+                raise RuntimeError(
+                    f"SSE Error from {url} (HTTP {e.code}): {err_text}"
+                ) from e
+
+
+# ─────────────────────────────────────────────────────────────
+# 2. Main Entry Point
+# ─────────────────────────────────────────────────────────────
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="VeADK Standard Managed Agents & Sandbox Demo"
+    )
+    parser.add_argument(
+        "--base-url",
+        default=os.getenv("SANDBOX_BASE_URL", "http://127.0.0.1:8080"),
+        help="Base URL of the Managed Agents Server (default: http://127.0.0.1:8080)",
+    )
+    parser.add_argument(
+        "--agent-id",
+        default=os.getenv("SANDBOX_AGENT_ID", "agent_011CSd8hFhXGpz33bM1pBw7y"),
+        help="Managed Agent ID",
+    )
+    parser.add_argument(
+        "--env-id",
+        default=os.getenv("SANDBOX_ENVIRONMENT_ID", "env_01SLqXHseguCmohifEqeUAYu"),
+        help="Self-Hosted Environment ID",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.getenv("SANDBOX_API_KEY", "your-api-key"),
+        help="API Key for Managed Agents Server",
+    )
+    parser.add_argument(
+        "--prompt",
+        default="请在沙箱工作区 /workspace 下创建一个 quick_sort.py 文件，编写快速排序代码并运行验证。",
+        help="Task prompt for the agent",
+    )
+    args = parser.parse_args()
+
+    client = ManagedAgentsStandardClient(base_url=args.base_url, api_key=args.api_key)
+
+    print("=" * 65)
+    print("🚀 Standard Managed Agents & Self-Hosted Sandbox Execution")
+    print(f"📍 Server Base URL:        {client.base_url}")
+    print(f"🤖 Agent ID:               {args.agent_id}")
+    print(f"📦 Environment ID:         {args.env_id}")
+    print(f"💬 Prompt:                 {args.prompt}")
+    print("=" * 65)
+
+    try:
+        # Step 1: Create Session via standard API
+        print("\n⏳ 正在通过标准 API (POST /v1/sessions) 创建 Session...")
+        session = client.create_session(
+            agent_id=args.agent_id,
+            environment_id=args.env_id,
+            initial_prompt=args.prompt,
+        )
+        session_id = session.get("id", session.get("session_id"))
+        print(f"✅ Session 创建成功! Session ID: {session_id}")
+        print(
+            "   (服务端已自动将该 Session 作为 WorkItem 派发给绑定的 Self-Hosted Worker)"
+        )
+
+        # Step 2: Stream Session Events via standard SSE
+        print("\n📡 正在连接标准 SSE 事件流 (GET /v1/sessions/:id/events/stream)...")
+        for event in client.stream_session_events(session_id):
+            event_type = event.get("type", "")
+
+            # 1. 打印 Agent 思考过程与回复
+            if event_type == "agent.message":
+                print(f"\n🤖 [Agent 回复]:\n{event.get('content', '')}")
+
+            # 2. 打印沙箱工具调用
+            elif event_type == "agent.tool_use":
+                print(
+                    f"🔧 [沙箱工具调用]: {event.get('name')} | 参数: {event.get('input')}"
+                )
+
+            # 3. 打印工具在沙箱内的执行结果
+            elif event_type == "user.tool_result" or event_type == "agent.tool_result":
+                print(f"📥 [沙箱执行回传]: {event.get('content')}")
+
+            # 4. 会话状态变化
+            elif event_type == "session.status_idle":
+                stop_reason = event.get("stop_reason", {})
+                if (
+                    isinstance(stop_reason, dict)
+                    and stop_reason.get("type") == "end_turn"
+                ):
+                    print("\n🏁 任务已全部在自建沙箱中执行完毕 (Turn Completed)！")
+                    break
+
+    except (ConnectionError, RuntimeError) as e:
+        print(f"\n⚠️ 连接或执行提示: {e}")
+        print(
+            "💡 提示: 请确保服务端（如 open-managed-agents 或 agentscope-service）以及沙箱 Worker (ant beta:worker poll) 已启动运行。"
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,11 @@ harness-sidecar = [
     "agentkit-sdk-python>=0.8.1,<0.9.0",
 ]
 cli = []
+sandbox = [
+    "anthropic>=0.40.0",
+    "python-dotenv>=1.0.0",
+    "httpx[socks]>=0.27.0",
+]
 dev = [
     "pre-commit>=4.2.0",            # Format checking
     "pytest>=8.4.1",

--- a/tests/runtime/test_dispatch_runtime_provider.py
+++ b/tests/runtime/test_dispatch_runtime_provider.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+from google.adk.tools import FunctionTool
+
+from veadk.runtime import DispatchRuntimeProvider
+
+
+def _tool_context():
+    return SimpleNamespace(
+        function_call_id="call-123",
+        _invocation_context=SimpleNamespace(session=SimpleNamespace(id="session-123")),
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_runtime_intercepts_configured_tool():
+    local_calls = []
+    dispatched_calls = []
+
+    def bash(command: str):
+        local_calls.append(command)
+        return {"source": "local"}
+
+    async def dispatch(tool_call):
+        dispatched_calls.append(tool_call)
+        return {"source": "remote", "stdout": "ok"}
+
+    provider = DispatchRuntimeProvider(dispatch, dispatchable_tools={"bash"})
+    result = await provider.before_tool_callback(
+        tool=FunctionTool(bash),
+        tool_args={"command": "echo ok"},
+        tool_context=_tool_context(),
+    )
+
+    assert result == {"source": "remote", "stdout": "ok"}
+    assert local_calls == []
+    assert len(dispatched_calls) == 1
+    assert dispatched_calls[0].name == "bash"
+    assert dispatched_calls[0].arguments == {"command": "echo ok"}
+    assert dispatched_calls[0].id == "call-123"
+    assert dispatched_calls[0].session_id == "session-123"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_runtime_falls_back_to_original_tool():
+    local_calls = []
+
+    def read_file(path: str):
+        local_calls.append(path)
+        return {"content": "local content"}
+
+    provider = DispatchRuntimeProvider(
+        lambda tool_call: {"unexpected": tool_call.name},
+        dispatchable_tools={"bash"},
+    )
+    result = await provider.before_tool_callback(
+        tool=FunctionTool(read_file),
+        tool_args={"path": "/tmp/example"},
+        tool_context=_tool_context(),
+    )
+
+    assert result == {"content": "local content"}
+    assert local_calls == ["/tmp/example"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_runtime_wraps_scalar_result():
+    def bash(command: str):
+        raise AssertionError(f"local bash must not run: {command}")
+
+    provider = DispatchRuntimeProvider(lambda tool_call: "remote output")
+    result = await provider.before_tool_callback(
+        tool=FunctionTool(bash),
+        tool_args={"command": "pwd"},
+        tool_context=_tool_context(),
+    )
+
+    assert result == {"result": "remote output"}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_all_keeps_mcp_tools_on_local_runtime():
+    local_calls = []
+    dispatched_calls = []
+
+    def call_remote_service(value: str):
+        local_calls.append(value)
+        return {"source": "mcp"}
+
+    class FakeMcpTool(FunctionTool):
+        pass
+
+    provider = DispatchRuntimeProvider(
+        lambda tool_call: dispatched_calls.append(tool_call),
+        dispatchable_tools=None,
+    )
+    result = await provider.before_tool_callback(
+        tool=FakeMcpTool(call_remote_service),
+        tool_args={"value": "hello"},
+        tool_context=_tool_context(),
+    )
+
+    assert result == {"source": "mcp"}
+    assert local_calls == ["hello"]
+    assert dispatched_calls == []

--- a/tests/runtime/test_self_host_sandbox_agent.py
+++ b/tests/runtime/test_self_host_sandbox_agent.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import importlib
+import sys
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+
+EXAMPLE_DIR = Path(__file__).parents[2] / "examples" / "16_self_host_sandbox"
+if str(EXAMPLE_DIR) not in sys.path:
+    sys.path.insert(0, str(EXAMPLE_DIR))
+
+os.environ.setdefault("ANTHROPIC_BASE_URL", "https://sandbox.example.com")
+os.environ.setdefault("ANTHROPIC_ENVIRONMENT_KEY", "test-token")
+os.environ.setdefault("MODEL_AGENT_API_KEY", "test-model-api-key")
+
+agent_module = importlib.import_module("agents.self_host_sandbox_agent.agent")
+SandboxSessionManager = agent_module.SandboxSessionManager
+
+
+class _FakeClient:
+    def __init__(self, remote_session_id: str):
+        self.session_id = None
+        self.remote_session_id = remote_session_id
+        self.created_titles = []
+        self.idle_count = 0
+
+    def create_session(self, title: str):
+        self.created_titles.append(title)
+        self.session_id = self.remote_session_id
+
+    def post_status_idle(self):
+        self.idle_count += 1
+
+
+def test_each_veadk_session_creates_a_distinct_remote_session(monkeypatch):
+    manager = SandboxSessionManager()
+    clients = iter((_FakeClient("remote-1"), _FakeClient("remote-2")))
+    monkeypatch.setattr(manager, "_new_client", lambda: next(clients))
+
+    assert manager.create_remote_session("veadk-1") == "remote-1"
+    assert manager.create_remote_session("veadk-1") == "remote-1"
+    assert manager.create_remote_session("veadk-2") == "remote-2"
+
+    assert manager.get("veadk-1") is not manager.get("veadk-2")
+    assert manager.get("veadk-1").created_titles == [
+        "VeADK Self-Hosted Sandbox Session veadk-1"
+    ]
+    assert manager.get("veadk-2").created_titles == [
+        "VeADK Self-Hosted Sandbox Session veadk-2"
+    ]
+
+
+def test_web_session_service_creation_provisions_remote_session(monkeypatch):
+    created = []
+    monkeypatch.setattr(
+        agent_module.sandbox_sessions,
+        "create_remote_session",
+        lambda session_id: created.append(session_id) or "remote-web",
+    )
+
+    asyncio.run(
+        agent_module.short_term_memory.session_service.create_session(
+            app_name="self_host_sandbox_agent",
+            user_id="user",
+            session_id="web-session",
+        )
+    )
+
+    assert created == ["web-session"]
+
+
+def test_dispatch_task_sends_only_the_model_tool_call(monkeypatch):
+    dispatched = []
+    client = SimpleNamespace(
+        dispatch_tool=lambda name, arguments, *, dispatch_id: dispatched.append(
+            (name, arguments, dispatch_id)
+        )
+        or {"stdout": "ok"}
+    )
+    monkeypatch.setattr(agent_module.sandbox_sessions, "get", lambda session_id: client)
+    tool_call = SimpleNamespace(
+        session_id="veadk-session",
+        id="tool-call-1",
+        name="bash",
+        arguments={"command": "printf ok"},
+    )
+
+    result = asyncio.run(agent_module.dispatch_task(tool_call))
+
+    assert result == {"stdout": "ok"}
+    assert dispatched == [("bash", {"command": "printf ok"}, "tool-call-1")]
+    assert not hasattr(agent_module.agent, "run_turn")

--- a/tests/runtime/test_self_host_sandbox_client.py
+++ b/tests/runtime/test_self_host_sandbox_client.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+
+CLIENT_PATH = (
+    Path(__file__).parents[2]
+    / "examples"
+    / "16_self_host_sandbox"
+    / "sandbox_client.py"
+)
+SPEC = importlib.util.spec_from_file_location("self_host_sandbox_client", CLIENT_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+SelfHostSandboxClient = MODULE.SelfHostSandboxClient
+
+
+def _client():
+    return SelfHostSandboxClient(
+        base_url="https://sandbox.example.com",
+        environment_id="env-123",
+        agent_id="agent-123",
+        session_id="session-123",
+        bearer_token="token",
+        remote_bash_tool_name="bash",
+    )
+
+
+def test_execute_command_posts_agent_tool_use_and_correlates_worker_result(
+    monkeypatch,
+):
+    client = _client()
+    posted_events = []
+    event_batches = iter(
+        [
+            [{"_seq": 10, "type": "session.status_idle"}],
+            [
+                {
+                    "_seq": 11,
+                    "type": "agent.tool_use",
+                    "id": "call-123",
+                    "name": "bash",
+                    "input": {"command": "echo hello", "timeout": 5000},
+                },
+                {
+                    "_seq": 12,
+                    "type": "user.tool_result",
+                    "tool_use_id": "call-123",
+                    "content": "exit=0\nhello\n",
+                    "is_error": False,
+                },
+            ],
+        ]
+    )
+
+    monkeypatch.setattr(client, "list_events", lambda **kwargs: next(event_batches))
+    monkeypatch.setattr(
+        client,
+        "post_events",
+        lambda events: posted_events.extend(events) or {"status": "accepted"},
+    )
+
+    result = client.execute_command(
+        "echo hello",
+        timeout=5,
+        dispatch_id="call-123",
+    )
+
+    assert posted_events == [
+        {
+            "type": "agent.tool_use",
+            "id": "call-123",
+            "name": "bash",
+            "input": {
+                "command": "echo hello",
+                "timeout_ms": 5000,
+                "timeout": 5000,
+            },
+        }
+    ]
+    assert result == {
+        "dispatch_id": "call-123",
+        "tool_use_id": "call-123",
+        "environment_id": "env-123",
+        "session_id": "session-123",
+        "status": "completed",
+        "exit_code": 0,
+        "stdout": "hello\n",
+        "stderr": "",
+    }
+
+
+def test_send_tool_result_uses_payload_shape(monkeypatch):
+    client = _client()
+    posted_events = []
+    monkeypatch.setattr(
+        client,
+        "post_events",
+        lambda events: posted_events.extend(events) or {"status": "accepted"},
+    )
+
+    client.send_tool_result("tool-123", "done")
+
+    assert posted_events == [
+        {
+            "type": "user.tool_result",
+            "tool_use_id": "tool-123",
+            "content": [{"type": "text", "text": "done"}],
+            "is_error": False,
+        }
+    ]
+
+
+def test_file_tools_are_converted_to_working_bash_commands(tmp_path):
+    client = _client()
+    target = tmp_path / "nested" / "example.txt"
+
+    write_command, _ = client._tool_to_bash(
+        "write_file",
+        {"file_path": str(target), "content": "alpha\nbeta\n"},
+    )
+    subprocess.run(write_command, shell=True, check=True)
+    assert target.read_text() == "alpha\nbeta\n"
+
+    edit_command, _ = client._tool_to_bash(
+        "edit_file",
+        {
+            "file_path": str(target),
+            "old_string": "beta",
+            "new_string": "gamma",
+        },
+    )
+    subprocess.run(edit_command, shell=True, check=True)
+    assert target.read_text() == "alpha\ngamma\n"
+
+    read_command, _ = client._tool_to_bash(
+        "read_file",
+        {"file_path": str(target), "offset": 2, "limit": 1},
+    )
+    result = subprocess.run(
+        read_command,
+        shell=True,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout == "2\tgamma\n"
+
+
+def test_non_mcp_tools_are_mapped_to_bash_and_unknown_tools_fail():
+    client = _client()
+
+    list_command, _ = client._tool_to_bash(
+        "list_files", {"path": "/workspace", "max_depth": 2}
+    )
+    search_command, _ = client._tool_to_bash(
+        "search_files", {"pattern": "needle", "glob": "*.py"}
+    )
+    python_command, _ = client._tool_to_bash(
+        "python", {"code": "print('ok')", "workdir": "/workspace"}
+    )
+
+    assert list_command.startswith("find /workspace")
+    assert "command -v rg" in search_command
+    assert "python3 -c" in python_command
+
+    try:
+        client._tool_to_bash("unknown_tool", {})
+    except ValueError as error:
+        assert "add an explicit bash adapter" in str(error)
+    else:
+        raise AssertionError("unknown non-MCP tools must fail closed")

--- a/tests/test_short_term_memory.py
+++ b/tests/test_short_term_memory.py
@@ -15,6 +15,8 @@
 import asyncio
 import os
 
+import pytest
+
 from veadk.memory.short_term_memory import ShortTermMemory
 from veadk.utils.misc import formatted_timestamp
 
@@ -52,3 +54,60 @@ def test_short_term_memory():
     assert session is not None
     assert os.path.exists(memory.local_database_path)
     os.remove(memory.local_database_path)
+
+
+def test_after_create_session_callback_only_runs_for_new_session():
+    created_session_ids = []
+
+    def after_create_session(session):
+        created_session_ids.append(session.id)
+
+    memory = ShortTermMemory(
+        backend="local",
+        after_create_session_callback=after_create_session,
+    )
+
+    first_session = asyncio.run(
+        memory.create_session(app_name="app", user_id="user", session_id="session")
+    )
+    second_session = asyncio.run(
+        memory.create_session(app_name="app", user_id="user", session_id="session")
+    )
+
+    assert first_session is not None
+    assert second_session is not None
+    assert created_session_ids == ["session"]
+
+
+def test_after_create_session_callback_supports_async_callback():
+    created_session_ids = []
+
+    async def after_create_session(session):
+        await asyncio.sleep(0)
+        created_session_ids.append(session.id)
+
+    memory = ShortTermMemory(
+        backend="local",
+        after_create_session_callback=after_create_session,
+    )
+
+    asyncio.run(
+        memory.create_session(app_name="app", user_id="user", session_id="session")
+    )
+
+    assert created_session_ids == ["session"]
+
+
+def test_after_create_session_callback_error_is_propagated():
+    def after_create_session(_session):
+        raise RuntimeError("callback failed")
+
+    memory = ShortTermMemory(
+        backend="local",
+        after_create_session_callback=after_create_session,
+    )
+
+    with pytest.raises(RuntimeError, match="callback failed"):
+        asyncio.run(
+            memory.create_session(app_name="app", user_id="user", session_id="session")
+        )

--- a/veadk/memory/short_term_memory.py
+++ b/veadk/memory/short_term_memory.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
@@ -74,6 +75,10 @@ class ShortTermMemory(BaseModel):
             Default to `/tmp/veadk_local_database.db`.
         after_load_memory_callback (Callable | None):
             A callback to be called after loading memory from the backend. The callback function should accept `Session` as an input.
+        after_create_session_callback (Callable | None):
+            A callback to be called after a new session is created. The callback
+            function should accept `Session` as an input and may be synchronous or
+            asynchronous. It is not called when an existing session is reused.
     """
 
     backend: Literal["local", "mysql", "sqlite", "postgresql", "database"] = "local"
@@ -87,6 +92,8 @@ class ShortTermMemory(BaseModel):
     local_database_path: str = "/tmp/veadk_local_database.db"
 
     after_load_memory_callback: Callable | None = None
+
+    after_create_session_callback: Callable | None = None
 
     _session_service: BaseSessionService = PrivateAttr()
 
@@ -174,9 +181,14 @@ class ShortTermMemory(BaseModel):
             )
             return session
         else:
-            return await self._session_service.create_session(
+            session = await self._session_service.create_session(
                 app_name=app_name, user_id=user_id, session_id=session_id
             )
+            if session and self.after_create_session_callback:
+                callback_result = self.after_create_session_callback(session)
+                if inspect.isawaitable(callback_result):
+                    await callback_result
+            return session
 
     async def generate_profile(
         self,

--- a/veadk/runtime/__init__.py
+++ b/veadk/runtime/__init__.py
@@ -27,6 +27,10 @@ from __future__ import annotations
 from functools import lru_cache
 
 from veadk.runtime.base_runtime import BaseRuntime
+from veadk.runtime.provider import DispatchRuntimeProvider
+from veadk.runtime.provider import LocalRuntimeProvider
+from veadk.runtime.provider import RuntimeProvider
+from veadk.runtime.provider import ToolCall
 
 
 @lru_cache(maxsize=None)
@@ -64,4 +68,11 @@ def get_runtime(name: str) -> BaseRuntime:
     raise ValueError(f"Unknown runtime: {name!r}")
 
 
-__all__ = ["BaseRuntime", "get_runtime"]
+__all__ = [
+    "BaseRuntime",
+    "DispatchRuntimeProvider",
+    "LocalRuntimeProvider",
+    "RuntimeProvider",
+    "ToolCall",
+    "get_runtime",
+]

--- a/veadk/runtime/provider.py
+++ b/veadk/runtime/provider.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pluggable routing for individual tool executions.
+
+Agent runtimes replace an agent's complete reasoning loop. Runtime providers
+operate at a narrower layer: they decide where each tool call executes while
+the Google ADK agent loop remains unchanged.
+"""
+
+from __future__ import annotations
+
+import inspect
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable, Collection
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from google.adk.plugins import BasePlugin
+
+if TYPE_CHECKING:
+    from google.adk.tools.base_tool import BaseTool
+    from google.adk.tools.tool_context import ToolContext
+
+
+@dataclass(slots=True)
+class ToolCall:
+    """One ADK tool invocation routed through a :class:`RuntimeProvider`."""
+
+    name: str
+    arguments: dict[str, Any]
+    tool: "BaseTool"
+    context: "ToolContext"
+
+    @property
+    def id(self) -> str:
+        """Return the ADK function-call identifier when available."""
+        return str(getattr(self.context, "function_call_id", "") or "")
+
+    @property
+    def session_id(self) -> str:
+        """Return the current VeADK session identifier when available."""
+        invocation = getattr(self.context, "_invocation_context", None)
+        session = getattr(invocation, "session", None)
+        return str(getattr(session, "id", "") or "")
+
+
+class RuntimeProvider(BasePlugin, ABC):
+    """ADK plugin that routes every tool call through ``execute``.
+
+    Returning a response from ``before_tool_callback`` prevents Google ADK
+    from invoking the original tool a second time. Subclasses may therefore
+    execute locally, dispatch remotely, or combine both strategies.
+    """
+
+    def __init__(self, *, name: str) -> None:
+        super().__init__(name=name)
+
+    @abstractmethod
+    async def execute(self, tool_call: ToolCall) -> Any:
+        """Execute one tool call and return its result."""
+        raise NotImplementedError
+
+    async def before_tool_callback(
+        self,
+        *,
+        tool: "BaseTool",
+        tool_args: dict[str, Any] | None = None,
+        args: dict[str, Any] | None = None,
+        tool_context: "ToolContext",
+    ) -> dict[str, Any]:
+        """Route the call before ADK invokes the tool implementation.
+
+        ADK plugin callbacks pass tool arguments as ``tool_args``, while
+        canonical agent callbacks pass the same value as ``args``. Runtime
+        providers support both callback paths.
+        """
+        if tool_args is not None and args is not None and tool_args != args:
+            raise ValueError("tool_args and args must match when both are provided")
+        resolved_args = tool_args if tool_args is not None else (args or {})
+        result = await self.execute(
+            ToolCall(
+                name=tool.name,
+                arguments=resolved_args,
+                tool=tool,
+                context=tool_context,
+            )
+        )
+        if isinstance(result, dict):
+            return result
+        return {"result": result}
+
+
+class LocalRuntimeProvider(RuntimeProvider):
+    """Execute tools through their original ADK implementation."""
+
+    def __init__(self, *, name: str = "veadk_local_runtime_provider") -> None:
+        super().__init__(name=name)
+
+    async def execute(self, tool_call: ToolCall) -> Any:
+        return await tool_call.tool.run_async(
+            args=tool_call.arguments,
+            tool_context=tool_call.context,
+        )
+
+
+DispatchCallable = Callable[[ToolCall], Any | Awaitable[Any]]
+
+
+def _is_mcp_tool(tool: "BaseTool") -> bool:
+    """Return whether a resolved ADK tool is backed by MCP."""
+    tool_type = type(tool)
+    module_name = tool_type.__module__.lower()
+    type_name = tool_type.__name__.lower()
+    return (
+        ".mcp_tool" in module_name
+        or "mcptool" in type_name
+        or hasattr(tool, "_mcp_tool")
+        or hasattr(tool, "_mcp_session_manager")
+    )
+
+
+class DispatchRuntimeProvider(RuntimeProvider):
+    """Dispatch selected tools remotely and execute all others locally.
+
+    Pass ``dispatchable_tools=None`` to dispatch every non-MCP tool. Resolved
+    MCP tools always retain their original ADK implementation.
+    """
+
+    def __init__(
+        self,
+        dispatch_task: DispatchCallable,
+        *,
+        dispatchable_tools: Collection[str] | None = ("bash",),
+        local_runtime: RuntimeProvider | None = None,
+        name: str = "veadk_dispatch_runtime_provider",
+    ) -> None:
+        super().__init__(name=name)
+        self.dispatch_task = dispatch_task
+        self.dispatchable_tools = (
+            None if dispatchable_tools is None else frozenset(dispatchable_tools)
+        )
+        self.local_runtime = local_runtime or LocalRuntimeProvider()
+
+    async def execute(self, tool_call: ToolCall) -> Any:
+        dispatch_all = self.dispatchable_tools is None
+        should_dispatch = dispatch_all or tool_call.name in self.dispatchable_tools
+        if should_dispatch and not _is_mcp_tool(tool_call.tool):
+            result = self.dispatch_task(tool_call)
+            if inspect.isawaitable(result):
+                return await result
+            return result
+        return await self.local_runtime.execute(tool_call)
+
+
+__all__ = [
+    "DispatchCallable",
+    "DispatchRuntimeProvider",
+    "LocalRuntimeProvider",
+    "RuntimeProvider",
+    "ToolCall",
+]


### PR DESCRIPTION
## Overview

This PR introduces support for self-hosted sandbox environments in VeADK and provides a complete, production-ready Kubernetes & Docker example (`examples/16_self_host_sandbox`).

In this architecture, the conversation and LLM reasoning loop run locally/in VeADK (`veadk web` or CLI), while tool execution (`agent.tool_use` events) is dispatched remotely to a self-hosted Sandbox Runtime (such as TAE Tool session).

---

## Key Changes

### 1. Core Runtime & Memory Enhancements
- **Dispatch Runtime Provider**: Added `DispatchRuntimeProvider` in `veadk/runtime/provider.py` to intercept tool calls, dispatch them to the remote runtime environment, wait for execution results, and feed them back to the local agent loop.
- **Short-Term Memory Session Hook**: Updated `veadk/memory/short_term_memory.py` with `after_create_session_callback` to support automatic 1:1 mapping between VeADK local sessions and remote Managed Sessions.

### 2. Complete Example & Deployment Assets (`examples/16_self_host_sandbox`)
- **Interactive Agent (`agent.py`, `main.py`, `sandbox_client.py`)**: Full implementation demonstrating session binding and remote tool execution.
- **Deployment Configurations**:
  - `Dockerfile` & `.dockerignore`: Container packaging with repo root build context.
  - `k8s.yaml`: Complete Kubernetes manifests (Deployment, Service, Ingress) with secret-based runtime configuration injection.
  - `run.sh` / `.env.example`: Convenient helper scripts for both Web UI (`veadk web`) and CLI modes.
- **Comprehensive Documentation**: Added both English (`README.md`) and Chinese (`README.zh.md`) guides detailing architecture, local startup, Docker/K8s deployment, and verification steps.

### 3. Tests & Documentation
- Added unit and integration tests:
  - `tests/runtime/test_dispatch_runtime_provider.py`
  - `tests/runtime/test_self_host_sandbox_agent.py`
  - `tests/runtime/test_self_host_sandbox_client.py`
  - `tests/test_short_term_memory.py`
- Updated documentation pages for Agent Runtime and Short-Term Memory under `docs/content/docs/framework/`.

---

## Verification & Testing

- Verified dispatch tests with `pytest`:
  ```bash
  uv sync --group dev --extra sandbox
  uv run pytest -q tests/runtime/test_self_host_sandbox_client.py tests/runtime/test_self_host_sandbox_agent.py
  ```
- Tested both Web UI mode (`veadk web --port 8067`) and CLI mode.