### PR TITLE
fix(studio): version environment TOS storage

### DIFF
--- a/frontend/server/environments/repository.py
+++ b/frontend/server/environments/repository.py
@@ -31,6 +31,26 @@ _ID_RE = re.compile(r"[0-9a-f]{32}")
 _VERSION_RE = re.compile(r"[0-9]{8}T[0-9]{6}Z-[0-9a-f]{8}")
 _MAX_JSON_BYTES = 256 * 1024
 _MAX_LOG_BYTES = 512 * 1024
+_CURRENT_STORAGE_VERSION = "v2"
+_LEGACY_RECORD_FIELDS = (
+    "name",
+    "description",
+    "operatingSystem",
+    "language",
+    "executionRuntime",
+    "optionIds",
+    "selectedSkills",
+    "dockerfile",
+    "id",
+    "ownerId",
+    "createdAt",
+    "updatedAt",
+    "latestVersionId",
+)
+_CURRENT_ONLY_RECORD_FIELDS = frozenset(
+    {"baseEnvironment", "gitSource", "imageSource", "containerRepository"}
+)
+_CURRENT_ONLY_BUILD_FIELDS = frozenset({"toolId", "toolStatus", "sourceCommitSha"})
 
 
 class EnvironmentNotFound(LookupError):
@@ -59,7 +79,12 @@ class TosEnvironmentRepository:
             raise ValueError("TOS environment storage requires a bucket.")
         self.bucket = bucket.strip()
         self._client_factory = client_factory
-        self._prefix = f"{root_prefix.strip('/')}/environments"
+        legacy_root_prefix = root_prefix.strip("/")
+        self._legacy_prefix = f"{legacy_root_prefix}/environments"
+        self._prefix = (
+            f"{_replace_storage_version(legacy_root_prefix, _CURRENT_STORAGE_VERSION)}"
+            "/environments"
+        )
 
     async def list(self, owner_id: str) -> list[EnvironmentRecord]:
         return await asyncio.to_thread(self._list, owner_id)
@@ -182,18 +207,24 @@ class TosEnvironmentRepository:
 
     def _list(self, owner_id: str) -> list[EnvironmentRecord]:
         client = self._client_factory()
-        owner_prefix = f"{self._owner_prefix(owner_id)}/"
-        records: list[EnvironmentRecord] = []
-        for key in self._list_keys(client, owner_prefix):
-            if not key.endswith("/summary.json"):
-                continue
-            record = EnvironmentRecord.model_validate_json(
-                self._read_object(client, key, _MAX_JSON_BYTES)
-            )
-            if record.owner_id == owner_id:
-                records.append(record)
+        records_by_id: dict[str, EnvironmentRecord] = {}
+        for prefix, legacy in (
+            (self._prefix, False),
+            (self._legacy_prefix, True),
+        ):
+            owner_prefix = f"{self._owner_prefix_for(prefix, owner_id)}/"
+            for key in self._list_keys(client, owner_prefix):
+                if not key.endswith("/summary.json"):
+                    continue
+                content = self._read_object(client, key, _MAX_JSON_BYTES)
+                record = EnvironmentRecord.model_validate_json(content)
+                if record.owner_id != owner_id:
+                    continue
+                if legacy:
+                    self._repair_legacy_record(client, record, content)
+                records_by_id.setdefault(record.id, record)
         return sorted(
-            records,
+            records_by_id.values(),
             key=lambda item: (item.updated_at, item.id),
             reverse=True,
         )
@@ -201,23 +232,28 @@ class TosEnvironmentRepository:
     def _get(self, owner_id: str, environment_id: str) -> EnvironmentRecord:
         self._validate_environment_id(environment_id)
         client = self._client_factory()
-        try:
-            content = self._read_object(
-                client,
-                self._summary_key(owner_id, environment_id),
-                _MAX_JSON_BYTES,
-            )
-        except Exception as error:
-            if _status_code(error) == 404:
-                raise EnvironmentNotFound("环境不存在或已被删除。") from error
-            raise
+        content, legacy = self._read_current_or_legacy(
+            client,
+            self._summary_key(owner_id, environment_id),
+            self._legacy_summary_key(owner_id, environment_id),
+            _MAX_JSON_BYTES,
+            not_found_message="环境不存在或已被删除。",
+        )
         record = EnvironmentRecord.model_validate_json(content)
         if record.id != environment_id or record.owner_id != owner_id:
             raise EnvironmentNotFound("环境不存在或已被删除。")
+        if legacy:
+            self._repair_legacy_record(client, record, content)
         return record
 
     def _create(self, record: EnvironmentRecord) -> EnvironmentRecord:
         self._validate_environment_id(record.id)
+        try:
+            self._get(record.owner_id, record.id)
+        except EnvironmentNotFound:
+            pass
+        else:
+            raise EnvironmentConflict("环境 ID 已存在。")
         try:
             self._put_json(
                 self._client_factory(),
@@ -245,9 +281,12 @@ class TosEnvironmentRepository:
     def _delete(self, owner_id: str, environment_id: str) -> None:
         _ = self._get(owner_id, environment_id)
         client = self._client_factory()
-        prefix = f"{self._environment_prefix(owner_id, environment_id)}/"
-        for key in self._list_keys(client, prefix):
-            client.delete_object(bucket=self.bucket, key=key)
+        for prefix in (
+            self._environment_prefix(owner_id, environment_id),
+            self._legacy_environment_prefix(owner_id, environment_id),
+        ):
+            for key in self._list_keys(client, f"{prefix}/"):
+                client.delete_object(bucket=self.bucket, key=key)
 
     def _create_version(
         self,
@@ -349,24 +388,31 @@ class TosEnvironmentRepository:
         self._validate_environment_id(environment_id)
         if not re.fullmatch(r"[0-9a-f]{64}", artifact_id):
             raise ValueError("Invalid environment skill artifact id.")
-        return self._read_object(
+        content, _ = self._read_current_or_legacy(
             self._client_factory(),
             f"{self._environment_prefix(owner_id, environment_id)}/skills/{artifact_id}.json",
+            f"{self._legacy_environment_prefix(owner_id, environment_id)}/skills/{artifact_id}.json",
             2 * 1024 * 1024,
+            not_found_message="环境技能不存在或已被删除。",
         )
+        return content
 
     def _get_skill_manifest(
         self, owner_id: str, environment_id: str, version_id: str
     ) -> EnvironmentSkillManifest:
         self._validate_environment_id(environment_id)
         self._validate_version_id(version_id)
-        key = f"{self._version_prefix(owner_id, environment_id, version_id)}/skills-manifest.json"
+        client = self._client_factory()
         try:
-            content = self._read_object(self._client_factory(), key, _MAX_JSON_BYTES)
-        except Exception as error:
-            if _status_code(error) == 404:
-                return EnvironmentSkillManifest()
-            raise
+            content, _ = self._read_current_or_legacy(
+                client,
+                f"{self._version_prefix(owner_id, environment_id, version_id)}/skills-manifest.json",
+                f"{self._legacy_version_prefix(owner_id, environment_id, version_id)}/skills-manifest.json",
+                _MAX_JSON_BYTES,
+                not_found_message="环境技能清单不存在。",
+            )
+        except EnvironmentNotFound:
+            return EnvironmentSkillManifest()
         return EnvironmentSkillManifest.model_validate_json(content)
 
     def _get_version_config(
@@ -374,18 +420,19 @@ class TosEnvironmentRepository:
     ) -> EnvironmentRecord:
         self._validate_environment_id(environment_id)
         self._validate_version_id(version_id)
-        key = (
-            f"{self._version_prefix(owner_id, environment_id, version_id)}/config.json"
+        client = self._client_factory()
+        content, legacy = self._read_current_or_legacy(
+            client,
+            f"{self._version_prefix(owner_id, environment_id, version_id)}/config.json",
+            f"{self._legacy_version_prefix(owner_id, environment_id, version_id)}/config.json",
+            _MAX_JSON_BYTES,
+            not_found_message="环境构建版本不存在。",
         )
-        try:
-            content = self._read_object(self._client_factory(), key, _MAX_JSON_BYTES)
-        except Exception as error:
-            if _status_code(error) == 404:
-                raise EnvironmentNotFound("环境构建版本不存在。") from error
-            raise
         record = EnvironmentRecord.model_validate_json(content)
         if record.id != environment_id or record.owner_id != owner_id:
             raise EnvironmentNotFound("环境构建版本不存在。")
+        if legacy:
+            self._repair_legacy_version_record(client, record, version_id, content)
         return record
 
     def _get_version_skill_files(
@@ -395,9 +442,16 @@ class TosEnvironmentRepository:
         self._validate_version_id(version_id)
         prefix = f"{self._version_prefix(owner_id, environment_id, version_id)}/skills/"
         client = self._client_factory()
+        keys = self._list_keys(client, prefix)
+        if not keys:
+            prefix = (
+                f"{self._legacy_version_prefix(owner_id, environment_id, version_id)}"
+                "/skills/"
+            )
+            keys = self._list_keys(client, prefix)
         files: list[tuple[str, bytes]] = []
         total = 0
-        for key in self._list_keys(client, prefix):
+        for key in keys:
             content = self._read_object(client, key, 256 * 1024)
             total += len(content)
             if total > 2 * 1024 * 1024:
@@ -413,16 +467,19 @@ class TosEnvironmentRepository:
     ) -> EnvironmentBuild:
         self._validate_environment_id(environment_id)
         self._validate_version_id(version_id)
-        key = f"{self._version_prefix(owner_id, environment_id, version_id)}/build.json"
-        try:
-            content = self._read_object(self._client_factory(), key, _MAX_JSON_BYTES)
-        except Exception as error:
-            if _status_code(error) == 404:
-                raise EnvironmentNotFound("环境构建版本不存在。") from error
-            raise
+        client = self._client_factory()
+        content, legacy = self._read_current_or_legacy(
+            client,
+            f"{self._version_prefix(owner_id, environment_id, version_id)}/build.json",
+            f"{self._legacy_version_prefix(owner_id, environment_id, version_id)}/build.json",
+            _MAX_JSON_BYTES,
+            not_found_message="环境构建版本不存在。",
+        )
         build = EnvironmentBuild.model_validate_json(content)
         if build.environment_id != environment_id or build.version_id != version_id:
             raise EnvironmentNotFound("环境构建版本不存在。")
+        if legacy:
+            self._repair_legacy_build(client, owner_id, build, content)
         return build
 
     def _update_build(
@@ -463,24 +520,38 @@ class TosEnvironmentRepository:
     ) -> str:
         self._validate_environment_id(environment_id)
         self._validate_version_id(version_id)
-        key = f"{self._version_prefix(owner_id, environment_id, version_id)}/build.log"
         try:
-            content = self._read_object(self._client_factory(), key, _MAX_LOG_BYTES)
-        except Exception as error:
-            if _status_code(error) == 404:
-                return ""
-            raise
+            content, _ = self._read_current_or_legacy(
+                self._client_factory(),
+                f"{self._version_prefix(owner_id, environment_id, version_id)}/build.log",
+                f"{self._legacy_version_prefix(owner_id, environment_id, version_id)}/build.log",
+                _MAX_LOG_BYTES,
+                not_found_message="环境构建日志不存在。",
+            )
+        except EnvironmentNotFound:
+            return ""
         return content.decode("utf-8", errors="replace")
 
     def _owner_prefix(self, owner_id: str) -> str:
+        return self._owner_prefix_for(self._prefix, owner_id)
+
+    def _legacy_owner_prefix(self, owner_id: str) -> str:
+        return self._owner_prefix_for(self._legacy_prefix, owner_id)
+
+    @staticmethod
+    def _owner_prefix_for(prefix: str, owner_id: str) -> str:
         owner = quote(owner_id.strip(), safe="")
         if not owner:
             raise ValueError("Environment owner id cannot be empty.")
-        return f"{self._prefix}/{owner}"
+        return f"{prefix}/{owner}"
 
     def _environment_prefix(self, owner_id: str, environment_id: str) -> str:
         self._validate_environment_id(environment_id)
         return f"{self._owner_prefix(owner_id)}/{environment_id}"
+
+    def _legacy_environment_prefix(self, owner_id: str, environment_id: str) -> str:
+        self._validate_environment_id(environment_id)
+        return f"{self._legacy_owner_prefix(owner_id)}/{environment_id}"
 
     def _version_prefix(
         self, owner_id: str, environment_id: str, version_id: str
@@ -488,8 +559,116 @@ class TosEnvironmentRepository:
         self._validate_version_id(version_id)
         return f"{self._environment_prefix(owner_id, environment_id)}/versions/{version_id}"
 
+    def _legacy_version_prefix(
+        self, owner_id: str, environment_id: str, version_id: str
+    ) -> str:
+        self._validate_version_id(version_id)
+        return (
+            f"{self._legacy_environment_prefix(owner_id, environment_id)}"
+            f"/versions/{version_id}"
+        )
+
     def _summary_key(self, owner_id: str, environment_id: str) -> str:
         return f"{self._environment_prefix(owner_id, environment_id)}/summary.json"
+
+    def _legacy_summary_key(self, owner_id: str, environment_id: str) -> str:
+        return (
+            f"{self._legacy_environment_prefix(owner_id, environment_id)}/summary.json"
+        )
+
+    def _read_current_or_legacy(
+        self,
+        client: Any,
+        current_key: str,
+        legacy_key: str,
+        limit: int,
+        *,
+        not_found_message: str,
+    ) -> tuple[bytes, bool]:
+        try:
+            return self._read_object(client, current_key, limit), False
+        except Exception as current_error:
+            if _status_code(current_error) != 404:
+                raise
+        try:
+            return self._read_object(client, legacy_key, limit), True
+        except Exception as legacy_error:
+            if _status_code(legacy_error) == 404:
+                raise EnvironmentNotFound(not_found_message) from legacy_error
+            raise
+
+    def _repair_legacy_record(
+        self,
+        client: Any,
+        record: EnvironmentRecord,
+        content: bytes,
+    ) -> None:
+        payload = _json_object(content)
+        if not (_CURRENT_ONLY_RECORD_FIELDS & payload.keys()):
+            return
+        self._put_json_if_absent(
+            client,
+            self._summary_key(record.owner_id, record.id),
+            record,
+        )
+        self._put_json(
+            client,
+            self._legacy_summary_key(record.owner_id, record.id),
+            _legacy_record_payload(record),
+        )
+
+    def _repair_legacy_version_record(
+        self,
+        client: Any,
+        record: EnvironmentRecord,
+        version_id: str,
+        content: bytes,
+    ) -> None:
+        payload = _json_object(content)
+        if not (_CURRENT_ONLY_RECORD_FIELDS & payload.keys()):
+            return
+        self._put_json_if_absent(
+            client,
+            f"{self._version_prefix(record.owner_id, record.id, version_id)}/config.json",
+            record,
+        )
+        self._put_json(
+            client,
+            f"{self._legacy_version_prefix(record.owner_id, record.id, version_id)}/config.json",
+            _legacy_record_payload(record),
+        )
+
+    def _repair_legacy_build(
+        self,
+        client: Any,
+        owner_id: str,
+        build: EnvironmentBuild,
+        content: bytes,
+    ) -> None:
+        payload = _json_object(content)
+        if not (_CURRENT_ONLY_BUILD_FIELDS & payload.keys()):
+            return
+        self._put_json_if_absent(
+            client,
+            f"{self._version_prefix(owner_id, build.environment_id, build.version_id)}/build.json",
+            build,
+        )
+        self._put_json(
+            client,
+            f"{self._legacy_version_prefix(owner_id, build.environment_id, build.version_id)}/build.json",
+            {
+                key: value
+                for key, value in payload.items()
+                if key not in _CURRENT_ONLY_BUILD_FIELDS
+            },
+        )
+
+    def _put_json_if_absent(self, client: Any, key: str, value: Any) -> None:
+        try:
+            self._put_json(client, key, value, forbid_overwrite=True)
+        except Exception as error:
+            if _status_code(error) not in {409, 412}:
+                raise
 
     @staticmethod
     def _validate_environment_id(environment_id: str) -> None:
@@ -541,7 +720,14 @@ class TosEnvironmentRepository:
         *,
         forbid_overwrite: bool = False,
     ) -> None:
-        content = value.model_dump_json(by_alias=True).encode("utf-8")
+        if hasattr(value, "model_dump_json"):
+            content = value.model_dump_json(by_alias=True).encode("utf-8")
+        else:
+            content = json.dumps(
+                value,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
         if len(content) > _MAX_JSON_BYTES:
             raise ValueError("Environment metadata is too large.")
         self._put_bytes(
@@ -582,6 +768,25 @@ def _status_code(error: BaseException) -> int | None:
             except (TypeError, ValueError):
                 continue
     return None
+
+
+def _replace_storage_version(root_prefix: str, version: str) -> str:
+    parent, separator, leaf = root_prefix.rpartition("/")
+    if re.fullmatch(r"v[0-9]+", leaf):
+        return f"{parent}{separator}{version}" if parent else version
+    return f"{root_prefix}/{version}"
+
+
+def _json_object(content: bytes) -> dict[str, Any]:
+    value = json.loads(content)
+    if not isinstance(value, dict):
+        raise ValueError("Stored environment object must be a JSON object.")
+    return value
+
+
+def _legacy_record_payload(record: EnvironmentRecord) -> dict[str, Any]:
+    payload = record.model_dump(mode="json", by_alias=True)
+    return {key: payload[key] for key in _LEGACY_RECORD_FIELDS}
 
 
 __all__ = [

--- a/tests/frontend/server/environments/test_environments.py
+++ b/tests/frontend/server/environments/test_environments.py
@@ -48,6 +48,13 @@ from frontend.server.environments.resources import (
 from frontend.server.environments.routes import mount_environment_routes
 from frontend.server.environments.service import EnvironmentService
 
+_CURRENT_RECORD_FIELDS = (
+    "baseEnvironment",
+    "gitSource",
+    "imageSource",
+    "containerRepository",
+)
+
 
 class _TosError(Exception):
     def __init__(self, status_code: int):
@@ -570,8 +577,12 @@ def test_environment_crud_build_and_tos_version_layout():
     latest = client.get(f"/web/environments/{environment_id}").json()["latestVersion"]
     assert latest["versionId"] == version_id
     assert latest["status"] == "available"
-    prefix = f"veadk-studio/v1/environments/tenant%2Fa/{environment_id}"
+    prefix = f"veadk-studio/v2/environments/tenant%2Fa/{environment_id}"
     assert f"{prefix}/summary.json" in tos.objects
+    assert (
+        f"veadk-studio/v1/environments/tenant%2Fa/{environment_id}/summary.json"
+        not in tos.objects
+    )
     assert f"{prefix}/latest.json" in tos.objects
     assert f"{prefix}/versions/{version_id}/config.json" in tos.objects
     assert f"{prefix}/versions/{version_id}/Dockerfile" in tos.objects
@@ -581,6 +592,162 @@ def test_environment_crud_build_and_tos_version_layout():
 
     assert client.delete(f"/web/environments/{environment_id}").status_code == 204
     assert client.get(f"/web/environments/{environment_id}").status_code == 404
+
+
+def test_environment_list_reads_legacy_v1_records():
+    service, tos = _service()
+    app = FastAPI()
+    mount_environment_routes(app, service, lambda _request: "owner")
+    client = TestClient(app)
+    created = client.post("/web/environments", json=_payload()).json()
+    current_key = f"veadk-studio/v2/environments/owner/{created['id']}/summary.json"
+    legacy_key = f"veadk-studio/v1/environments/owner/{created['id']}/summary.json"
+    legacy = json.loads(tos.objects.pop(current_key))
+    for field in _CURRENT_RECORD_FIELDS:
+        legacy.pop(field)
+    tos.objects[legacy_key] = json.dumps(legacy).encode()
+
+    response = client.get("/web/environments")
+
+    assert response.status_code == 200
+    assert [item["id"] for item in response.json()["items"]] == [created["id"]]
+    assert response.json()["items"][0]["baseEnvironment"] == "ubuntu"
+    assert current_key not in tos.objects
+
+
+def test_environment_api_reads_a_complete_legacy_v1_environment_tree():
+    initial_service, tos = _service()
+    initial_app = FastAPI()
+    mount_environment_routes(initial_app, initial_service, lambda _request: "owner")
+    initial_client = TestClient(initial_app)
+    created = initial_client.post("/web/environments", json=_payload()).json()
+    started = initial_client.post(f"/web/environments/{created['id']}/build").json()
+    initial_client.get(
+        f"/web/environments/{created['id']}/builds/{started['versionId']}"
+    )
+    current_prefix = f"veadk-studio/v2/environments/owner/{created['id']}"
+    legacy_prefix = f"veadk-studio/v1/environments/owner/{created['id']}"
+    for current_key in [key for key in tos.objects if key.startswith(current_prefix)]:
+        content = tos.objects.pop(current_key)
+        if current_key.endswith(("/summary.json", "/config.json")):
+            payload = json.loads(content)
+            for field in _CURRENT_RECORD_FIELDS:
+                payload.pop(field)
+            content = json.dumps(payload).encode()
+        elif current_key.endswith(("/build.json", "/latest.json")):
+            payload = json.loads(content)
+            for field in ("toolId", "toolStatus", "sourceCommitSha"):
+                payload.pop(field)
+            content = json.dumps(payload).encode()
+        tos.objects[current_key.replace(current_prefix, legacy_prefix, 1)] = content
+
+    restored_service, _ = _service(tos=tos)
+    restored_app = FastAPI()
+    mount_environment_routes(restored_app, restored_service, lambda _request: "owner")
+    restored_client = TestClient(restored_app)
+
+    listed = restored_client.get("/web/environments")
+    build = restored_client.get(
+        f"/web/environments/{created['id']}/builds/{started['versionId']}"
+    )
+    manifest = restored_client.get(
+        f"/web/environments/{created['id']}/builds/{started['versionId']}/manifest"
+    )
+
+    assert listed.status_code == 200
+    assert [item["id"] for item in listed.json()["items"]] == [created["id"]]
+    assert build.status_code == 200
+    assert build.json()["versionId"] == started["versionId"]
+    assert manifest.status_code == 200
+    assert manifest.json()["spec"]["baseEnvironment"] == "ubuntu"
+
+
+def test_environment_list_prefers_v2_record_over_legacy_v1_record():
+    service, tos = _service()
+    app = FastAPI()
+    mount_environment_routes(app, service, lambda _request: "owner")
+    client = TestClient(app)
+    created = client.post("/web/environments", json=_payload()).json()
+    current_key = f"veadk-studio/v2/environments/owner/{created['id']}/summary.json"
+    legacy_key = f"veadk-studio/v1/environments/owner/{created['id']}/summary.json"
+    legacy = json.loads(tos.objects[current_key])
+    legacy["name"] = "旧版本名称"
+    for field in _CURRENT_RECORD_FIELDS:
+        legacy.pop(field)
+    tos.objects[legacy_key] = json.dumps(legacy).encode()
+
+    response = client.get("/web/environments")
+
+    assert response.status_code == 200
+    assert len(response.json()["items"]) == 1
+    assert response.json()["items"][0]["name"] == created["name"]
+
+
+def test_environment_update_copies_legacy_v1_record_to_v2():
+    service, tos = _service()
+    app = FastAPI()
+    mount_environment_routes(app, service, lambda _request: "owner")
+    client = TestClient(app)
+    created = client.post("/web/environments", json=_payload()).json()
+    current_key = f"veadk-studio/v2/environments/owner/{created['id']}/summary.json"
+    legacy_key = f"veadk-studio/v1/environments/owner/{created['id']}/summary.json"
+    legacy = json.loads(tos.objects.pop(current_key))
+    for field in _CURRENT_RECORD_FIELDS:
+        legacy.pop(field)
+    tos.objects[legacy_key] = json.dumps(legacy).encode()
+
+    response = client.patch(
+        f"/web/environments/{created['id']}", json={"name": "迁移后的环境"}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "迁移后的环境"
+    assert json.loads(tos.objects[current_key])["name"] == "迁移后的环境"
+    assert json.loads(tos.objects[legacy_key])["name"] == created["name"]
+
+
+def test_environment_list_repairs_records_written_to_legacy_prefix_by_new_schema():
+    service, tos = _service()
+    app = FastAPI()
+    mount_environment_routes(app, service, lambda _request: "owner")
+    client = TestClient(app)
+    created = client.post(
+        "/web/environments",
+        json=_payload(
+            baseEnvironment="aio-sandbox",
+            gitSource={
+                "repositoryUrl": "https://github.com/example/repo.git",
+                "ref": "main",
+                "dockerfilePath": "Dockerfile",
+            },
+        ),
+    ).json()
+    current_key = f"veadk-studio/v2/environments/owner/{created['id']}/summary.json"
+    legacy_key = f"veadk-studio/v1/environments/owner/{created['id']}/summary.json"
+    polluted = tos.objects.pop(current_key)
+    tos.objects[legacy_key] = polluted
+
+    response = client.get("/web/environments")
+
+    assert response.status_code == 200
+    assert response.json()["items"][0]["gitSource"]["ref"] == "main"
+    assert json.loads(tos.objects[current_key])["gitSource"]["ref"] == "main"
+    repaired = json.loads(tos.objects[legacy_key])
+    assert set(repaired) == {
+        "name",
+        "description",
+        "operatingSystem",
+        "language",
+        "executionRuntime",
+        "optionIds",
+        "selectedSkills",
+        "dockerfile",
+        "id",
+        "ownerId",
+        "createdAt",
+        "updatedAt",
+        "latestVersionId",
+    }
 
 
 def test_environment_manifest_describes_the_immutable_image_version():
@@ -676,7 +843,7 @@ def test_aio_build_provisions_and_persists_a_ready_private_tool(provider, region
     assert completed["steps"][-1]["status"] == "succeeded"
     assert provisioner.calls == [(started["image"], provider, region)]
     prefix = (
-        f"veadk-studio/v1/environments/owner/{environment['id']}"
+        f"veadk-studio/v2/environments/owner/{environment['id']}"
         f"/versions/{started['versionId']}"
     )
     persisted = json.loads(tos.objects[f"{prefix}/build.json"])
@@ -739,7 +906,7 @@ async def test_environment_queries_backfill_legacy_aio_tool_binding(query: str):
         client.get(build_url)
         _wait_for_build(client, build_url)
     prefix = (
-        f"veadk-studio/v1/environments/owner/{environment['id']}"
+        f"veadk-studio/v2/environments/owner/{environment['id']}"
         f"/versions/{started['versionId']}"
     )
     legacy = json.loads(tos.objects[f"{prefix}/build.json"])
@@ -797,7 +964,7 @@ async def test_resolving_legacy_aio_version_backfills_persisted_tool_binding():
         client.get(build_url)
         _wait_for_build(client, build_url)
     prefix = (
-        f"veadk-studio/v1/environments/owner/{environment['id']}"
+        f"veadk-studio/v2/environments/owner/{environment['id']}"
         f"/versions/{started['versionId']}"
     )
     legacy = json.loads(tos.objects[f"{prefix}/build.json"])
@@ -920,7 +1087,7 @@ def test_build_detail_returns_steps_and_only_downloads_logs_when_requested():
     assert complete["logUpdatedAt"]
     assert cloud.log_calls == 1
     prefix = (
-        f"veadk-studio/v1/environments/owner/{environment_id}/versions/{version_id}"
+        f"veadk-studio/v2/environments/owner/{environment_id}/versions/{version_id}"
     )
     assert tos.objects[f"{prefix}/build.log"] == b"build failed"
 
@@ -974,7 +1141,7 @@ def test_custom_dockerfile_is_preserved_verbatim():
     assert response.json()["dockerfile"] == custom
     environment_id = response.json()["id"]
     summary = tos.objects[
-        f"veadk-studio/v1/environments/owner/{environment_id}/summary.json"
+        f"veadk-studio/v2/environments/owner/{environment_id}/summary.json"
     ]
     assert json.loads(summary)["dockerfile"] == custom
 
@@ -1014,7 +1181,7 @@ def test_environment_build_snapshots_local_skills_into_fixed_image_directory(tmp
     assert build.status_code == 202
     version_id = build.json()["versionId"]
     prefix = (
-        f"veadk-studio/v1/environments/owner/{environment['id']}/versions/{version_id}"
+        f"veadk-studio/v2/environments/owner/{environment['id']}/versions/{version_id}"
     )
     manifest = json.loads(tos.objects[f"{prefix}/skills-manifest.json"])
     assert manifest["skills"][0]["name"] == "release-notes"


### PR DESCRIPTION
## Summary

- store new environment records and build artifacts under the v2 TOS prefix
- keep v1 as a read fallback for existing Studio installations
- prefer v2 records when both versions exist and copy legacy edits forward to v2
- repair records that were previously written with newer fields under the v1 prefix

## Validation

- `pre-commit run --all-files`
- `uv run pytest tests/frontend/server/environments tests/frontend/server/workspaces/test_workspaces.py -q` (110 passed)
- verified against real TOS: old Studio writes v1, new Studio reads v1 and writes v2, old Studio continues listing v1 without errors