### PR TITLE
Support non-ADK agent transfer

### DIFF
--- a/tests/runtime/codex/test_codex_runtime.py
+++ b/tests/runtime/codex/test_codex_runtime.py
@@ -39,10 +39,12 @@ from fastapi.openapi.models import APIKey
 from fastapi.openapi.models import APIKeyIn
 
 from veadk.runtime.base_runtime import resolve_system_append
+from veadk.runtime.agent_transfer import build_transfer_tool
 from veadk.runtime.codex.config import CodexRuntimeConfig
 from veadk.runtime.codex.config import codex_subprocess_env
 from veadk.runtime.codex.config import toml_string
 from veadk.runtime.codex.proxy import ResponsesShim
+from veadk.runtime.codex.tools_bridge import add_tool_to_bundle
 from veadk.runtime.codex.tools_bridge import build_executable_tools
 from veadk.runtime.codex.tools_bridge import close_toolsets
 from veadk.runtime.codex.tools_bridge import resume_authenticated_tools
@@ -729,6 +731,44 @@ async def test_tool_executor_supports_stdio_mcp_toolset() -> None:
 
 
 @pytest.mark.asyncio
+async def test_transfer_tool_executor_emits_adk_transfer_action() -> None:
+    worker = LlmAgent(name="worker", model="gemini-2.5-flash")
+    agent = LlmAgent(
+        name="agent",
+        model="gemini-2.5-flash",
+        sub_agents=[worker],
+    )
+    ctx = _ctx(agent)
+    emitted: list[Event] = []
+
+    async def emit(event: Event) -> None:
+        emitted.append(event)
+
+    bundle = await build_executable_tools(agent, ctx, event_sink=emit)
+    try:
+        add_tool_to_bundle(
+            bundle,
+            build_transfer_tool([worker]),
+            ctx,
+            event_sink=emit,
+        )
+        output = json.loads(
+            await bundle.executors["transfer_to_agent"](
+                {"agent_name": "worker"}, "call-transfer"
+            )
+        )
+    finally:
+        await close_toolsets(bundle.opened_toolsets)
+
+    assert output["status"] == "transferred"
+    assert output["agent_name"] == "worker"
+    assert bundle.specs[0]["parameters"]["properties"]["agent_name"]["enum"] == [
+        "worker"
+    ]
+    assert any(event.actions.transfer_to_agent == "worker" for event in emitted)
+
+
+@pytest.mark.asyncio
 async def test_shim_routes_concurrent_turns_to_their_own_executors(
     monkeypatch,
 ) -> None:
@@ -825,6 +865,67 @@ async def test_shim_rejects_unknown_invocation_token() -> None:
             json={"model": "model", "input": []},
         )
     assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_shim_completes_turn_after_transfer_without_second_model_call(
+    monkeypatch,
+) -> None:
+    shim = ResponsesShim("https://backend.invalid/v1", "backend-key")
+    backend_calls = 0
+
+    async def executor(args, call_id):
+        return json.dumps(
+            {
+                "status": "transferred",
+                "call_id": call_id,
+                "agent_name": args["agent_name"],
+            }
+        )
+
+    token = shim.register_turn(
+        [{"type": "function", "name": "transfer_to_agent", "parameters": {}}],
+        {"transfer_to_agent": executor},
+    )
+
+    async def fake_aresponses(**kwargs):
+        nonlocal backend_calls
+        backend_calls += 1
+        assert not any(
+            item.get("type") == "function_call_output" for item in kwargs["input"]
+        )
+        return {
+            "id": "transfer-response",
+            "model": "model",
+            "output": [
+                {
+                    "id": "fc-transfer",
+                    "call_id": "call-transfer",
+                    "type": "function_call",
+                    "name": "transfer_to_agent",
+                    "arguments": json.dumps({"agent_name": "worker"}),
+                    "status": "completed",
+                }
+            ],
+        }
+
+    monkeypatch.setattr("veadk.runtime.codex.proxy.litellm.aresponses", fake_aresponses)
+    transport = httpx.ASGITransport(app=shim._app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://shim") as client:
+        response = await client.post(
+            "/v1/responses",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "model": "model",
+                "input": [{"type": "message", "role": "user", "content": "go"}],
+            },
+        )
+
+    assert response.status_code == 200
+    assert backend_calls == 1
+    body = response.json()
+    assert body["status"] == "completed"
+    assert body["output"][0]["type"] == "message"
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/piagent/test_piagent_runtime.py
+++ b/tests/runtime/piagent/test_piagent_runtime.py
@@ -28,6 +28,7 @@ from google.adk.models.llm_response import LlmResponse
 from google.adk.tools.base_tool import BaseTool
 from google.adk.tools.base_toolset import BaseToolset
 from google.adk.tools.function_tool import FunctionTool
+from google.adk.tools.tool_context import ToolContext
 from google.genai import types
 
 from veadk import Agent
@@ -73,6 +74,8 @@ def _fake_ctx(*events: Event):
     return SimpleNamespace(
         invocation_id="inv-1",
         session=SimpleNamespace(events=list(events), state={}),
+        branch=None,
+        plugin_manager=None,
     )
 
 
@@ -230,6 +233,74 @@ for raw in sys.stdin:
     return path, prompt_path
 
 
+def _make_fake_pi_that_calls_bridge(tmp_path, *, tool_name: str = "get_weather"):
+    path = tmp_path / "pi"
+    path.write_text(
+        f"""#!/usr/bin/env python3
+import json
+import re
+import sys
+import urllib.request
+
+extension = sys.argv[sys.argv.index("--extension") + 1]
+source = open(extension, encoding="utf-8").read()
+bridge_url = json.loads(re.search(r'const BRIDGE_URL = (.*?);', source).group(1))
+token = json.loads(re.search(r'const TOKEN = (.*?);', source).group(1))
+
+for raw in sys.stdin:
+    command = json.loads(raw)
+    if command.get("type") == "prompt":
+        print(json.dumps({{
+            "id": command.get("id"),
+            "type": "response",
+            "command": "prompt",
+            "success": True,
+        }}), flush=True)
+        print(json.dumps({{
+            "type": "tool_execution_start",
+            "toolCallId": "call-weather",
+            "toolName": {tool_name!r},
+            "args": {{"city": "Beijing"}},
+        }}), flush=True)
+        body = json.dumps({{
+            "toolName": {tool_name!r},
+            "toolCallId": "call-weather",
+            "args": {{"city": "Beijing"}},
+        }}).encode()
+        request = urllib.request.Request(
+            bridge_url + "/call",
+            data=body,
+            headers={{
+                "Authorization": "Bearer " + token,
+                "Content-Type": "application/json",
+            }},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=5) as response:
+            payload = json.loads(response.read().decode())
+        print(json.dumps({{
+            "type": "tool_execution_end",
+            "toolCallId": "call-weather",
+            "toolName": {tool_name!r},
+            "result": payload["result"],
+            "isError": False,
+        }}), flush=True)
+        print(json.dumps({{
+            "type": "message_update",
+            "assistantMessageEvent": {{
+                "type": "text_delta",
+                "delta": "done",
+            }},
+        }}), flush=True)
+        print(json.dumps({{"type": "agent_settled"}}), flush=True)
+        break
+""",
+        encoding="utf-8",
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
 def _write_skill(path: Path, *, name: str, body: str = "Skill body.") -> None:
     path.mkdir(parents=True, exist_ok=True)
     (path / "SKILL.md").write_text(
@@ -292,12 +363,8 @@ def test_build_prompt_skips_thought_parts():
         _user_event("follow up"),
     )
 
-    assert build_prompt(ctx) == "\n".join(
-        [
-            "User: hello",
-            "Assistant: visible answer",
-            "User: follow up",
-        ]
+    assert (
+        build_prompt(ctx) == "User: hello\nAssistant: visible answer\nUser: follow up"
     )
 
 
@@ -606,6 +673,60 @@ def test_pi_event_translator_native_tool_update():
     function_response = response.content.parts[0].function_response
     assert function_response.name == "bash"
     assert function_response.response["result"]["content"] == "line 1\nline 2"
+
+
+def test_pi_event_translator_suppresses_bridged_tool_events():
+    translator = PiEventTranslator(
+        author="agent",
+        invocation_id="inv-1",
+        bridged_tool_names={"get_weather"},
+    )
+
+    assert (
+        translator.event_to_adk_events(
+            {
+                "type": "tool_execution_start",
+                "toolCallId": "call-1",
+                "toolName": "get_weather",
+                "args": {"city": "Beijing"},
+            }
+        )
+        == []
+    )
+    assert (
+        translator.event_to_adk_events(
+            {
+                "type": "tool_execution_update",
+                "toolCallId": "call-1",
+                "toolName": "get_weather",
+                "partialResult": {"stdout": "ignored"},
+            }
+        )
+        == []
+    )
+    assert (
+        translator.event_to_adk_events(
+            {
+                "type": "tool_execution_end",
+                "toolCallId": "call-1",
+                "toolName": "get_weather",
+                "result": {"content": [{"type": "text", "text": "ignored"}]},
+                "isError": False,
+            }
+        )
+        == []
+    )
+
+    native_call = translator.event_to_adk_events(
+        {
+            "type": "tool_execution_start",
+            "toolCallId": "call-2",
+            "toolName": "bash",
+            "args": {"command": "pwd"},
+        }
+    )
+
+    assert native_call[0].content.parts[0].function_call.name == "bash"
 
 
 def test_model_config_uses_custom_provider():
@@ -1070,6 +1191,59 @@ async def test_build_executable_tools_prefixes_pi_reserved_names():
     assert output["name"] == "read"
 
 
+@pytest.mark.asyncio
+async def test_build_executable_tools_runs_adk_tool_lifecycle_callbacks():
+    callback_order: list[str] = []
+    emitted: list[Event] = []
+
+    def get_weather(city: str, tool_context: ToolContext) -> dict[str, str]:
+        """Get weather.
+
+        Args:
+            city: City name.
+        """
+        callback_order.append("tool")
+        tool_context.state["weather_city"] = city
+        return {"weather": f"sunny in {city}"}
+
+    async def before_tool_callback(tool, args, tool_context):
+        callback_order.append("before")
+
+    async def after_tool_callback(tool, args, tool_context, tool_response):
+        callback_order.append("after")
+        return {"weather": "patched"}
+
+    agent = Agent(
+        name="assistant",
+        instruction="Answer briefly.",
+        model_name="model-a",
+        model_api_base="https://ark.example.com/api/v3/",
+        model_api_key="test-key",
+        model_api_key_name="",
+        runtime="piagent",
+        tools=[get_weather],
+        before_tool_callback=before_tool_callback,
+        after_tool_callback=after_tool_callback,
+    )
+    ctx = _fake_ctx(_user_event("hi"))
+
+    async def sink(event: Event) -> None:
+        emitted.append(event)
+
+    bundle = await build_executable_tools(agent, ctx, event_sink=sink)
+    output = await bundle.executors["get_weather"](
+        {"city": "Beijing"},
+        "call-weather",
+    )
+
+    assert output == {"weather": "patched"}
+    assert callback_order == ["before", "tool", "after"]
+    assert len(emitted) == 2
+    assert emitted[0].get_function_calls()[0].id == "call-weather"
+    assert emitted[1].actions.state_delta == {"weather_city": "Beijing"}
+    assert emitted[1].get_function_responses()[0].id == "call-weather"
+
+
 def test_render_extension_uses_pi_tool_shape():
     spec = PiToolSpec(
         name="get_weather",
@@ -1094,7 +1268,8 @@ def test_render_extension_uses_pi_tool_shape():
 
 @pytest.mark.asyncio
 async def test_pi_tool_runtime_serves_executor_call():
-    async def executor(args):
+    async def executor(args, call_id):
+        assert call_id == "call-1"
         return {"echo": args["value"]}
 
     bundle = PiToolBundle(
@@ -1199,6 +1374,116 @@ async def test_piagent_runtime_text_only_end_to_end(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_piagent_runtime_emits_canonical_bridge_tool_events(
+    tmp_path,
+    monkeypatch,
+):
+    def get_weather(city: str) -> dict[str, str]:
+        """Get weather.
+
+        Args:
+            city: City name.
+        """
+        return {"weather": f"sunny in {city}"}
+
+    binary = _make_fake_pi_that_calls_bridge(tmp_path)
+    agent_dir = tmp_path / "agent-home"
+    monkeypatch.setenv("PIAGENT_BINARY", str(binary))
+    monkeypatch.setenv("PIAGENT_AGENT_DIR", str(agent_dir))
+
+    agent = Agent(
+        name="assistant",
+        instruction="Answer briefly.",
+        model_name="model-a",
+        model_api_base="https://ark.example.com/api/v3/",
+        model_api_key="test-key",
+        model_api_key_name="",
+        runtime="piagent",
+        tools=[get_weather],
+    )
+    ctx = _fake_ctx(_user_event("ping"))
+
+    events = [event async for event in PiAgentRuntime().run_async(agent, ctx)]
+    function_calls = [
+        part.function_call
+        for event in events
+        for part in event.content.parts
+        if part.function_call
+    ]
+    function_responses = [
+        part.function_response
+        for event in events
+        for part in event.content.parts
+        if part.function_response
+    ]
+
+    assert [call.name for call in function_calls] == ["get_weather"]
+    assert function_calls[0].id == "call-weather"
+    assert function_calls[0].args == {"city": "Beijing"}
+    assert [response.name for response in function_responses] == ["get_weather"]
+    assert function_responses[0].id == "call-weather"
+    assert function_responses[0].response == {"weather": "sunny in Beijing"}
+    assert [
+        part.text for event in events for part in event.content.parts if part.text
+    ] == [
+        "done",
+        "done",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_piagent_runtime_exposes_before_model_added_tools(
+    tmp_path,
+    monkeypatch,
+):
+    def get_weather(city: str) -> dict[str, str]:
+        """Get weather.
+
+        Args:
+            city: City name.
+        """
+        return {"weather": f"sunny in {city}"}
+
+    def before_model_callback(callback_context, llm_request):
+        llm_request.tools_dict["get_weather"] = FunctionTool(get_weather)
+
+    binary = _make_fake_pi_that_calls_bridge(tmp_path)
+    agent_dir = tmp_path / "agent-home"
+    monkeypatch.setenv("PIAGENT_BINARY", str(binary))
+    monkeypatch.setenv("PIAGENT_AGENT_DIR", str(agent_dir))
+
+    agent = Agent(
+        name="assistant",
+        instruction="Answer briefly.",
+        model_name="model-a",
+        model_api_base="https://ark.example.com/api/v3/",
+        model_api_key="test-key",
+        model_api_key_name="",
+        runtime="piagent",
+        before_model_callback=before_model_callback,
+    )
+    ctx = _fake_ctx(_user_event("ping"))
+
+    events = [event async for event in PiAgentRuntime().run_async(agent, ctx)]
+    function_calls = [
+        part.function_call
+        for event in events
+        for part in event.content.parts
+        if part.function_call
+    ]
+    function_responses = [
+        part.function_response
+        for event in events
+        for part in event.content.parts
+        if part.function_response
+    ]
+
+    assert [call.name for call in function_calls] == ["get_weather"]
+    assert [response.name for response in function_responses] == ["get_weather"]
+    assert function_responses[0].response == {"weather": "sunny in Beijing"}
+
+
+@pytest.mark.asyncio
 async def test_piagent_runtime_closes_opened_toolsets(tmp_path, monkeypatch):
     def get_weather(city: str) -> dict[str, str]:
         """Get weather.
@@ -1236,6 +1521,46 @@ async def test_piagent_runtime_closes_opened_toolsets(tmp_path, monkeypatch):
     assert events[2].partial is not True
     assert [part.text for part in events[2].content.parts] == ["checking", "pong"]
     assert toolset.closed is True
+
+
+@pytest.mark.asyncio
+async def test_piagent_runtime_syncs_tools_after_before_model_callback(
+    tmp_path,
+    monkeypatch,
+):
+    def get_weather(city: str) -> dict[str, str]:
+        """Get weather.
+
+        Args:
+            city: City name.
+        """
+        return {"weather": f"sunny in {city}"}
+
+    def before_model_callback(callback_context, llm_request):
+        llm_request.tools_dict.clear()
+
+    binary, argv_path = _make_fake_pi_with_argv_capture(tmp_path)
+    agent_dir = tmp_path / "agent-home"
+    monkeypatch.setenv("PIAGENT_BINARY", str(binary))
+    monkeypatch.setenv("PIAGENT_AGENT_DIR", str(agent_dir))
+
+    agent = Agent(
+        name="assistant",
+        instruction="Answer briefly.",
+        model_name="model-a",
+        model_api_base="https://ark.example.com/api/v3/",
+        model_api_key="test-key",
+        model_api_key_name="",
+        runtime="piagent",
+        tools=[get_weather],
+        before_model_callback=before_model_callback,
+    )
+    ctx = _fake_ctx(_user_event("ping"))
+
+    _events = [event async for event in PiAgentRuntime().run_async(agent, ctx)]
+
+    argv = json.loads(argv_path.read_text(encoding="utf-8"))
+    assert "--extension" not in argv
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/piagent/test_piagent_runtime.py
+++ b/tests/runtime/piagent/test_piagent_runtime.py
@@ -19,12 +19,17 @@ import json
 import stat
 import sys
 import tarfile
+from collections.abc import AsyncGenerator
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from google.adk.agents.base_agent import BaseAgent
+from google.adk.agents.invocation_context import InvocationContext
 from google.adk.events.event import Event
 from google.adk.models.llm_response import LlmResponse
+from google.adk.sessions.in_memory_session_service import InMemorySessionService
+from google.adk.sessions.session import Session
 from google.adk.tools.base_tool import BaseTool
 from google.adk.tools.base_toolset import BaseToolset
 from google.adk.tools.function_tool import FunctionTool
@@ -33,6 +38,7 @@ from google.genai import types
 
 from veadk import Agent
 from veadk.runtime import get_runtime
+from veadk.runtime.agent_transfer import build_transfer_tool
 from veadk.runtime.piagent import installer
 from veadk.runtime.piagent.client import PiAgentRpcClient
 from veadk.runtime.piagent.config import PiAgentConfig, PiAgentModelConfig
@@ -46,6 +52,7 @@ from veadk.runtime.piagent.tool_runtime import PiToolRuntime, render_extension
 from veadk.runtime.piagent.tools_bridge import (
     PiToolBundle,
     PiToolSpec,
+    add_tool_to_bundle,
     build_executable_tools,
     close_toolsets,
 )
@@ -76,6 +83,22 @@ def _fake_ctx(*events: Event):
         session=SimpleNamespace(events=list(events), state={}),
         branch=None,
         plugin_manager=None,
+    )
+
+
+def _ctx(agent, *events: Event, user_content=None) -> InvocationContext:
+    return InvocationContext(
+        session_service=InMemorySessionService(),
+        invocation_id="inv-1",
+        agent=agent,
+        user_content=user_content,
+        session=Session(
+            id="session-1",
+            appName="app",
+            userId="user",
+            state={},
+            events=list(events),
+        ),
     )
 
 
@@ -119,6 +142,23 @@ class _NamedTool(BaseTool):
 
     async def run_async(self, *, args, tool_context):
         return {"name": self.name, "args": args}
+
+
+class _TextAgent(BaseAgent):
+    marker: str
+
+    async def _run_async_impl(
+        self,
+        ctx: InvocationContext,
+    ) -> AsyncGenerator[Event, None]:
+        yield Event(
+            invocation_id=ctx.invocation_id,
+            author=self.name,
+            content=types.Content(
+                role="model",
+                parts=[types.Part(text=self.marker)],
+            ),
+        )
 
 
 def _make_fake_pi(tmp_path):
@@ -233,8 +273,16 @@ for raw in sys.stdin:
     return path, prompt_path
 
 
-def _make_fake_pi_that_calls_bridge(tmp_path, *, tool_name: str = "get_weather"):
+def _make_fake_pi_that_calls_bridge(
+    tmp_path,
+    *,
+    tool_name: str = "get_weather",
+    tool_args: dict | None = None,
+    text_after_tool: str = "done",
+):
     path = tmp_path / "pi"
+    tool_args = tool_args or {"city": "Beijing"}
+    tool_args_json = json.dumps(tool_args)
     path.write_text(
         f"""#!/usr/bin/env python3
 import json
@@ -260,12 +308,12 @@ for raw in sys.stdin:
             "type": "tool_execution_start",
             "toolCallId": "call-weather",
             "toolName": {tool_name!r},
-            "args": {{"city": "Beijing"}},
+            "args": {tool_args_json},
         }}), flush=True)
         body = json.dumps({{
             "toolName": {tool_name!r},
             "toolCallId": "call-weather",
-            "args": {{"city": "Beijing"}},
+            "args": {tool_args_json},
         }}).encode()
         request = urllib.request.Request(
             bridge_url + "/call",
@@ -288,9 +336,9 @@ for raw in sys.stdin:
         print(json.dumps({{
             "type": "message_update",
             "assistantMessageEvent": {{
-                "type": "text_delta",
-                "delta": "done",
-            }},
+            "type": "text_delta",
+            "delta": {text_after_tool!r},
+        }},
         }}), flush=True)
         print(json.dumps({{"type": "agent_settled"}}), flush=True)
         break
@@ -1244,6 +1292,47 @@ async def test_build_executable_tools_runs_adk_tool_lifecycle_callbacks():
     assert emitted[1].get_function_responses()[0].id == "call-weather"
 
 
+@pytest.mark.asyncio
+async def test_transfer_tool_executor_emits_adk_transfer_action():
+    worker = _TextAgent(name="worker", marker="worker handled it")
+    agent = Agent(
+        name="assistant",
+        instruction="Route to workers when appropriate.",
+        model_name="model-a",
+        model_api_base="https://ark.example.com/api/v3/",
+        model_api_key="test-key",
+        model_api_key_name="",
+        runtime="piagent",
+        sub_agents=[worker],
+    )
+    ctx = _ctx(agent)
+    emitted: list[Event] = []
+
+    async def emit(event: Event) -> None:
+        emitted.append(event)
+
+    bundle = await build_executable_tools(agent, ctx, event_sink=emit)
+    add_tool_to_bundle(
+        bundle,
+        build_transfer_tool([worker]),
+        ctx,
+        seen={spec.name for spec in bundle.specs},
+        event_sink=emit,
+    )
+
+    output = await bundle.executors["transfer_to_agent"](
+        {"agent_name": "worker"},
+        "call-transfer",
+    )
+
+    assert output["status"] == "transferred"
+    assert output["agent_name"] == "worker"
+    assert bundle.specs[0].parameters["properties"]["agent_name"]["enum"] == ["worker"]
+    assert emitted[0].get_function_calls()[0].name == "transfer_to_agent"
+    assert emitted[0].get_function_calls()[0].id == "call-transfer"
+    assert any(event.actions.transfer_to_agent == "worker" for event in emitted)
+
+
 def test_render_extension_uses_pi_tool_shape():
     spec = PiToolSpec(
         name="get_weather",
@@ -1484,6 +1573,190 @@ async def test_piagent_runtime_exposes_before_model_added_tools(
 
 
 @pytest.mark.asyncio
+async def test_piagent_runtime_runs_transferred_agent(tmp_path, monkeypatch):
+    worker = _TextAgent(name="worker", marker="worker handled it")
+    binary = _make_fake_pi_that_calls_bridge(
+        tmp_path,
+        tool_name="transfer_to_agent",
+        tool_args={"agent_name": "worker"},
+        text_after_tool="root text should not leak",
+    )
+    agent_dir = tmp_path / "agent-home"
+    monkeypatch.setenv("PIAGENT_BINARY", str(binary))
+    monkeypatch.setenv("PIAGENT_AGENT_DIR", str(agent_dir))
+
+    agent = Agent(
+        name="assistant",
+        description="Routes specialist work.",
+        instruction="Transfer implementation work to worker.",
+        model_name="model-a",
+        model_api_base="https://ark.example.com/api/v3/",
+        model_api_key="test-key",
+        model_api_key_name="",
+        runtime="piagent",
+        sub_agents=[worker],
+    )
+    ctx = _ctx(agent, _user_event("please ask worker"))
+
+    events = [event async for event in PiAgentRuntime().run_async(agent, ctx)]
+    function_calls = [
+        part.function_call
+        for event in events
+        for part in event.content.parts
+        if part.function_call
+    ]
+    transfer_events = [
+        event for event in events if event.actions.transfer_to_agent == "worker"
+    ]
+    texts = [
+        part.text
+        for event in events
+        for part in (event.content.parts if event.content else [])
+        if part.text
+    ]
+
+    assert [call.name for call in function_calls] == ["transfer_to_agent"]
+    assert len(transfer_events) == 1
+    assert "worker handled it" in texts
+    assert "root text should not leak" not in texts
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("target", "expected_text"),
+    [
+        ("planner", "planner handled it"),
+        ("coder", "coder handled it"),
+        ("reviewer", "reviewer handled it"),
+    ],
+)
+async def test_piagent_runtime_transfers_to_selected_sub_agent(
+    tmp_path,
+    monkeypatch,
+    target,
+    expected_text,
+):
+    sub_agents = [
+        _TextAgent(name="planner", marker="planner handled it"),
+        _TextAgent(name="coder", marker="coder handled it"),
+        _TextAgent(name="reviewer", marker="reviewer handled it"),
+    ]
+    binary = _make_fake_pi_that_calls_bridge(
+        tmp_path,
+        tool_name="transfer_to_agent",
+        tool_args={"agent_name": target},
+        text_after_tool="root text should not leak",
+    )
+    agent_dir = tmp_path / "agent-home"
+    monkeypatch.setenv("PIAGENT_BINARY", str(binary))
+    monkeypatch.setenv("PIAGENT_AGENT_DIR", str(agent_dir))
+
+    agent = Agent(
+        name="assistant",
+        description="Routes specialist work.",
+        instruction="Transfer work to the right specialist.",
+        model_name="model-a",
+        model_api_base="https://ark.example.com/api/v3/",
+        model_api_key="test-key",
+        model_api_key_name="",
+        runtime="piagent",
+        sub_agents=sub_agents,
+    )
+    ctx = _ctx(agent, _user_event(f"please ask {target}"))
+
+    events = [event async for event in PiAgentRuntime().run_async(agent, ctx)]
+    function_calls = [
+        part.function_call
+        for event in events
+        for part in event.content.parts
+        if part.function_call
+    ]
+    transfer_events = [
+        event for event in events if event.actions.transfer_to_agent == target
+    ]
+    texts = [
+        part.text
+        for event in events
+        for part in (event.content.parts if event.content else [])
+        if part.text
+    ]
+
+    assert [call.name for call in function_calls] == ["transfer_to_agent"]
+    assert function_calls[0].args == {"agent_name": target}
+    assert len(transfer_events) == 1
+    assert any(event.author == target for event in events)
+    assert expected_text in texts
+    assert "root text should not leak" not in texts
+
+
+@pytest.mark.asyncio
+async def test_piagent_runtime_rejects_unknown_transfer_target(tmp_path, monkeypatch):
+    worker = _TextAgent(name="worker", marker="worker handled it")
+    binary = _make_fake_pi_that_calls_bridge(
+        tmp_path,
+        tool_name="transfer_to_agent",
+        tool_args={"agent_name": "missing_agent"},
+        text_after_tool="root text should not leak",
+    )
+    agent_dir = tmp_path / "agent-home"
+    monkeypatch.setenv("PIAGENT_BINARY", str(binary))
+    monkeypatch.setenv("PIAGENT_AGENT_DIR", str(agent_dir))
+
+    agent = Agent(
+        name="assistant",
+        description="Routes specialist work.",
+        instruction="Transfer work to the right specialist.",
+        model_name="model-a",
+        model_api_base="https://ark.example.com/api/v3/",
+        model_api_key="test-key",
+        model_api_key_name="",
+        runtime="piagent",
+        sub_agents=[worker],
+    )
+    ctx = _ctx(agent, _user_event("please ask missing_agent"))
+
+    events: list[Event] = []
+    with pytest.raises(ValueError, match="Agent missing_agent not found"):
+        async for event in PiAgentRuntime().run_async(agent, ctx):
+            events.append(event)
+
+    assert any(event.actions.transfer_to_agent == "missing_agent" for event in events)
+    assert all(event.author != "worker" for event in events)
+
+
+@pytest.mark.asyncio
+async def test_piagent_runtime_appends_transfer_instructions(tmp_path, monkeypatch):
+    worker = _TextAgent(
+        name="worker",
+        description="Handles implementation work.",
+        marker="worker handled it",
+    )
+    binary, prompt_path = _make_fake_pi_with_prompt_capture(tmp_path)
+    agent_dir = tmp_path / "agent-home"
+    monkeypatch.setenv("PIAGENT_BINARY", str(binary))
+    monkeypatch.setenv("PIAGENT_AGENT_DIR", str(agent_dir))
+
+    agent = Agent(
+        name="assistant",
+        instruction="Route work when needed.",
+        model_name="model-a",
+        model_api_base="https://ark.example.com/api/v3/",
+        model_api_key="test-key",
+        model_api_key_name="",
+        runtime="piagent",
+        sub_agents=[worker],
+    )
+    ctx = _ctx(agent, _user_event("please ask worker"))
+
+    _events = [event async for event in PiAgentRuntime().run_async(agent, ctx)]
+
+    prompt = prompt_path.read_text(encoding="utf-8")
+    assert "transfer_to_agent" in prompt
+    assert "`worker`" in prompt
+    assert "Handles implementation work." in prompt
+
+
+@pytest.mark.asyncio
 async def test_piagent_runtime_closes_opened_toolsets(tmp_path, monkeypatch):
     def get_weather(city: str) -> dict[str, str]:
         """Get weather.
@@ -1556,6 +1829,40 @@ async def test_piagent_runtime_syncs_tools_after_before_model_callback(
         before_model_callback=before_model_callback,
     )
     ctx = _fake_ctx(_user_event("ping"))
+
+    _events = [event async for event in PiAgentRuntime().run_async(agent, ctx)]
+
+    argv = json.loads(argv_path.read_text(encoding="utf-8"))
+    assert "--extension" not in argv
+
+
+@pytest.mark.asyncio
+async def test_piagent_runtime_before_model_can_remove_transfer_tool(
+    tmp_path,
+    monkeypatch,
+):
+    worker = _TextAgent(name="worker", marker="worker handled it")
+
+    def before_model_callback(callback_context, llm_request):
+        llm_request.tools_dict.clear()
+
+    binary, argv_path = _make_fake_pi_with_argv_capture(tmp_path)
+    agent_dir = tmp_path / "agent-home"
+    monkeypatch.setenv("PIAGENT_BINARY", str(binary))
+    monkeypatch.setenv("PIAGENT_AGENT_DIR", str(agent_dir))
+
+    agent = Agent(
+        name="assistant",
+        instruction="Answer briefly.",
+        model_name="model-a",
+        model_api_base="https://ark.example.com/api/v3/",
+        model_api_key="test-key",
+        model_api_key_name="",
+        runtime="piagent",
+        sub_agents=[worker],
+        before_model_callback=before_model_callback,
+    )
+    ctx = _ctx(agent, _user_event("ping"))
 
     _events = [event async for event in PiAgentRuntime().run_async(agent, ctx)]
 

--- a/tests/runtime/test_agent_transfer.py
+++ b/tests/runtime/test_agent_transfer.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+from google.adk.agents.base_agent import BaseAgent
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.agents.llm_agent import LlmAgent
+from google.adk.events.event import Event
+from google.adk.events.event_actions import EventActions
+from google.adk.models.llm_request import LlmRequest
+from google.adk.sessions.in_memory_session_service import InMemorySessionService
+from google.adk.sessions.session import Session
+from google.genai import types
+
+from veadk.runtime.agent_transfer import append_transfer_instructions
+from veadk.runtime.agent_transfer import get_transfer_targets
+from veadk.runtime.agent_transfer import run_transferred_agent
+
+
+class _TextAgent(BaseAgent):
+    marker: str
+    output_key: str = ""
+    output_schema: object | None = None
+
+    async def _run_async_impl(self, ctx: InvocationContext):
+        yield Event(
+            invocation_id=ctx.invocation_id,
+            author=self.name,
+            content=types.ModelContent(parts=[types.Part(text=self.marker)]),
+        )
+
+
+def _ctx(agent: BaseAgent) -> InvocationContext:
+    return InvocationContext(
+        session_service=InMemorySessionService(),
+        invocation_id="inv-transfer",
+        agent=agent,
+        session=Session(
+            id="session-transfer",
+            appName="app",
+            userId="user",
+            state={},
+            events=[],
+        ),
+    )
+
+
+def _names(agents: list[BaseAgent]) -> list[str]:
+    return [agent.name for agent in agents]
+
+
+def test_get_transfer_targets_matches_adk_tree_rules() -> None:
+    planner = LlmAgent(name="planner", model="gemini-2.5-flash")
+    writer = LlmAgent(name="writer", model="gemini-2.5-flash")
+    task = LlmAgent(name="task", model="gemini-2.5-flash", mode="task")
+    root = LlmAgent(
+        name="root",
+        model="gemini-2.5-flash",
+        sub_agents=[planner, writer, task],
+    )
+
+    assert _names(get_transfer_targets(root)) == ["planner", "writer"]
+    assert _names(get_transfer_targets(planner)) == ["root", "writer"]
+
+    planner.disallow_transfer_to_parent = True
+    planner.disallow_transfer_to_peers = True
+
+    assert get_transfer_targets(planner) == []
+
+
+def test_append_transfer_instructions_lists_available_agents() -> None:
+    worker = LlmAgent(
+        name="worker",
+        model="gemini-2.5-flash",
+        description="Handles implementation work.",
+    )
+    root = LlmAgent(
+        name="root",
+        model="gemini-2.5-flash",
+        sub_agents=[worker],
+    )
+    llm_request = LlmRequest(model="gemini-2.5-flash")
+
+    append_transfer_instructions(root, llm_request)
+
+    instruction = str(llm_request.config.system_instruction)
+    assert "transfer_to_agent" in instruction
+    assert "`worker`" in instruction
+    assert "Handles implementation work." in instruction
+
+
+@pytest.mark.asyncio
+async def test_run_transferred_agent_executes_target_and_saves_output_key() -> None:
+    worker = _TextAgent(name="worker", marker="done", output_key="worker_answer")
+    root = LlmAgent(
+        name="root",
+        model="gemini-2.5-flash",
+        sub_agents=[worker],
+    )
+    ctx = _ctx(root)
+    transfer_event = Event(
+        invocation_id=ctx.invocation_id,
+        author=root.name,
+        actions=EventActions(transfer_to_agent="worker"),
+    )
+
+    events = [event async for event in run_transferred_agent(ctx, transfer_event)]
+
+    assert [event.author for event in events] == ["worker"]
+    assert events[0].actions.state_delta == {"worker_answer": "done"}

--- a/veadk/runtime/agent_transfer.py
+++ b/veadk/runtime/agent_transfer.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ADK-compatible transfer support for non-ADK runtimes."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, AsyncGenerator, Sequence
+
+from google.adk.tools.transfer_to_agent_tool import TransferToAgentTool
+from google.adk.tools.transfer_to_agent_tool import transfer_to_agent
+from google.adk.utils.context_utils import Aclosing
+
+from veadk.runtime.output_state import maybe_save_output_to_state
+
+if TYPE_CHECKING:
+    from google.adk.agents.base_agent import BaseAgent
+    from google.adk.agents.invocation_context import InvocationContext
+    from google.adk.events.event import Event
+    from google.adk.models.llm_request import LlmRequest
+    from google.adk.tools.base_tool import BaseTool
+
+
+TRANSFER_TOOL_NAME = transfer_to_agent.__name__
+
+
+def get_transfer_targets(agent: "BaseAgent") -> list["BaseAgent"]:
+    """Return the agents ADK AutoFlow would expose as transfer targets."""
+
+    try:
+        from google.adk.agents.llm_agent import LlmAgent
+    except ImportError:
+        return []
+
+    if not isinstance(agent, LlmAgent):
+        return []
+
+    targets: list[BaseAgent] = [
+        sub_agent
+        for sub_agent in getattr(agent, "sub_agents", None) or []
+        if not _is_non_transferable_mode(sub_agent)
+    ]
+    parent = getattr(agent, "parent_agent", None)
+    if parent is None or not hasattr(parent, "disallow_transfer_to_parent"):
+        return targets
+
+    if not getattr(agent, "disallow_transfer_to_parent", False):
+        targets.append(parent)
+
+    if not getattr(agent, "disallow_transfer_to_peers", False):
+        targets.extend(
+            peer
+            for peer in getattr(parent, "sub_agents", None) or []
+            if getattr(peer, "name", None) != getattr(agent, "name", None)
+            and not _is_non_transferable_mode(peer)
+        )
+
+    return targets
+
+
+def has_transfer_targets(agent: "BaseAgent") -> bool:
+    """Whether transfer should be exposed for this agent."""
+
+    return bool(get_transfer_targets(agent))
+
+
+def build_transfer_tool(targets: Sequence["BaseAgent"] | None = None) -> "BaseTool":
+    """Build the standard ADK transfer tool."""
+
+    return TransferToAgentTool(agent_names=[agent.name for agent in targets or []])
+
+
+def append_transfer_instructions(
+    agent: "BaseAgent",
+    llm_request: "LlmRequest",
+    targets: list["BaseAgent"] | None = None,
+) -> None:
+    """Append ADK-compatible transfer target instructions to an LLM request."""
+
+    targets = list(targets) if targets is not None else get_transfer_targets(agent)
+    if not targets:
+        return
+
+    instructions = _build_target_agents_instructions(agent, targets)
+    if instructions:
+        llm_request.append_instructions([instructions])
+
+
+def transfer_agent_name(event: "Event") -> str:
+    """Return the transfer target requested by an event, if any."""
+
+    return str(getattr(getattr(event, "actions", None), "transfer_to_agent", "") or "")
+
+
+async def run_transferred_agent(
+    ctx: "InvocationContext",
+    event: "Event",
+) -> AsyncGenerator["Event", None]:
+    """Run the target agent requested by ``event.actions.transfer_to_agent``."""
+
+    agent_name = transfer_agent_name(event)
+    if not agent_name:
+        return
+
+    root_agent = getattr(getattr(ctx, "agent", None), "root_agent", None)
+    if root_agent is None:
+        root_agent = getattr(ctx, "agent", None)
+    find_agent = getattr(root_agent, "find_agent", None)
+    target_agent = find_agent(agent_name) if callable(find_agent) else None
+    if target_agent is None:
+        raise ValueError(f"Agent {agent_name} not found in the agent tree.")
+
+    async with Aclosing(target_agent.run_async(ctx)) as agen:
+        async for target_event in agen:
+            maybe_save_output_to_state(target_agent, target_event)
+            yield target_event
+
+
+def _build_target_agents_info(target_agent: "BaseAgent") -> str:
+    return f"""
+Agent name: {target_agent.name}
+Agent description: {target_agent.description}
+"""
+
+
+def _build_target_agents_instructions(
+    agent: "BaseAgent",
+    target_agents: list["BaseAgent"],
+) -> str:
+    if getattr(agent, "mode", None) in ("single_turn", "task"):
+        return ""
+
+    available_agent_names = sorted(target_agent.name for target_agent in target_agents)
+    formatted_agent_names = ", ".join(f"`{name}`" for name in available_agent_names)
+    target_agents_info = "\n".join(
+        _build_target_agents_info(target_agent) for target_agent in target_agents
+    )
+
+    instructions = f"""
+You have a list of other agents to transfer to:
+
+{target_agents_info}
+
+If you are the best to answer the question according to your description, you
+can answer it.
+
+If another agent is better for answering the question according to its
+description, call `{TRANSFER_TOOL_NAME}` function to transfer the question to
+that agent. When transferring, do not generate any text other than the function
+call.
+
+**NOTE**: the only available agents for `{TRANSFER_TOOL_NAME}` function are {formatted_agent_names}.
+"""
+
+    if getattr(agent, "parent_agent", None) and not getattr(
+        agent, "disallow_transfer_to_parent", False
+    ):
+        instructions += f"""
+If neither you nor the other agents are best for the question, transfer to your parent agent {agent.parent_agent.name}.
+"""
+    return instructions
+
+
+def _is_non_transferable_mode(agent: "BaseAgent") -> bool:
+    return getattr(agent, "mode", None) in ("single_turn", "task")

--- a/veadk/runtime/codex/proxy.py
+++ b/veadk/runtime/codex/proxy.py
@@ -29,6 +29,7 @@ import asyncio
 import json
 import os
 import secrets
+import time
 from dataclasses import dataclass
 from typing import Any, AsyncIterator
 
@@ -41,6 +42,7 @@ from litellm.exceptions import APIError
 from veadk.utils.logger import get_logger
 
 logger = get_logger(__name__)
+_TRANSFERRED_STATUS = "transferred"
 
 # Parameters accepted by litellm.aresponses; everything else in the inbound
 # request body is dropped to avoid forwarding unsupported fields.
@@ -287,30 +289,42 @@ class ResponsesShim:
                         ),
                     )
 
-                async def _execute(fc: dict[str, Any]) -> tuple[dict[str, Any], str]:
+                async def _execute(
+                    fc: dict[str, Any],
+                ) -> tuple[dict[str, Any], str, bool]:
                     cid = fc.get("call_id") or fc.get("id")
                     try:
                         args = json.loads(fc.get("arguments") or "{}")
                     except json.JSONDecodeError as e:
-                        return fc, json.dumps(
-                            {
-                                "error": f"Invalid JSON tool arguments: {e}",
-                                "status": "failed",
-                            }
+                        return (
+                            fc,
+                            json.dumps(
+                                {
+                                    "error": f"Invalid JSON tool arguments: {e}",
+                                    "status": "failed",
+                                }
+                            ),
+                            False,
                         )
                     if not isinstance(args, dict):
-                        return fc, json.dumps(
-                            {
-                                "error": "Tool arguments must decode to an object.",
-                                "status": "failed",
-                            }
+                        return (
+                            fc,
+                            json.dumps(
+                                {
+                                    "error": "Tool arguments must decode to an object.",
+                                    "status": "failed",
+                                }
+                            ),
+                            False,
                         )
                     out = await agent_executors[fc["name"]](args, str(cid))
-                    return fc, out
+                    return fc, out, _is_transfer_output(out)
 
                 executed = await asyncio.gather(*(_execute(fc) for fc in calls))
-                for fc, out in executed:
+                transferred = False
+                for fc, out, did_transfer in executed:
                     cid = fc.get("call_id") or fc.get("id")
+                    transferred = transferred or did_transfer
                     conv.append(
                         {
                             "type": "function_call",
@@ -328,6 +342,9 @@ class ResponsesShim:
                             "output": out,
                         }
                     )
+                if transferred:
+                    resp = _completed_transfer_response(resp)
+                    break
                 iters += 1
 
             if stream:
@@ -411,6 +428,35 @@ def _to_dict(obj: Any) -> dict[str, Any]:
     if hasattr(obj, "model_dump"):
         return obj.model_dump()
     return dict(obj)
+
+
+def _is_transfer_output(value: str) -> bool:
+    try:
+        payload = json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return False
+    return isinstance(payload, dict) and payload.get("status") == _TRANSFERRED_STATUS
+
+
+def _completed_transfer_response(resp: dict[str, Any]) -> dict[str, Any]:
+    """Return a minimal completed response after VeADK handled a transfer."""
+
+    return {
+        "id": resp.get("id") or "resp_transfer_complete",
+        "object": resp.get("object") or "response",
+        "created_at": resp.get("created_at") or int(time.time()),
+        "model": resp.get("model") or "model",
+        "status": "completed",
+        "output": [
+            {
+                "id": "msg_transfer_complete",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": ""}],
+            }
+        ],
+    }
 
 
 def _sse(event: dict[str, Any]) -> bytes:

--- a/veadk/runtime/codex/runtime.py
+++ b/veadk/runtime/codex/runtime.py
@@ -61,16 +61,23 @@ from openai_codex.generated.v2_all import (  # type: ignore[import-not-found]
 )
 
 from veadk.runtime.base_runtime import BaseRuntime
+from veadk.runtime.agent_transfer import append_transfer_instructions
+from veadk.runtime.agent_transfer import build_transfer_tool
+from veadk.runtime.agent_transfer import get_transfer_targets
+from veadk.runtime.agent_transfer import run_transferred_agent
+from veadk.runtime.agent_transfer import transfer_agent_name
 from veadk.runtime.codex.config import CodexRuntimeConfig
 from veadk.runtime.codex.config import codex_subprocess_env
 from veadk.runtime.codex.config import toml_string
 from veadk.runtime.codex.proxy import get_shim
 from veadk.runtime.codex.skills import sync_skills_to_codex_home
 from veadk.runtime.codex.tools_bridge import (
+    add_tool_to_bundle,
     build_executable_tools,
     close_toolsets,
     resume_authenticated_tools,
     resume_confirmed_tools,
+    sync_bundle_to_tools_dict,
 )
 from veadk.runtime.codex.translate import (
     build_input_attachments_from_llm_request,
@@ -88,6 +95,7 @@ from veadk.runtime.model_callbacks import (
     run_on_model_error_callbacks,
     system_instruction_to_text,
 )
+from veadk.utils.adk_compat import is_adk_gte
 from veadk.utils.logger import get_logger
 
 if TYPE_CHECKING:
@@ -143,6 +151,10 @@ class CodexRuntime(BaseRuntime):
             )
 
         event_queue: asyncio.Queue[object] = asyncio.Queue()
+        turn_token: str | None = None
+        run_started_at = time.monotonic()
+        run_status = "failed"
+        use_adk_transfer_scheduler = _uses_adk_transfer_scheduler(ctx)
 
         async def _emit_tool_event(event: "Event") -> None:
             await event_queue.put(event)
@@ -154,16 +166,19 @@ class CodexRuntime(BaseRuntime):
                 event_sink=_emit_tool_event,
                 timeout_seconds=runtime_config.tool_timeout_seconds,
             )
+            transfer_targets = get_transfer_targets(agent)
+            if transfer_targets:
+                add_tool_to_bundle(
+                    tool_bundle,
+                    build_transfer_tool(transfer_targets),
+                    ctx,
+                    event_sink=_emit_tool_event,
+                    timeout_seconds=runtime_config.tool_timeout_seconds,
+                )
             resumed_events = [
                 *await resume_authenticated_tools(tool_bundle, ctx),
                 *await resume_confirmed_tools(tool_bundle, ctx),
             ]
-            turn_token = shim.register_turn(
-                tool_bundle.specs,
-                tool_bundle.executors,
-                max_tool_iterations=runtime_config.max_tool_iterations,
-                invocation_id=ctx.invocation_id,
-            )
         except BaseException as e:
             logger.error(
                 "codex_runtime_setup_failed invocation_id=%s stage=tools error_type=%s",
@@ -181,13 +196,39 @@ class CodexRuntime(BaseRuntime):
             # Persist resumed confirmation responses before constructing history,
             # so Codex sees the completed/rejected tool result exactly once.
             for event in resumed_events:
+                _scope_event(event, ctx)
+                run_status = "transferred" if transfer_agent_name(event) else run_status
                 yield event
+                if transfer_agent_name(event):
+                    if not use_adk_transfer_scheduler:
+                        async for transferred_event in run_transferred_agent(
+                            ctx, event
+                        ):
+                            _scope_event(transferred_event, ctx)
+                            yield transferred_event
+                    run_status = "transferred"
+                    await close_toolsets(tool_bundle.opened_toolsets)
+                    shutil.rmtree(codex_home, ignore_errors=True)
+                    if cleanup_workspace:
+                        shutil.rmtree(workspace, ignore_errors=True)
+                    logger.info(
+                        "codex_runtime_complete invocation_id=%s status=%s duration_ms=%d",
+                        ctx.invocation_id,
+                        run_status,
+                        round((time.monotonic() - run_started_at) * 1000),
+                    )
+                    return
 
             runtime_call = await build_runtime_llm_request(
                 agent,
                 ctx,
                 model=model,
                 tools_dict=tool_bundle.tools,
+            )
+            append_transfer_instructions(
+                agent,
+                runtime_call.llm_request,
+                transfer_targets,
             )
             short_circuit = await run_before_model_callbacks(
                 agent,
@@ -202,13 +243,33 @@ class CodexRuntime(BaseRuntime):
                     runtime_call.model_response_event,
                 )
                 _scope_event(event, ctx)
-                shim.unregister_turn(turn_token)
                 await close_toolsets(tool_bundle.opened_toolsets)
                 shutil.rmtree(codex_home, ignore_errors=True)
                 if cleanup_workspace:
                     shutil.rmtree(workspace, ignore_errors=True)
+                run_status = "completed"
+                logger.info(
+                    "codex_runtime_complete invocation_id=%s status=%s duration_ms=%d",
+                    ctx.invocation_id,
+                    run_status,
+                    round((time.monotonic() - run_started_at) * 1000),
+                )
                 yield event
                 return
+
+            sync_bundle_to_tools_dict(
+                tool_bundle,
+                runtime_call.llm_request.tools_dict,
+                ctx,
+                event_sink=_emit_tool_event,
+                timeout_seconds=runtime_config.tool_timeout_seconds,
+            )
+            turn_token = shim.register_turn(
+                tool_bundle.specs,
+                tool_bundle.executors,
+                max_tool_iterations=runtime_config.max_tool_iterations,
+                invocation_id=ctx.invocation_id,
+            )
 
             # Keep privileged instructions out of the user transcript. The SDK
             # exposes native base/developer instruction channels.
@@ -243,7 +304,8 @@ class CodexRuntime(BaseRuntime):
                 ctx.invocation_id,
                 type(e).__name__,
             )
-            shim.unregister_turn(turn_token)
+            if turn_token is not None:
+                shim.unregister_turn(turn_token)
             await close_toolsets(tool_bundle.opened_toolsets)
             shutil.rmtree(codex_home, ignore_errors=True)
             if cleanup_workspace:
@@ -251,8 +313,6 @@ class CodexRuntime(BaseRuntime):
             raise
         turn = None
         pump: asyncio.Task[None] | None = None
-        run_started_at = time.monotonic()
-        run_status = "failed"
         try:
             async with AsyncCodex(config=sdk_config) as codex:
                 thread = await codex.thread_start(
@@ -314,6 +374,8 @@ class CodexRuntime(BaseRuntime):
                 pump = asyncio.create_task(_pump_codex())
                 buffer_final_text = has_after_model_callbacks(agent, ctx)
                 final_text_events: list[Event] = []
+                transfer_requested = False
+                deferred_transfer_event: Event | None = None
                 while True:
                     queued = await event_queue.get()
                     if queued is _QUEUE_DONE:
@@ -321,12 +383,34 @@ class CodexRuntime(BaseRuntime):
                     if isinstance(queued, BaseException):
                         raise queued
                     event = queued  # type: ignore[assignment]
+                    transfer_target = transfer_agent_name(event)
+                    if transfer_target and use_adk_transfer_scheduler:
+                        transfer_requested = True
+                        run_status = "transferred"
+                        final_text_events.clear()
+                        deferred_transfer_event = event
+                        continue
                     if buffer_final_text and is_final_model_text_event(
                         event, agent.name
                     ):
                         final_text_events.append(event)
                         continue
                     yield event
+                    if transfer_target:
+                        transfer_requested = True
+                        final_text_events.clear()
+                        async for transferred_event in run_transferred_agent(
+                            ctx, event
+                        ):
+                            _scope_event(transferred_event, ctx)
+                            yield transferred_event
+                        run_status = "transferred"
+                        break
+                if transfer_requested:
+                    await pump
+                    if deferred_transfer_event is not None:
+                        yield deferred_transfer_event
+                    return
                 await pump
                 if final_text_events:
                     llm_response = final_events_to_llm_response(final_text_events)
@@ -345,8 +429,9 @@ class CodexRuntime(BaseRuntime):
                     yield event
                 run_status = "completed"
         except asyncio.CancelledError:
-            run_status = "cancelled"
-            if turn is not None:
+            if run_status != "transferred":
+                run_status = "cancelled"
+            if turn is not None and run_status != "transferred":
                 try:
                     await turn.interrupt()
                 except Exception:  # noqa: BLE001
@@ -384,7 +469,8 @@ class CodexRuntime(BaseRuntime):
             if pump is not None and not pump.done():
                 pump.cancel()
                 await asyncio.gather(pump, return_exceptions=True)
-            shim.unregister_turn(turn_token)
+            if turn_token is not None:
+                shim.unregister_turn(turn_token)
             await close_toolsets(tool_bundle.opened_toolsets)
             shutil.rmtree(codex_home, ignore_errors=True)
             if cleanup_workspace:
@@ -513,3 +599,9 @@ def _build_codex_input(
 def _scope_event(event: "Event", ctx: "InvocationContext") -> None:
     event.branch = getattr(ctx, "branch", None)
     event.isolation_scope = getattr(ctx, "isolation_scope", None)
+
+
+def _uses_adk_transfer_scheduler(ctx: "InvocationContext") -> bool:
+    """Whether ADK's outer workflow scheduler should run transfer targets."""
+
+    return is_adk_gte("2.0.0") and getattr(ctx, "_event_queue", None) is not None

--- a/veadk/runtime/codex/tools_bridge.py
+++ b/veadk/runtime/codex/tools_bridge.py
@@ -58,6 +58,7 @@ logger = get_logger(__name__)
 
 EventSink = Callable[[Event], Awaitable[None]]
 Executor = Callable[[dict[str, Any], str], Awaitable[str]]
+TRANSFERRED_STATUS = "transferred"
 
 
 @dataclass
@@ -166,6 +167,65 @@ async def build_executable_tools(
             ",".join(bundle.executors),
         )
     return bundle
+
+
+def add_tool_to_bundle(
+    bundle: CodexToolBundle,
+    tool: "BaseTool",
+    ctx: "InvocationContext",
+    *,
+    event_sink: EventSink | None = None,
+    timeout_seconds: float | None = None,
+) -> None:
+    """Add one ADK tool to an existing Codex tool bundle."""
+
+    from google.adk.models.lite_llm import _function_declaration_to_tool_param
+
+    try:
+        declaration = tool._get_declaration()
+    except Exception as e:  # noqa: BLE001 - one tool must not break the turn
+        logger.warning(
+            "codex_tool_skipped reason=missing_declaration error_type=%s",
+            type(e).__name__,
+        )
+        return
+    if declaration is None or not declaration.name:
+        return
+    name = str(declaration.name)
+    if name in bundle.tools:
+        raise ValueError(f"codex: duplicate tool name {name!r}")
+    chat_param = _function_declaration_to_tool_param(declaration)
+    bundle.specs.append({"type": "function", **chat_param["function"]})
+    bundle.tools[name] = tool
+    bundle.executors[name] = _make_executor(
+        tool,
+        ctx,
+        event_sink=event_sink,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def sync_bundle_to_tools_dict(
+    bundle: CodexToolBundle,
+    tools_dict: dict[str, "BaseTool"],
+    ctx: "InvocationContext",
+    *,
+    event_sink: EventSink | None = None,
+    timeout_seconds: float | None = None,
+) -> None:
+    """Rebuild specs/executors so the shim matches callback-mutated tools."""
+
+    bundle.specs = []
+    bundle.executors = {}
+    bundle.tools = {}
+    for tool in tools_dict.values():
+        add_tool_to_bundle(
+            bundle,
+            tool,
+            ctx,
+            event_sink=event_sink,
+            timeout_seconds=timeout_seconds,
+        )
 
 
 async def resume_confirmed_tools(
@@ -488,6 +548,14 @@ def _make_executor(
             payload = {
                 "status": status,
                 "call_id": call_id,
+                "response": payload,
+            }
+        elif getattr(actions, "transfer_to_agent", None):
+            status = TRANSFERRED_STATUS
+            payload = {
+                "status": status,
+                "call_id": call_id,
+                "agent_name": actions.transfer_to_agent,
                 "response": payload,
             }
         else:

--- a/veadk/runtime/piagent/runtime.py
+++ b/veadk/runtime/piagent/runtime.py
@@ -20,6 +20,13 @@ import asyncio
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING
 
+from veadk.runtime.agent_transfer import (
+    append_transfer_instructions,
+    build_transfer_tool,
+    get_transfer_targets,
+    run_transferred_agent,
+    transfer_agent_name,
+)
 from veadk.runtime.base_runtime import BaseRuntime
 from veadk.runtime.model_callbacks import (
     build_runtime_llm_request,
@@ -37,6 +44,7 @@ from veadk.runtime.piagent.installer import resolve_or_install_piagent_binary
 from veadk.runtime.piagent.skills import materialize_skills_for_pi
 from veadk.runtime.piagent.tool_runtime import PiToolRuntime
 from veadk.runtime.piagent.tools_bridge import (
+    add_tool_to_bundle,
     build_executable_tools,
     close_toolsets,
     sync_bundle_to_tools_dict,
@@ -79,6 +87,15 @@ class PiAgentRuntime(BaseRuntime):
             tool_bundle = await build_executable_tools(
                 agent, ctx, event_sink=_emit_tool_event
             )
+            transfer_targets = get_transfer_targets(agent)
+            if transfer_targets:
+                add_tool_to_bundle(
+                    tool_bundle,
+                    build_transfer_tool(transfer_targets),
+                    ctx,
+                    seen={spec.name for spec in tool_bundle.specs},
+                    event_sink=_emit_tool_event,
+                )
 
             runtime_call = await build_runtime_llm_request(
                 agent,
@@ -106,6 +123,12 @@ class PiAgentRuntime(BaseRuntime):
                 ctx,
                 event_sink=_emit_tool_event,
             )
+            if "transfer_to_agent" in runtime_call.llm_request.tools_dict:
+                append_transfer_instructions(
+                    agent,
+                    runtime_call.llm_request,
+                    transfer_targets,
+                )
             prompt = build_prompt_from_llm_request(runtime_call.llm_request)
 
             logger.info(
@@ -152,12 +175,28 @@ class PiAgentRuntime(BaseRuntime):
                             if isinstance(queued, BaseException):
                                 raise queued
                             event = queued  # type: ignore[assignment]
+                            transfer_target = transfer_agent_name(event)
                             if buffer_final_text and is_final_model_text_event(
                                 event, agent.name
                             ):
                                 final_text_events.append(event)
                                 continue
                             yield event
+                            if transfer_target:
+                                final_text_events.clear()
+                                async for transferred_event in run_transferred_agent(
+                                    ctx,
+                                    event,
+                                ):
+                                    _scope_event(transferred_event, ctx)
+                                    yield transferred_event
+                                if pump is not None and not pump.done():
+                                    pump.cancel()
+                                    await asyncio.gather(
+                                        pump,
+                                        return_exceptions=True,
+                                    )
+                                return
                         await pump
                     except Exception as e:
                         if pump is not None and not pump.done():
@@ -195,3 +234,8 @@ class PiAgentRuntime(BaseRuntime):
             if tool_bundle is not None:
                 await close_toolsets(tool_bundle.opened_toolsets)
             skill_bundle.close()
+
+
+def _scope_event(event: Event, ctx: InvocationContext) -> None:
+    event.branch = getattr(ctx, "branch", None)
+    event.isolation_scope = getattr(ctx, "isolation_scope", None)

--- a/veadk/runtime/piagent/runtime.py
+++ b/veadk/runtime/piagent/runtime.py
@@ -16,7 +16,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, AsyncGenerator
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
 
 from veadk.runtime.base_runtime import BaseRuntime
 from veadk.runtime.model_callbacks import (
@@ -37,6 +39,7 @@ from veadk.runtime.piagent.tool_runtime import PiToolRuntime
 from veadk.runtime.piagent.tools_bridge import (
     build_executable_tools,
     close_toolsets,
+    sync_bundle_to_tools_dict,
 )
 from veadk.runtime.piagent.translate import (
     PiEventTranslator,
@@ -51,6 +54,7 @@ if TYPE_CHECKING:
     from veadk.agent import Agent
 
 logger = get_logger(__name__)
+_QUEUE_DONE = object()
 
 
 class PiAgentRuntime(BaseRuntime):
@@ -59,15 +63,22 @@ class PiAgentRuntime(BaseRuntime):
     name = "piagent"
 
     async def run_async(
-        self, agent: "Agent", ctx: "InvocationContext"
-    ) -> AsyncGenerator["Event", None]:
+        self, agent: Agent, ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
         binary_path = resolve_or_install_piagent_binary()
         config = PiAgentConfig.from_agent(agent, binary_path)
         prepare_piagent_home(config)
         skill_bundle = materialize_skills_for_pi(agent)
         tool_bundle = None
+        event_queue: asyncio.Queue[object] = asyncio.Queue()
+
+        async def _emit_tool_event(event: Event) -> None:
+            await event_queue.put(event)
+
         try:
-            tool_bundle = await build_executable_tools(agent, ctx)
+            tool_bundle = await build_executable_tools(
+                agent, ctx, event_sink=_emit_tool_event
+            )
 
             runtime_call = await build_runtime_llm_request(
                 agent,
@@ -89,6 +100,12 @@ class PiAgentRuntime(BaseRuntime):
                 )
                 return
 
+            sync_bundle_to_tools_dict(
+                tool_bundle,
+                runtime_call.llm_request.tools_dict,
+                ctx,
+                event_sink=_emit_tool_event,
+            )
             prompt = build_prompt_from_llm_request(runtime_call.llm_request)
 
             logger.info(
@@ -98,6 +115,7 @@ class PiAgentRuntime(BaseRuntime):
             translator = PiEventTranslator(
                 author=agent.name,
                 invocation_id=ctx.invocation_id,
+                bridged_tool_names=set(tool_bundle.executors),
             )
             buffer_final_text = has_after_model_callbacks(agent, ctx)
             final_text_events: list[Event] = []
@@ -113,16 +131,38 @@ class PiAgentRuntime(BaseRuntime):
                     else run_config
                 )
                 async with PiAgentRpcClient(run_config) as client:
+                    pump: asyncio.Task[None] | None = None
+
+                    async def _pump_pi() -> None:
+                        try:
+                            async for pi_event in client.prompt(prompt):
+                                for event in translator.event_to_adk_events(pi_event):
+                                    await event_queue.put(event)
+                        except Exception as e:  # noqa: BLE001 - forward pump errors
+                            await event_queue.put(e)
+                        finally:
+                            await event_queue.put(_QUEUE_DONE)
+
                     try:
-                        async for pi_event in client.prompt(prompt):
-                            for event in translator.event_to_adk_events(pi_event):
-                                if buffer_final_text and is_final_model_text_event(
-                                    event, agent.name
-                                ):
-                                    final_text_events.append(event)
-                                    continue
-                                yield event
+                        pump = asyncio.create_task(_pump_pi())
+                        while True:
+                            queued = await event_queue.get()
+                            if queued is _QUEUE_DONE:
+                                break
+                            if isinstance(queued, BaseException):
+                                raise queued
+                            event = queued  # type: ignore[assignment]
+                            if buffer_final_text and is_final_model_text_event(
+                                event, agent.name
+                            ):
+                                final_text_events.append(event)
+                                continue
+                            yield event
+                        await pump
                     except Exception as e:
+                        if pump is not None and not pump.done():
+                            pump.cancel()
+                            await asyncio.gather(pump, return_exceptions=True)
                         fallback = await run_on_model_error_callbacks(
                             agent,
                             ctx,

--- a/veadk/runtime/piagent/tool_runtime.py
+++ b/veadk/runtime/piagent/tool_runtime.py
@@ -27,6 +27,8 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from typing_extensions import Self
+
 from veadk.runtime.piagent.tools_bridge import PiToolBundle, PiToolSpec
 from veadk.utils.logger import get_logger
 
@@ -47,7 +49,7 @@ class PiToolRuntime:
         self._token = secrets.token_urlsafe(24)
         self._tmpdir: tempfile.TemporaryDirectory[str] | None = None
 
-    async def __aenter__(self) -> "PiToolRuntime":
+    async def __aenter__(self) -> Self:
         if not self.bundle.has_tools:
             return self
 
@@ -100,8 +102,11 @@ class PiToolRuntime:
             writer.close()
             try:
                 await writer.wait_closed()
-            except Exception:  # noqa: BLE001
-                pass
+            except Exception as e:  # noqa: BLE001
+                logger.debug(
+                    "piagent: failed to close tool bridge response writer: %s",
+                    type(e).__name__,
+                )
 
     async def _dispatch(self, request: dict[str, Any]) -> tuple[int, dict[str, Any]]:
         if request["method"] != "POST" or request["path"] != "/call":
@@ -120,7 +125,8 @@ class PiToolRuntime:
         if executor is None:
             return 404, {"ok": False, "error": f"unknown tool: {tool_name}"}
 
-        result = _tool_result_to_pi_result(await executor(args))
+        tool_call_id = str(body.get("toolCallId") or "")
+        result = _tool_result_to_pi_result(await executor(args, tool_call_id))
         return 200, {"ok": True, "result": result}
 
 
@@ -147,7 +153,7 @@ async def _read_http_json(reader: asyncio.StreamReader) -> dict[str, Any]:
     except json.JSONDecodeError as e:
         raise ValueError("invalid JSON request body") from e
     if not isinstance(body, dict):
-        raise ValueError("request body must be a JSON object")
+        raise TypeError("request body must be a JSON object")
     return {"method": method, "path": path, "headers": headers, "body": body}
 
 

--- a/veadk/runtime/piagent/tools_bridge.py
+++ b/veadk/runtime/piagent/tools_bridge.py
@@ -16,22 +16,31 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import re
+import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, ClassVar
 
+from google.adk.events.event import Event
+from google.genai import types
+
+from veadk.utils.adk_compat import get_event_function_responses
 from veadk.utils.logger import get_logger
 
 if TYPE_CHECKING:
     from google.adk.agents.invocation_context import InvocationContext
+    from google.adk.tools.base_tool import BaseTool
     from google.adk.tools.base_toolset import BaseToolset
 
     from veadk.agent import Agent
 
 logger = get_logger(__name__)
 
-Executor = Callable[[dict[str, Any]], Awaitable[Any]]
+EventSink = Callable[[Event], Awaitable[None]]
+Executor = Callable[[dict[str, Any], str], Awaitable[Any]]
 
 _TOOL_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
 _MAX_TOOL_RESULT_CHARS = 20000
@@ -65,7 +74,7 @@ class PiToolBundle:
     executors: dict[str, Executor] = field(default_factory=dict)
     tools: dict[str, Any] = field(default_factory=dict)
     skipped: list[SkippedTool] = field(default_factory=list)
-    opened_toolsets: list["BaseToolset"] = field(default_factory=list)
+    opened_toolsets: list[BaseToolset] = field(default_factory=list)
 
     @property
     def has_tools(self) -> bool:
@@ -73,7 +82,11 @@ class PiToolBundle:
 
 
 async def build_executable_tools(
-    agent: "Agent", ctx: "InvocationContext"
+    agent: Agent,
+    ctx: InvocationContext,
+    *,
+    event_sink: EventSink | None = None,
+    timeout_seconds: float | None = None,
 ) -> PiToolBundle:
     """Collect ADK tools and toolsets as Pi custom tools.
 
@@ -82,52 +95,31 @@ async def build_executable_tools(
     ``BaseTool`` is bridged through the same Pi custom tool path. Skill toolsets
     are still skipped because skills need a separate materialization strategy.
     """
-    from google.adk.models.lite_llm import _function_declaration_to_tool_param
     from google.adk.agents.readonly_context import ReadonlyContext
     from google.adk.tools.base_tool import BaseTool
     from google.adk.tools.base_toolset import BaseToolset
     from google.adk.tools.function_tool import FunctionTool
-    from google.adk.tools.tool_context import ToolContext
 
     bundle = PiToolBundle()
     seen: set[str] = set()
     readonly_context = ReadonlyContext(ctx)
 
+    _ensure_invocation_context_defaults(ctx, agent)
+
     def _skip(name: str, reason: str) -> None:
         logger.warning(f"piagent: skipping tool {name!r}: {reason}")
         bundle.skipped.append(SkippedTool(name=name, reason=reason))
 
-    def _add(tool: "BaseTool") -> None:
-        try:
-            declaration = tool._get_declaration()
-        except Exception as e:  # noqa: BLE001 - one tool must not break the turn
-            _skip(repr(tool), f"failed to build declaration: {e}")
-            return
-        if declaration is None or not declaration.name:
-            return
-
-        original_name = str(declaration.name)
-        name = _pi_tool_name(original_name, seen)
-        if name != original_name:
-            logger.info(f"piagent: exposing tool {original_name!r} to Pi as {name!r}")
-
-        chat_param = _function_declaration_to_tool_param(declaration)
-        function = chat_param.get("function") or {}
-        parameters = function.get("parameters") or {"type": "object", "properties": {}}
-        if not isinstance(parameters, dict):
-            parameters = {"type": "object", "properties": {}}
-
-        spec = PiToolSpec(
-            name=name,
-            label=original_name,
-            description=str(function.get("description") or ""),
-            parameters=parameters,
-            original_name=original_name,
+    def _add(tool: BaseTool) -> None:
+        add_tool_to_bundle(
+            bundle,
+            tool,
+            ctx,
+            seen=seen,
+            event_sink=event_sink,
+            timeout_seconds=timeout_seconds,
+            skip=_skip,
         )
-        bundle.specs.append(spec)
-        bundle.tools[original_name] = tool
-        bundle.executors[name] = _make_executor(tool, ctx, ToolContext)
-        seen.add(name)
 
     try:
         for entry in getattr(agent, "tools", None) or []:
@@ -171,17 +163,298 @@ async def build_executable_tools(
     return bundle
 
 
+def add_tool_to_bundle(
+    bundle: PiToolBundle,
+    tool: BaseTool,
+    ctx: InvocationContext,
+    *,
+    seen: set[str],
+    event_sink: EventSink | None = None,
+    timeout_seconds: float | None = None,
+    skip: Callable[[str, str], None] | None = None,
+) -> None:
+    """Add one ADK tool to an existing Pi tool bundle."""
+
+    from google.adk.models.lite_llm import _function_declaration_to_tool_param
+
+    def _skip(name: str, reason: str) -> None:
+        if skip is not None:
+            skip(name, reason)
+        else:
+            logger.warning(f"piagent: skipping tool {name!r}: {reason}")
+            bundle.skipped.append(SkippedTool(name=name, reason=reason))
+
+    try:
+        declaration = tool._get_declaration()
+    except Exception as e:  # noqa: BLE001 - one tool must not break the turn
+        _skip(repr(tool), f"failed to build declaration: {e}")
+        return
+    if declaration is None or not declaration.name:
+        return
+
+    original_name = str(declaration.name)
+    name = _pi_tool_name(original_name, seen)
+    if name != original_name:
+        logger.info(f"piagent: exposing tool {original_name!r} to Pi as {name!r}")
+
+    chat_param = _function_declaration_to_tool_param(declaration)
+    function = chat_param.get("function") or {}
+    parameters = function.get("parameters") or {"type": "object", "properties": {}}
+    if not isinstance(parameters, dict):
+        parameters = {"type": "object", "properties": {}}
+
+    spec = PiToolSpec(
+        name=name,
+        label=original_name,
+        description=str(function.get("description") or ""),
+        parameters=parameters,
+        original_name=original_name,
+    )
+    bundle.specs.append(spec)
+    bundle.tools[original_name] = tool
+    bundle.executors[name] = _make_executor(
+        tool,
+        ctx,
+        event_sink=event_sink,
+        timeout_seconds=timeout_seconds,
+    )
+    seen.add(name)
+
+
+def sync_bundle_to_tools_dict(
+    bundle: PiToolBundle,
+    tools_dict: dict[str, BaseTool],
+    ctx: InvocationContext,
+    *,
+    event_sink: EventSink | None = None,
+    timeout_seconds: float | None = None,
+) -> None:
+    """Rebuild Pi tool specs and executors from callback-mutated tools."""
+
+    bundle.specs = []
+    bundle.executors = {}
+    bundle.tools = {}
+    seen: set[str] = set()
+    for tool in tools_dict.values():
+        add_tool_to_bundle(
+            bundle,
+            tool,
+            ctx,
+            seen=seen,
+            event_sink=event_sink,
+            timeout_seconds=timeout_seconds,
+        )
+
+
 def _make_executor(
-    tool: Any, ctx: "InvocationContext", tool_context_cls: Any
+    tool: Any,
+    ctx: InvocationContext,
+    *,
+    event_sink: EventSink | None,
+    timeout_seconds: float | None,
 ) -> Executor:
-    async def _run(args: dict[str, Any]) -> Any:
+    async def _emit(event: Event) -> None:
+        if event_sink is not None:
+            await event_sink(event)
+
+    async def _run(args: dict[str, Any], call_id: str = "") -> Any:
+        started_at = time.monotonic()
+        call_id = call_id or f"piagent-{time.time_ns()}"
+        logger.debug(
+            "piagent_tool_start invocation_id=%s call_id=%s tool=%s",
+            ctx.invocation_id,
+            call_id,
+            tool.name,
+        )
+
+        def _log_complete(status: str) -> None:
+            logger.info(
+                "piagent_tool_complete invocation_id=%s call_id=%s tool=%s "
+                "status=%s duration_ms=%d",
+                ctx.invocation_id,
+                call_id,
+                tool.name,
+                status,
+                round((time.monotonic() - started_at) * 1000),
+            )
+
+        call_event = Event(
+            invocation_id=ctx.invocation_id,
+            author=ctx.agent.name,
+            content=types.Content(
+                role="model",
+                parts=[
+                    types.Part(
+                        function_call=types.FunctionCall(
+                            id=call_id,
+                            name=tool.name,
+                            args=args,
+                        )
+                    )
+                ],
+            ),
+            branch=getattr(ctx, "branch", None),
+        )
+        if getattr(tool, "is_long_running", False) or getattr(
+            tool, "_defers_response", False
+        ):
+            call_event.long_running_tool_ids = {call_id}
+        await _emit(call_event)
+
         try:
-            result = await tool.run_async(args=args, tool_context=tool_context_cls(ctx))
+            from google.adk.flows.llm_flows import functions
+
+            execution = functions.handle_function_calls_async(
+                ctx,
+                call_event,
+                {tool.name: tool},
+            )
+            response_event = (
+                await asyncio.wait_for(execution, timeout_seconds)
+                if timeout_seconds
+                else await execution
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "piagent_tool_timeout invocation_id=%s call_id=%s tool=%s "
+                "timeout_seconds=%s",
+                ctx.invocation_id,
+                call_id,
+                tool.name,
+                timeout_seconds,
+            )
+            response_event = _error_response_event(
+                ctx,
+                tool.name,
+                call_id,
+                f"Tool timed out after {timeout_seconds}s",
+            )
+        except asyncio.CancelledError:
+            _log_complete("cancelled")
+            raise
         except Exception as e:  # noqa: BLE001 - surface tool failure to Pi
-            return {"error": str(e), "isError": True}
-        return _coerce_tool_result(result)
+            logger.warning(
+                "piagent_tool_failed invocation_id=%s call_id=%s tool=%s error_type=%s",
+                ctx.invocation_id,
+                call_id,
+                tool.name,
+                type(e).__name__,
+            )
+            response_event = _error_response_event(ctx, tool.name, call_id, str(e))
+
+        if response_event is None:
+            _log_complete("pending")
+            return {"status": "pending", "call_id": call_id}
+
+        try:
+            from google.adk.flows.llm_flows import functions
+
+            auth_event = functions.generate_auth_event(ctx, response_event)
+            if auth_event is not None:
+                await _emit(auth_event)
+            confirmation_event = functions.generate_request_confirmation_event(
+                ctx,
+                call_event,
+                response_event,
+            )
+            if confirmation_event is not None:
+                await _emit(confirmation_event)
+        except (AttributeError, ImportError):
+            pass
+
+        await _emit(response_event)
+        responses = get_event_function_responses(response_event)
+        payload: Any = responses[0].response if responses else {"status": "completed"}
+        actions = response_event.actions
+        if getattr(actions, "requested_auth_configs", None):
+            status = "authentication_required"
+            payload = {"status": status, "call_id": call_id, "response": payload}
+        elif getattr(actions, "requested_tool_confirmations", None):
+            status = "confirmation_required"
+            payload = {"status": status, "call_id": call_id, "response": payload}
+        else:
+            response = responses[0].response if responses else {}
+            status = (
+                "failed"
+                if isinstance(response, dict) and response.get("status") == "failed"
+                else "completed"
+            )
+        _log_complete(status)
+        return _coerce_tool_result(payload)
 
     return _run
+
+
+def _error_response_event(
+    ctx: InvocationContext, tool_name: str, call_id: str, message: str
+) -> Event:
+    return Event(
+        invocation_id=ctx.invocation_id,
+        author=ctx.agent.name,
+        content=types.Content(
+            role="user",
+            parts=[
+                types.Part(
+                    function_response=types.FunctionResponse(
+                        id=call_id,
+                        name=tool_name,
+                        response={"error": message, "status": "failed"},
+                    )
+                )
+            ],
+        ),
+        branch=getattr(ctx, "branch", None),
+    )
+
+
+class _NoopPluginManager:
+    plugins: ClassVar[list[Any]] = []
+
+    async def run_before_model_callback(self, **_: Any) -> Any:
+        return None
+
+    async def run_after_model_callback(self, **_: Any) -> Any:
+        return None
+
+    async def run_on_model_error_callback(self, **_: Any) -> Any:
+        return None
+
+    async def run_before_tool_callback(self, **_: Any) -> Any:
+        return None
+
+    async def run_after_tool_callback(self, **_: Any) -> Any:
+        return None
+
+    async def run_on_tool_error_callback(self, **_: Any) -> Any:
+        return None
+
+
+def _ensure_invocation_context_defaults(ctx: InvocationContext, agent: Agent) -> None:
+    if getattr(agent, "name", None) is None:
+        _set_default_attr(agent, "name", "assistant")
+    for callback_name in (
+        "canonical_before_tool_callbacks",
+        "canonical_after_tool_callbacks",
+        "canonical_on_tool_error_callbacks",
+    ):
+        if getattr(agent, callback_name, None) is None:
+            _set_default_attr(agent, callback_name, [])
+    if getattr(ctx, "agent", None) is None:
+        _set_default_attr(ctx, "agent", agent)
+    if getattr(ctx, "plugin_manager", None) is None:
+        _set_default_attr(ctx, "plugin_manager", _NoopPluginManager())
+
+
+def _set_default_attr(target: Any, name: str, value: Any) -> None:
+    try:
+        setattr(target, name, value)
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "piagent: failed to set default %s on %s: %s",
+            name,
+            type(target).__name__,
+            type(e).__name__,
+        )
 
 
 def _coerce_tool_result(result: Any) -> Any:
@@ -238,7 +511,7 @@ def _short_hash(value: str) -> str:
     return hashlib.sha1(value.encode("utf-8")).hexdigest()[:8]
 
 
-async def close_toolsets(toolsets: list["BaseToolset"]) -> None:
+async def close_toolsets(toolsets: list[BaseToolset]) -> None:
     """Best-effort close of toolsets opened during Pi tool collection."""
     for toolset in toolsets:
         close = getattr(toolset, "close", None)

--- a/veadk/runtime/piagent/tools_bridge.py
+++ b/veadk/runtime/piagent/tools_bridge.py
@@ -41,6 +41,7 @@ logger = get_logger(__name__)
 
 EventSink = Callable[[Event], Awaitable[None]]
 Executor = Callable[[dict[str, Any], str], Awaitable[Any]]
+TRANSFERRED_STATUS = "transferred"
 
 _TOOL_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
 _MAX_TOOL_RESULT_CHARS = 20000
@@ -372,6 +373,14 @@ def _make_executor(
         elif getattr(actions, "requested_tool_confirmations", None):
             status = "confirmation_required"
             payload = {"status": status, "call_id": call_id, "response": payload}
+        elif getattr(actions, "transfer_to_agent", None):
+            status = TRANSFERRED_STATUS
+            payload = {
+                "status": status,
+                "call_id": call_id,
+                "agent_name": actions.transfer_to_agent,
+                "response": payload,
+            }
         else:
             response = responses[0].response if responses else {}
             status = (
@@ -409,6 +418,12 @@ def _error_response_event(
 
 class _NoopPluginManager:
     plugins: ClassVar[list[Any]] = []
+
+    async def run_before_agent_callback(self, **_: Any) -> Any:
+        return None
+
+    async def run_after_agent_callback(self, **_: Any) -> Any:
+        return None
 
     async def run_before_model_callback(self, **_: Any) -> Any:
         return None

--- a/veadk/runtime/piagent/translate.py
+++ b/veadk/runtime/piagent/translate.py
@@ -36,7 +36,7 @@ _THINKING_MESSAGE_TYPES = {
 }
 
 
-def build_prompt(ctx: "InvocationContext") -> str:
+def build_prompt(ctx: InvocationContext) -> str:
     """Render ADK session history into a text prompt for Pi RPC Phase 1."""
 
     lines: list[str] = []
@@ -61,7 +61,7 @@ def build_prompt(ctx: "InvocationContext") -> str:
     return "\n".join(lines)
 
 
-def build_prompt_from_llm_request(llm_request: "LlmRequest") -> str:
+def build_prompt_from_llm_request(llm_request: LlmRequest) -> str:
     """Render callback-mutated LlmRequest contents into a Pi prompt."""
 
     lines: list[str] = []
@@ -150,9 +150,16 @@ def make_model_event(
 class PiEventTranslator:
     """Stateful converter for one Pi turn."""
 
-    def __init__(self, *, author: str, invocation_id: str):
+    def __init__(
+        self,
+        *,
+        author: str,
+        invocation_id: str,
+        bridged_tool_names: set[str] | None = None,
+    ):
         self.author = author
         self.invocation_id = invocation_id
+        self.bridged_tool_names = set(bridged_tool_names or ())
         self.emitted_text = False
         self._thinking_parts: list[str] = []
         self._text_parts: list[str] = []
@@ -162,10 +169,17 @@ class PiEventTranslator:
         if event_type == "message_update":
             return self._message_update_to_events(event)
         if event_type == "tool_execution_start":
+            if self._is_bridged_tool_event(event):
+                self._drain_pending_parts()
+                return []
             return [self._tool_call_event(event)]
         if event_type == "tool_execution_update":
+            if self._is_bridged_tool_event(event):
+                return []
             return self._tool_update_events(event)
         if event_type == "tool_execution_end":
+            if self._is_bridged_tool_event(event):
+                return []
             return [self._tool_response_event(event)]
         if event_type == "message_end":
             message = event.get("message")
@@ -181,6 +195,9 @@ class PiEventTranslator:
         if event_type == "agent_settled":
             return self._flush_events()
         return []
+
+    def _is_bridged_tool_event(self, event: dict[str, Any]) -> bool:
+        return str(event.get("toolName") or "") in self.bridged_tool_names
 
     def _message_update_to_events(self, event: dict[str, Any]) -> list[Event]:
         update = event.get("assistantMessageEvent")


### PR DESCRIPTION
## 背景

Codex/PiAgent 这类非 ADK 原生 runtime 会进入各自的 reasoning / tool loop，不再继续走 Google ADK AutoFlow。ADK AutoFlow 原生动态注入的 `transfer_to_agent(...)` 因此不会自动存在，导致配置了 `sub_agents` 的 Agent 在非 ADK runtime 下无法完成 agent transfer。

这个 PR 的目标是：在不重新依赖 ADK AutoFlow 的前提下，为非 ADK runtime 恢复 ADK 兼容的 agent transfer 语义。

## 总体方案

- 新增公共 transfer 兼容层 `veadk.runtime.agent_transfer`：
  - 复用 ADK `TransferToAgentTool` 暴露标准 `transfer_to_agent`；
  - 按 ADK agent tree 规则计算可转移目标，包括 child / parent / peer，并排除 `single_turn`、`task` 等不可转移 agent；
  - 给 LLM request 追加可用目标 agent 的 transfer instruction；
  - 从 ADK Event 中识别 `actions.transfer_to_agent`；
  - transfer 发生后调用目标 agent 的 `run_async`，并保留 `output_key` 写 state 的行为。

## Codex runtime

- 在 Codex runtime 初始化工具时注入 `transfer_to_agent`，让 Codex 的 Responses/tool loop 能看到和 ADK AutoFlow 等价的 transfer tool。
- 在 `before_model_callback` 之后重新同步 tool bundle，确保 callback 对工具集合的增删改会反映到 Codex shim 中。
- Codex tool executor 将 `actions.transfer_to_agent` 映射成结构化 `status="transferred"`，用于 runtime/proxy 判断 transfer 已发生。
- Codex Responses shim 在检测到 transfer tool output 后，会返回一个最小 completed response，避免继续发起第二次模型调用；真正的目标 agent 执行由 VeADK runtime 接管。
- Codex runtime 在收到 transfer event 后：
  - 对普通运行场景直接执行目标 agent，并把目标 agent event 继续 yield 出去；
  - 对 ADK 2.x 外层 scheduler 场景，延迟交还 transfer event，避免和 ADK 自己的 transfer 调度重复执行；
  - transfer 后清空 root final text buffer，避免 router transfer 后的文本泄漏。

## PiAgent runtime

- 先补齐 PiAgent 工具生命周期，使 PiAgent tool bridge 走 ADK tool callback 语义：
  - 支持 before/after tool callback；
  - 支持工具确认、鉴权恢复、callback 改写工具结果；
  - 支持 `before_model_callback` 修改后的 tools_dict 回写到 PiAgent extension；
  - 正确关闭 MCP/toolset 生命周期。
- 在 PiAgent runtime 中注入 `transfer_to_agent`，并把 transfer instruction 一起写入 prompt。
- PiAgent tool executor 同样将 `actions.transfer_to_agent` 映射成 `status="transferred"`。
- PiAgent runtime 在收到 transfer event 后执行目标子 agent，并停止 root PiAgent 后续输出，避免 router 文本泄漏。

## 测试覆盖

- 公共 transfer 测试：
  - `get_transfer_targets` 覆盖 ADK child / parent / peer 规则；
  - `append_transfer_instructions` 覆盖 transfer instruction 生成；
  - `run_transferred_agent` 覆盖目标 agent 执行和 `output_key` 写 state。
- Codex 测试：
  - transfer tool executor 能产出 ADK `actions.transfer_to_agent`；
  - Responses shim 在 transfer 后完成当前 turn，不触发第二次模型调用；
  - Codex runtime transfer 后继续执行目标 agent；
  - 覆盖 callback/tool bundle 同步、认证/确认工具恢复、MCP toolset 等既有工具链路，避免 transfer 接入破坏原有行为。
- PiAgent 测试：
  - transfer tool executor 能产出 ADK `actions.transfer_to_agent`；
  - 单 worker transfer 后执行目标 agent；
  - 多子 agent 能按 `agent_name` 精确路由到 `planner / coder / reviewer`；
  - 非法 target 会明确报错，不会误进入已有子 agent；
  - transfer instruction 注入 prompt；
  - `before_model_callback` 可以删除 transfer tool；
  - PiAgent 工具生命周期、MCP toolset、toolset close、callback 改写工具结果等行为保持可用。

## 验证

- `uv run pre-commit run --files veadk/runtime/agent_transfer.py veadk/runtime/codex/proxy.py veadk/runtime/codex/runtime.py veadk/runtime/codex/tools_bridge.py veadk/runtime/piagent/runtime.py veadk/runtime/piagent/tool_runtime.py veadk/runtime/piagent/tools_bridge.py veadk/runtime/piagent/translate.py tests/runtime/test_agent_transfer.py tests/runtime/codex/test_codex_runtime.py tests/runtime/piagent/test_piagent_runtime.py`
  - 结果：Passed
- `uv run pytest tests/runtime/piagent/test_piagent_runtime.py tests/runtime/test_agent_transfer.py tests/runtime/codex/test_codex_runtime.py`
  - 结果：`82 passed, 9 warnings`
- 使用本地临时真实模型 E2E 脚本验证 PiAgent root 转给真实 LLM worker：
  - root 使用 `runtime="piagent"`；worker 使用真实 LLM Agent；
  - 模型参数来自仓库 `.env`，`MODEL_AGENT_API_BASE` 显式使用 `https://ark.cn-beijing.volces.com/api/v3/`；
  - 结果：出现 `CALL transfer_to_agent {"agent_name": "worker"}`、`TRANSFER_ACTION worker`，最终 worker 输出 `PIAGENT_REAL_LLM_WORKER_OK`。
- 已做云端 AgentKit PiAgent smoke：
  - runtime `r-yeu2jhhkowdvde9li1qa`
  - `/run_sse` 返回 200
  - 日志出现 `piagent: generated tool extension for ['transfer_to_agent']` 和 `tool=transfer_to_agent status=transferred`
  - 最终事件 author 为 `worker`。
