### PR TITLE
feat(studio): add AgentKit CLI terminal

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -226,6 +226,7 @@ import {
   type VideoTaskEvent,
 } from "./ui/new-chat-modes/video-task";
 import { NewChatVideoTaskDialog } from "./ui/new-chat-modes/NewChatVideoTaskDialog";
+import { AgentKitCliDialog } from "./ui/AgentKitCliDialog";
 import {
   SandboxLaunchDialog,
   type SandboxLaunchState,
@@ -1321,6 +1322,7 @@ export default function App() {
   );
   const [videoTask, setVideoTask] = useState<VideoGenerationTask | null>(null);
   const [videoTaskDialogOpen, setVideoTaskDialogOpen] = useState(false);
+  const [agentKitCliOpen, setAgentKitCliOpen] = useState(false);
   const videoTaskRef = useRef<VideoGenerationTask | null>(null);
   const videoTaskAbortRef = useRef<AbortController | null>(null);
   const [newChatCapabilities, setNewChatCapabilities] =
@@ -6306,6 +6308,7 @@ export default function App() {
         onWorkspace={() => requestIntelligentNavigation(openWorkspacePage)}
         onApplications={() => requestIntelligentNavigation(openApplicationsPage)}
         onCronJobs={() => requestIntelligentNavigation(openCronJobsPage)}
+        onAgentKitCli={() => setAgentKitCliOpen(true)}
         onSystemInfo={() => requestIntelligentNavigation(() => {
           pushStudioPage({
             page: "system-info",
@@ -7774,6 +7777,11 @@ export default function App() {
         checking={authRecoveryChecking}
         error={authRecoveryError}
         onLogin={() => void recoverAuthentication()}
+      />
+
+      <AgentKitCliDialog
+        open={agentKitCliOpen}
+        onClose={() => setAgentKitCliOpen(false)}
       />
 
       <NewChatVideoTaskDialog

--- a/frontend/src/adk/agentkitCli.ts
+++ b/frontend/src/adk/agentkitCli.ts
@@ -1,0 +1,132 @@
+import { httpErrorMessage, studioFetch } from "./client";
+import type { SandboxToolLaunch } from "./sandbox";
+
+const API = "/web/agentkit-cli";
+const REQUEST_TIMEOUT_MS = 60_000;
+const CREATE_TIMEOUT_MS = 330_000;
+
+export const AGENTKIT_CLI_UNCONFIGURED_MESSAGE =
+  "管理员未配置 AgentKit Dev Sandbox，请配置后再使用";
+
+export interface AgentKitCliCapabilities {
+  enabled: boolean;
+  reason: string;
+}
+
+export interface AgentKitCliSession {
+  id: string;
+  status: string;
+  displayName: string;
+  expireAt: string;
+}
+
+interface RequestOptions {
+  signal?: AbortSignal;
+}
+
+function headers(json = false): Headers {
+  const value = new Headers({ Accept: "application/json" });
+  if (json) value.set("Content-Type", "application/json");
+  return value;
+}
+
+async function responseError(response: Response, fallback: string): Promise<Error> {
+  return new Error(await httpErrorMessage(response, fallback));
+}
+
+function parseSession(value: unknown): AgentKitCliSession {
+  const session = value as {
+    sessionId?: unknown;
+    status?: unknown;
+    displayName?: unknown;
+    expireAt?: unknown;
+  };
+  if (typeof session?.sessionId !== "string" || typeof session.status !== "string") {
+    throw new Error("AgentKit CLI 返回了无效的 Session。");
+  }
+  return {
+    id: session.sessionId,
+    status: session.status,
+    displayName: typeof session.displayName === "string" ? session.displayName : "",
+    expireAt: typeof session.expireAt === "string" ? session.expireAt : "",
+  };
+}
+
+export const agentKitCliClient = {
+  async capabilities(options: RequestOptions = {}): Promise<AgentKitCliCapabilities> {
+    const response = await studioFetch(
+      `${API}/capabilities`,
+      { headers: headers(), signal: options.signal },
+      REQUEST_TIMEOUT_MS,
+    );
+    if (!response.ok) throw await responseError(response, "无法读取 AgentKit CLI 配置。");
+    const value = (await response.json()) as { enabled?: unknown; reason?: unknown };
+    if (typeof value.enabled !== "boolean") {
+      throw new Error("AgentKit CLI 返回了无效的配置状态。");
+    }
+    return {
+      enabled: value.enabled,
+      reason: typeof value.reason === "string" ? value.reason : "",
+    };
+  },
+
+  async listSessions(options: RequestOptions = {}): Promise<AgentKitCliSession[]> {
+    const response = await studioFetch(
+      `${API}/sessions`,
+      { headers: headers(), signal: options.signal },
+      REQUEST_TIMEOUT_MS,
+    );
+    if (!response.ok) throw await responseError(response, "无法读取 AgentKit CLI Session。");
+    const value = (await response.json()) as { sessions?: unknown };
+    if (!Array.isArray(value.sessions)) {
+      throw new Error("AgentKit CLI 返回了无效的 Session 列表。");
+    }
+    return value.sessions.map(parseSession);
+  },
+
+  async createSession(options: RequestOptions = {}): Promise<AgentKitCliSession> {
+    const response = await studioFetch(
+      `${API}/sessions`,
+      {
+        method: "POST",
+        headers: headers(true),
+        body: JSON.stringify({ persistent: false }),
+        signal: options.signal,
+      },
+      CREATE_TIMEOUT_MS,
+    );
+    if (!response.ok) throw await responseError(response, "无法创建 AgentKit CLI Session。");
+    return parseSession(await response.json());
+  },
+
+  async openSession(sessionId: string, options: RequestOptions = {}): Promise<void> {
+    const response = await studioFetch(
+      `${API}/sessions/${encodeURIComponent(sessionId)}/open`,
+      { method: "POST", headers: headers(), signal: options.signal },
+      REQUEST_TIMEOUT_MS,
+    );
+    if (!response.ok) throw await responseError(response, "无法打开 AgentKit CLI Session。");
+  },
+
+  async launchTerminal(
+    sessionId: string,
+    options: RequestOptions = {},
+  ): Promise<SandboxToolLaunch> {
+    const response = await studioFetch(
+      `${API}/sessions/${encodeURIComponent(sessionId)}/terminal`,
+      { method: "POST", headers: headers(), signal: options.signal },
+      REQUEST_TIMEOUT_MS,
+    );
+    if (!response.ok) throw await responseError(response, "无法打开 AgentKit CLI 终端。");
+    const value = (await response.json()) as { url?: unknown; shellSessionId?: unknown };
+    if (typeof value.url !== "string" || !value.url) {
+      throw new Error("AgentKit CLI 返回了无效的终端地址。");
+    }
+    return {
+      url: value.url,
+      ...(typeof value.shellSessionId === "string"
+        ? { shellSessionId: value.shellSessionId }
+        : {}),
+    };
+  },
+};

--- a/frontend/src/adk/client.ts
+++ b/frontend/src/adk/client.ts
@@ -499,7 +499,10 @@ function formatErrorDetail(detail: unknown): string {
   return "";
 }
 
-async function httpErrorMessage(res: Response, fallback: string): Promise<string> {
+export async function httpErrorMessage(
+  res: Response,
+  fallback: string,
+): Promise<string> {
   const context = `${fallback}（HTTP ${res.status}）`;
   const text = await res.text().catch(() => "");
   if (!text) return context;

--- a/frontend/src/ui/AgentKitCliDialog.css
+++ b/frontend/src/ui/AgentKitCliDialog.css
@@ -1,0 +1,129 @@
+.agentkit-cli-dialog {
+  width: min(1180px, calc(100vw - 44px));
+  height: min(780px, calc(100vh - 48px));
+}
+
+.agentkit-cli-dialog .sandbox-control-head {
+  grid-template-columns: 18px minmax(0, 1fr) 30px;
+  gap: 8px;
+  padding-left: 14px;
+}
+
+.agentkit-cli-dialog .sandbox-control-head-icon {
+  width: 18px;
+  height: 18px;
+  border-radius: 0;
+  background: transparent;
+}
+
+.agentkit-cli-dialog .sandbox-control-head-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.agentkit-cli-dialog .sandbox-control-head h2 {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.agentkit-cli-dialog .sandbox-tool-toolbar {
+  padding-left: 14px;
+}
+
+.agentkit-cli-dialog .sandbox-tool-toolbar > span {
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 20px;
+}
+
+.agentkit-cli-state {
+  --foreground: 0 0% 94%;
+  --muted-foreground: 220 8% 68%;
+  --border: 220 9% 30%;
+  --background: 225 15% 14%;
+  --secondary: 220 10% 22%;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 12px;
+  min-height: 100%;
+  padding: 32px;
+  color: hsl(var(--muted-foreground));
+  text-align: center;
+}
+
+.agentkit-cli-state > svg {
+  width: 28px;
+  height: 28px;
+  color: hsl(var(--foreground));
+}
+
+.agentkit-cli-state strong {
+  max-width: 520px;
+  color: hsl(var(--foreground));
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.6;
+  text-wrap: balance;
+}
+
+.agentkit-cli-state span {
+  max-width: 520px;
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.agentkit-cli-error-detail {
+  width: min(680px, 100%);
+  max-height: 220px;
+  margin: 0;
+  padding: 12px 14px;
+  overflow: auto;
+  border: 1px solid hsl(var(--border));
+  border-radius: 8px;
+  background: hsl(var(--background));
+  color: hsl(var(--muted-foreground));
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.6;
+  text-align: left;
+  white-space: pre-wrap;
+  word-break: break-word;
+  user-select: text;
+}
+
+.agentkit-cli-state button {
+  min-width: 72px;
+  height: 32px;
+  padding: 0 14px;
+  border: 1px solid hsl(var(--border));
+  border-radius: 8px;
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.agentkit-cli-state button:hover {
+  background: hsl(var(--secondary));
+}
+
+@media (max-width: 640px) {
+  .agentkit-cli-dialog {
+    width: calc(100vw - 20px);
+    height: calc(100dvh - 20px);
+  }
+
+  .agentkit-cli-dialog .sandbox-control-head {
+    padding-inline: 14px;
+  }
+
+  .agentkit-cli-dialog .sandbox-tool-toolbar {
+    padding-inline: 12px;
+  }
+
+  .agentkit-cli-state {
+    padding: 24px 18px;
+  }
+}

--- a/frontend/src/ui/AgentKitCliDialog.tsx
+++ b/frontend/src/ui/AgentKitCliDialog.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useState } from "react";
+import { LoadingIndicator } from "@openai/apps-sdk-ui/components/Indicator";
+import {
+  AGENTKIT_CLI_UNCONFIGURED_MESSAGE,
+  agentKitCliClient,
+  type AgentKitCliSession,
+} from "../adk/agentkitCli";
+import type { SandboxToolLaunch } from "../adk/sandbox";
+import { DialogShell } from "./SandboxControls";
+import { SandboxTerminalIcon } from "./icons/SandboxControlIcons";
+import { TextShimmer } from "./text-shimmer/TextShimmer";
+import "./AgentKitCliDialog.css";
+
+type LoadingStage = "searching" | "creating" | "connecting";
+type DialogState = LoadingStage | "ready" | "unconfigured" | "error";
+
+const LOADING_LABELS: Record<LoadingStage, string> = {
+  searching: "正在查找已有环境",
+  creating: "环境初始化中",
+  connecting: "正在连接已有环境",
+};
+
+const ACTIVE_STATUSES = new Set([
+  "creating",
+  "pending",
+  "running",
+  "starting",
+  "initializing",
+]);
+const READY_STATUS = "ready";
+const SESSION_POLL_INTERVAL_MS = 1_500;
+const SESSION_POLL_ATTEMPTS = 80;
+
+function normalizedStatus(session: AgentKitCliSession): string {
+  return session.status.trim().toLowerCase();
+}
+
+function waitForPoll(signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = window.setTimeout(resolve, SESSION_POLL_INTERVAL_MS);
+    signal.addEventListener(
+      "abort",
+      () => {
+        window.clearTimeout(timer);
+        reject(new DOMException("Aborted", "AbortError"));
+      },
+      { once: true },
+    );
+  });
+}
+
+async function waitUntilReady(
+  initial: AgentKitCliSession,
+  signal: AbortSignal,
+): Promise<AgentKitCliSession> {
+  let session = initial;
+  for (let attempt = 0; attempt < SESSION_POLL_ATTEMPTS; attempt += 1) {
+    const status = normalizedStatus(session);
+    if (status === READY_STATUS) return session;
+    if (!ACTIVE_STATUSES.has(status)) {
+      throw new Error(`AgentKit CLI 环境初始化失败，当前状态：${session.status}。`);
+    }
+    await waitForPoll(signal);
+    const sessions = await agentKitCliClient.listSessions({ signal });
+    const refreshed = sessions.find((candidate) => candidate.id === session.id);
+    if (!refreshed) {
+      throw new Error("AgentKit CLI Session 不存在或已过期，请重试。");
+    }
+    session = refreshed;
+  }
+  throw new Error("AgentKit CLI 环境初始化超时，请稍后重试。");
+}
+
+async function initializeTerminal(
+  signal: AbortSignal,
+  onStage: (stage: LoadingStage) => void,
+): Promise<{ launch: SandboxToolLaunch; session: AgentKitCliSession }> {
+  onStage("searching");
+  const capabilities = await agentKitCliClient.capabilities({ signal });
+  if (!capabilities.enabled) {
+    throw new Error(capabilities.reason || AGENTKIT_CLI_UNCONFIGURED_MESSAGE);
+  }
+  const sessions = await agentKitCliClient.listSessions({ signal });
+  let session = sessions.find((candidate) => normalizedStatus(candidate) === READY_STATUS)
+    ?? sessions.find((candidate) => ACTIVE_STATUSES.has(normalizedStatus(candidate)));
+  if (!session) {
+    onStage("creating");
+    session = await agentKitCliClient.createSession({ signal });
+  } else {
+    onStage("connecting");
+  }
+  session = await waitUntilReady(session, signal);
+  onStage("connecting");
+  await agentKitCliClient.openSession(session.id, { signal });
+  return {
+    launch: await agentKitCliClient.launchTerminal(session.id, { signal }),
+    session,
+  };
+}
+
+function isLoadingState(state: DialogState): state is LoadingStage {
+  return state === "searching" || state === "creating" || state === "connecting";
+}
+
+function isLaunchReusable(expireAt: string, now: number): boolean {
+  const expiresAt = Date.parse(expireAt);
+  return Number.isFinite(expiresAt) && expiresAt > now;
+}
+
+function recyclingLabel(expireAt: string, now: number): string {
+  const expiresAt = Date.parse(expireAt);
+  if (!Number.isFinite(expiresAt)) return "非持久化环境";
+  const remainingMinutes = Math.max(0, Math.ceil((expiresAt - now) / 60_000));
+  const hours = Math.floor(remainingMinutes / 60);
+  const minutes = remainingMinutes % 60;
+  if (hours > 0) return `${hours} 小时 ${minutes} 分钟后环境回收`;
+  return `${minutes} 分钟后环境回收`;
+}
+
+function errorMessage(cause: unknown): string {
+  const raw = cause instanceof Error ? cause.message : String(cause);
+  if (cause instanceof TypeError) {
+    return `无法连接 Studio 服务，未收到服务端响应。\n原始错误：${raw}`;
+  }
+  return raw;
+}
+
+export function AgentKitCliDialog({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [state, setState] = useState<DialogState>("searching");
+  const [launch, setLaunch] = useState<SandboxToolLaunch | null>(null);
+  const [expireAt, setExpireAt] = useState("");
+  const [error, setError] = useState("");
+  const [attempt, setAttempt] = useState(0);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!open || !expireAt) return undefined;
+    setNow(Date.now());
+    const timer = window.setInterval(() => setNow(Date.now()), 60_000);
+    return () => window.clearInterval(timer);
+  }, [expireAt, open]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    if (launch && isLaunchReusable(expireAt, Date.now())) {
+      setError("");
+      setState("ready");
+      return undefined;
+    }
+    const controller = new AbortController();
+    setState("searching");
+    setLaunch(null);
+    setExpireAt("");
+    setError("");
+    void initializeTerminal(controller.signal, setState)
+      .then(({ launch: nextLaunch, session }) => {
+        if (controller.signal.aborted) return;
+        setLaunch(nextLaunch);
+        setExpireAt(session.expireAt);
+        setState("ready");
+      })
+      .catch((cause) => {
+        if (controller.signal.aborted) return;
+        const message = errorMessage(cause);
+        setError(message);
+        setState(
+          message.includes(AGENTKIT_CLI_UNCONFIGURED_MESSAGE)
+            ? "unconfigured"
+            : "error",
+        );
+      });
+    return () => controller.abort();
+  }, [attempt, expireAt, launch, open]);
+
+  const loading = isLoadingState(state);
+
+  return (
+    <DialogShell
+      open={open}
+      keepMounted
+      title="AgentKit CLI"
+      icon={<SandboxTerminalIcon />}
+      className="sandbox-tool-dialog sandbox-tool-dialog--terminal agentkit-cli-dialog"
+      onClose={onClose}
+    >
+      <div className="sandbox-tool-toolbar">
+        <span>
+          <i className={loading ? "is-loading" : state === "ready" ? "is-ready" : ""} />
+          {loading
+            ? LOADING_LABELS[state]
+            : state === "ready"
+              ? recyclingLabel(expireAt, now)
+              : "连接不可用"}
+        </span>
+      </div>
+      <div className="sandbox-tool-surface agentkit-cli-surface">
+        {loading ? (
+          <div className="agentkit-cli-state" role="status" aria-live="polite">
+            <LoadingIndicator size={20} />
+            <TextShimmer as="strong">{LOADING_LABELS[state]}</TextShimmer>
+          </div>
+        ) : state === "unconfigured" ? (
+          <div className="agentkit-cli-state" role="status">
+            <SandboxTerminalIcon />
+            <strong>{AGENTKIT_CLI_UNCONFIGURED_MESSAGE}</strong>
+          </div>
+        ) : state === "error" ? (
+          <div className="agentkit-cli-state is-error" role="alert">
+            <strong>AgentKit CLI 请求失败</strong>
+            <pre className="agentkit-cli-error-detail">{error}</pre>
+            <button type="button" onClick={() => setAttempt((value) => value + 1)}>
+              重试
+            </button>
+          </div>
+        ) : launch ? (
+          <iframe
+            src={launch.url}
+            title="AgentKit CLI 终端"
+            allow="clipboard-read; clipboard-write"
+            sandbox="allow-downloads allow-forms allow-modals allow-popups allow-pointer-lock allow-same-origin allow-scripts"
+          />
+        ) : null}
+      </div>
+    </DialogShell>
+  );
+}

--- a/frontend/src/ui/AgentKitPromoCard.css
+++ b/frontend/src/ui/AgentKitPromoCard.css
@@ -53,25 +53,37 @@
 .agentkit-promo-actions {
   display: flex;
   justify-content: flex-start;
-  gap: 6px;
-  margin-top: 12px;
+  gap: 14px;
+  margin-top: 10px;
 }
 
 .agentkit-promo-action {
+  display: inline-flex;
+  align-items: center;
   min-width: 0;
   flex: 0 0 auto;
+  color: hsl(var(--sidebar-section-title));
   font-size: 12px;
   font-weight: 400;
+  line-height: 18px;
+  text-decoration-line: underline;
+  text-decoration-color: hsl(var(--sidebar-section-title) / 0.45);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  transition:
+    color 120ms ease-out,
+    text-decoration-color 120ms ease-out;
 }
 
-.agentkit-promo-arrow-icon {
-  transform: translateX(0);
-  transition: transform 160ms ease-out;
+.agentkit-promo-action:hover {
+  color: hsl(var(--sidebar-foreground));
+  text-decoration-color: currentColor;
 }
 
-.agentkit-promo-action.is-console:hover .agentkit-promo-arrow-icon,
-.agentkit-promo-action.is-console:focus-visible .agentkit-promo-arrow-icon {
-  transform: translateX(2px);
+.agentkit-promo-action:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid hsl(var(--ring) / 0.45);
+  outline-offset: 3px;
 }
 
 .sidebar.is-collapsed .agentkit-promo-card {
@@ -81,7 +93,7 @@
 @media (prefers-reduced-motion: reduce) {
   .agentkit-promo-card,
   .agentkit-promo-close,
-  .agentkit-promo-arrow-icon {
+  .agentkit-promo-action {
     transition: none;
   }
 }

--- a/frontend/src/ui/AgentKitPromoCard.tsx
+++ b/frontend/src/ui/AgentKitPromoCard.tsx
@@ -1,6 +1,6 @@
 import { type MouseEvent, useState } from "react";
-import { Button, ButtonLink } from "@openai/apps-sdk-ui/components/Button";
-import { ArrowRight, X } from "@openai/apps-sdk-ui/components/Icon";
+import { Button } from "@openai/apps-sdk-ui/components/Button";
+import { X } from "@openai/apps-sdk-ui/components/Icon";
 import type { CloudProvider } from "../adk/cloudProvider";
 import { agentKitLinks } from "./agentKitLinks";
 import "./AgentKitPromoCard.css";
@@ -47,36 +47,26 @@ export function AgentKitPromoCard({ cloudProvider }: AgentKitPromoCardProps) {
       </p>
 
       <div className="agentkit-promo-actions">
-        <ButtonLink
+        <a
           className="agentkit-promo-action is-docs"
           href={links.docs}
-          external
-          color="secondary"
-          variant="soft"
-          size="xs"
-          pill={false}
+          target="_blank"
+          rel="noreferrer"
           aria-label="打开 AgentKit 文档，在新窗口打开"
           onClick={handleActionClick}
         >
           文档
-        </ButtonLink>
-        <ButtonLink
+        </a>
+        <a
           className="agentkit-promo-action is-console"
           href={links.console}
-          external
-          color="primary"
-          variant="solid"
-          size="xs"
-          pill={false}
+          target="_blank"
+          rel="noreferrer"
           aria-label="打开 AgentKit 控制台，在新窗口打开"
           onClick={handleActionClick}
         >
           控制台
-          <ArrowRight
-            className="agentkit-promo-arrow-icon"
-            aria-hidden="true"
-          />
-        </ButtonLink>
+        </a>
       </div>
     </section>
   );

--- a/frontend/src/ui/SandboxControls.tsx
+++ b/frontend/src/ui/SandboxControls.tsx
@@ -28,16 +28,18 @@ import "./SandboxControls.css";
 
 interface DialogShellProps {
   open: boolean;
+  keepMounted?: boolean;
   title: string;
-  subtitle: string;
+  subtitle?: string;
   icon: ReactNode;
   className?: string;
   onClose: () => void;
   children: ReactNode;
 }
 
-function DialogShell({
+export function DialogShell({
   open,
+  keepMounted = false,
   title,
   subtitle,
   icon,
@@ -91,10 +93,11 @@ function DialogShell({
     };
   }, [open]);
 
-  if (!open) return null;
+  if (!open && !keepMounted) return null;
   return createPortal(
     <div
       className="sandbox-control-backdrop"
+      hidden={!open}
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) onClose();
       }}
@@ -111,7 +114,7 @@ function DialogShell({
           </span>
           <div>
             <h2 id={titleId}>{title}</h2>
-            <p>{subtitle}</p>
+            {subtitle ? <p>{subtitle}</p> : null}
           </div>
           <button
             ref={closeRef}

--- a/frontend/src/ui/Sidebar.css
+++ b/frontend/src/ui/Sidebar.css
@@ -6,3 +6,7 @@
 .new-chat--cronjobs.is-active > .icon {
   color: hsl(var(--foreground));
 }
+
+.sidebar-agentkit-cli-slot {
+  padding: 6px 8px 0;
+}

--- a/frontend/src/ui/Sidebar.tsx
+++ b/frontend/src/ui/Sidebar.tsx
@@ -28,6 +28,7 @@ import { displayName, profilePictureUrl } from "../adk/identity";
 import { SearchButton } from "./Search";
 import { AgentKitPromoCard } from "./AgentKitPromoCard";
 import { IssueFeedbackIcon } from "./icons/FeedbackIcons";
+import { SandboxTerminalIcon } from "./icons/SandboxControlIcons";
 import {
   NewChatIcon,
   ResourceLibraryIcon,
@@ -149,6 +150,7 @@ export interface SidebarProps {
   onWorkspace: () => void;
   onApplications: () => void;
   onCronJobs: () => void;
+  onAgentKitCli: () => void;
   onSystemInfo: () => void;
   onIssueFeedback: () => void;
   onPickSession: (id: string) => void;
@@ -331,6 +333,7 @@ export function Sidebar({
   onWorkspace,
   onApplications,
   onCronJobs,
+  onAgentKitCli,
   onSystemInfo,
   onIssueFeedback,
   onPickSession,
@@ -691,6 +694,18 @@ export function Sidebar({
 
       <div className="sidebar-footer">
         <AgentKitPromoCard cloudProvider={cloudProvider} />
+        <nav className="sidebar-nav sidebar-agentkit-cli-slot" aria-label="快捷入口">
+          <button
+            type="button"
+            className="new-chat sidebar-agentkit-cli"
+            onClick={onAgentKitCli}
+            aria-label="AgentKit CLI"
+            title="AgentKit CLI"
+          >
+            <SandboxTerminalIcon className="icon" />
+            <span className="sidebar-nav-label">AgentKit CLI</span>
+          </button>
+        </nav>
         <SidebarUser
           access={access}
           userInfo={userInfo}

--- a/frontend/tests/agentKitCli.test.mjs
+++ b/frontend/tests/agentKitCli.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const sidebarSource = readFileSync(
+  new URL("../src/ui/Sidebar.tsx", import.meta.url),
+  "utf8",
+);
+const dialogSource = readFileSync(
+  new URL("../src/ui/AgentKitCliDialog.tsx", import.meta.url),
+  "utf8",
+);
+const sandboxControlsSource = readFileSync(
+  new URL("../src/ui/SandboxControls.tsx", import.meta.url),
+  "utf8",
+);
+const clientSource = readFileSync(
+  new URL("../src/adk/agentkitCli.ts", import.meta.url),
+  "utf8",
+);
+const appSource = readFileSync(new URL("../src/App.tsx", import.meta.url), "utf8");
+
+test("places the AgentKit CLI entry between the promo and account", () => {
+  assert.match(sidebarSource, /onAgentKitCli: \(\) => void/);
+  assert.match(
+    sidebarSource,
+    /<AgentKitPromoCard[\s\S]*?className="new-chat sidebar-agentkit-cli"[\s\S]*?<SidebarUser/,
+  );
+  assert.match(sidebarSource, /<SandboxTerminalIcon className="icon" \/>[\s\S]*?AgentKit CLI/);
+  assert.match(sidebarSource, /<span className="sidebar-nav-label">AgentKit CLI<\/span>/);
+  assert.match(appSource, /onAgentKitCli=\{\(\) => setAgentKitCliOpen\(true\)\}/);
+  assert.match(appSource, /<AgentKitCliDialog[\s\S]*?open=\{agentKitCliOpen\}/);
+});
+
+test("initializes a non-persistent per-user AgentKit CLI session", () => {
+  assert.match(clientSource, /const API = "\/web\/agentkit-cli"/);
+  assert.match(clientSource, /JSON\.stringify\(\{ persistent: false \}\)/);
+  assert.match(dialogSource, /agentKitCliClient\.listSessions/);
+  assert.match(dialogSource, /agentKitCliClient\.createSession/);
+  assert.match(dialogSource, /agentKitCliClient\.openSession/);
+  assert.match(dialogSource, /agentKitCliClient\.launchTerminal/);
+  assert.match(dialogSource, /searching: "正在查找已有环境"/);
+  assert.match(dialogSource, /creating: "环境初始化中"/);
+  assert.match(dialogSource, /connecting: "正在连接已有环境"/);
+  assert.match(dialogSource, /onStage\("searching"\)/);
+  assert.match(dialogSource, /onStage\("creating"\)/);
+  assert.match(dialogSource, /onStage\("connecting"\)/);
+});
+
+test("reuses the current terminal launch while its session is valid", () => {
+  assert.match(
+    dialogSource,
+    /if \(launch && isLaunchReusable\(expireAt, Date\.now\(\)\)\) \{[\s\S]*?setState\("ready"\);[\s\S]*?return undefined;/,
+  );
+  assert.doesNotMatch(
+    dialogSource,
+    /if \(!open\) return undefined;[\s\S]{0,120}setLaunch\(null\);/,
+  );
+  assert.match(dialogSource, /<DialogShell[\s\S]*?keepMounted/);
+  assert.match(sandboxControlsSource, /if \(!open && !keepMounted\) return null/);
+  assert.match(sandboxControlsSource, /hidden=\{!open\}/);
+});
+
+test("shows configuration, retry, terminal, and expiry states", () => {
+  assert.match(
+    clientSource,
+    /管理员未配置 AgentKit Dev Sandbox，请配置后再使用/,
+  );
+  assert.match(dialogSource, /小时 \$\{minutes\} 分钟后环境回收/);
+  assert.match(dialogSource, /分钟后环境回收/);
+  assert.doesNotMatch(dialogSource, /在专属 Dev Sandbox Session 中体验 AgentKit CLI/);
+  assert.match(dialogSource, /AgentKit CLI 请求失败/);
+  assert.match(dialogSource, /agentkit-cli-error-detail/);
+  assert.match(dialogSource, /未收到服务端响应/);
+  assert.match(dialogSource, /原始错误/);
+  assert.match(clientSource, /httpErrorMessage\(response, fallback\)/);
+  assert.match(dialogSource, />\s*重试\s*</);
+  assert.match(dialogSource, /title="AgentKit CLI 终端"/);
+});

--- a/frontend/tests/agentKitPromoCard.test.mjs
+++ b/frontend/tests/agentKitPromoCard.test.mjs
@@ -50,12 +50,9 @@ test("promo links resolve to the matching cloud provider", () => {
 test("promo renders one AgentKit welcome card with native actions", () => {
   assert.match(
     promoSource,
-    /import \{ Button, ButtonLink \} from "@openai\/apps-sdk-ui\/components\/Button"/,
+    /import \{ Button \} from "@openai\/apps-sdk-ui\/components\/Button"/,
   );
-  assert.match(
-    promoSource,
-    /import \{ ArrowRight, X \} from "@openai\/apps-sdk-ui\/components\/Icon"/,
-  );
+  assert.match(promoSource, /import \{ X \} from "@openai\/apps-sdk-ui\/components\/Icon"/);
   assert.match(promoSource, /className=\{`agentkit-promo-card/);
   assert.match(promoSource, /欢迎使用 AgentKit/);
   assert.match(
@@ -64,14 +61,14 @@ test("promo renders one AgentKit welcome card with native actions", () => {
   );
   assert.match(
     promoSource,
-    /href=\{links\.docs\}[\s\S]*?color="secondary"[\s\S]*?文档/,
+    /<a[\s\S]*?href=\{links\.docs\}[\s\S]*?target="_blank"[\s\S]*?文档/,
   );
   assert.match(
     promoSource,
-    /href=\{links\.console\}[\s\S]*?color="primary"[\s\S]*?控制台[\s\S]*?<ArrowRight/,
+    /<a[\s\S]*?href=\{links\.console\}[\s\S]*?target="_blank"[\s\S]*?控制台/,
   );
-  assert.equal((promoSource.match(/<ButtonLink/g) ?? []).length, 2);
-  assert.equal((promoSource.match(/<ArrowRight/g) ?? []).length, 1);
+  assert.equal((promoSource.match(/<a/g) ?? []).length, 2);
+  assert.doesNotMatch(promoSource, /ButtonLink|ArrowRight/);
   assert.doesNotMatch(promoSource, /ExternalLink/);
   assert.doesNotMatch(promoSource, /AgentKitLogoIcon|agentkit-promo-leading-icon/);
 });
@@ -105,20 +102,17 @@ test("promo card uses neutral hover and restrained control motion", () => {
   );
   assert.match(
     promoStyles,
-    /\.agentkit-promo-action\s*\{[^}]*flex:\s*0 0 auto;[^}]*font-size:\s*12px;[^}]*font-weight:\s*400;/s,
+    /\.agentkit-promo-action\s*\{[^}]*flex:\s*0 0 auto;[^}]*font-size:\s*12px;[^}]*text-decoration-line:\s*underline;/s,
   );
   assert.match(
     promoStyles,
-    /\.agentkit-promo-arrow-icon\s*\{[^}]*transform:\s*translateX\(0\);[^}]*transition:\s*transform 160ms ease-out;/s,
+    /\.agentkit-promo-action:hover\s*\{[^}]*color:\s*hsl\(var\(--sidebar-foreground\)\);/s,
   );
   assert.match(
     promoStyles,
-    /\.agentkit-promo-action\.is-console:hover \.agentkit-promo-arrow-icon[\s\S]*?\.agentkit-promo-action\.is-console:focus-visible \.agentkit-promo-arrow-icon[\s\S]*?transform:\s*translateX\(2px\)/,
+    /\.agentkit-promo-action:focus-visible\s*\{[^}]*outline:\s*2px solid/s,
   );
-  assert.doesNotMatch(
-    promoStyles,
-    /\.agentkit-promo-arrow-icon\s*\{[^}]*opacity:/s,
-  );
+  assert.doesNotMatch(promoStyles, /agentkit-promo-arrow-icon/);
   assert.match(
     promoStyles,
     /\.sidebar\.is-collapsed \.agentkit-promo-card\s*\{[^}]*display:\s*none;/s,

--- a/frontend/tests/viteProxy.test.mjs
+++ b/frontend/tests/viteProxy.test.mjs
@@ -18,6 +18,10 @@ test("proxies Runtime harness APIs in development", () => {
 test("local API proxy strips browser origin headers before forwarding", () => {
   assert.match(
     source,
+    /function localApiProxy\(\): ProxyOptions[\s\S]*?ws:\s*true/,
+  );
+  assert.match(
+    source,
     /function localApiProxy\(\): ProxyOptions[\s\S]*?proxy\.on\(["']proxyReq["'][\s\S]*?removeHeader\(["']origin["']\)[\s\S]*?removeHeader\(["']referer["']\)/,
   );
   for (const route of [

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,6 +10,7 @@ const API_TARGET = process.env.VEADK_API_TARGET ?? "http://127.0.0.1:8000";
 function localApiProxy(): ProxyOptions {
   return {
     target: API_TARGET,
+    ws: true,
     configure(proxy) {
       proxy.on("proxyReq", (proxyRequest) => {
         // The browser talks to Vite same-origin. Do not forward browser-only

--- a/tests/cli/test_frontend_sandbox.py
+++ b/tests/cli/test_frontend_sandbox.py
@@ -23,6 +23,7 @@ import time
 from collections.abc import AsyncIterator, Mapping
 from dataclasses import replace
 from types import SimpleNamespace
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from fastapi import FastAPI, HTTPException, Request
@@ -474,6 +475,7 @@ def _agent_app(
     gateway: _FakeGateway,
     *,
     snapshot_tool_ids: dict[str, str] | None = None,
+    agentkit_cli_tool_id: str | None = "tool-dev",
 ) -> FastAPI:
     if snapshot_tool_ids is None:
         snapshot_tool_ids = {
@@ -498,6 +500,18 @@ def _agent_app(
     mount_sandbox_agent_routes(
         app,
         {
+            "agentkit-cli": SandboxAgentSessionService(
+                gateway,
+                kind="agentkit-cli",
+                tool_id=agentkit_cli_tool_id,
+                filter_agent_kind=True,
+                display_name_prefix="akcli-",
+                allow_admin_cross_owner=False,
+                terminal_initial_command="clear; agentkit --help; agentkit --version",
+                unconfigured_message=(
+                    "管理员未配置 AgentKit Dev Sandbox，请配置后再使用"
+                ),
+            ),
             "deepseek-harness": SandboxAgentSessionService(
                 gateway,
                 kind="deepseek-harness",
@@ -651,6 +665,90 @@ def test_deepseek_harness_reuses_codex_tools_and_has_its_own_surface() -> None:
     assert opened.json()["webuiUrl"].endswith("/deepseek-harness/")
     assert gateway.agent_kinds == ["deepseek-harness"]
     assert "tool-studio-snapshot" in gateway.tool_ids
+
+
+def test_agentkit_cli_uses_dev_tool_and_isolates_admin_by_owner() -> None:
+    gateway = _FakeGateway()
+    alice_headers = {
+        "X-Test-User": "tenant-alice",
+        "X-Test-Creator": "alice",
+    }
+    bob_admin_headers = {
+        "X-Test-User": "tenant-bob",
+        "X-Test-Creator": "bob",
+        "X-Test-Role": "admin",
+    }
+    with TestClient(_agent_app(gateway)) as client:
+        created = client.post(
+            "/web/agentkit-cli/sessions",
+            headers=alice_headers,
+            json={"displayName": "untrusted", "persistent": False},
+        )
+        session_id = created.json()["sessionId"]
+        alice_sessions = client.get(
+            "/web/agentkit-cli/sessions",
+            headers=alice_headers,
+        )
+        bob_sessions = client.get(
+            "/web/agentkit-cli/sessions",
+            headers=bob_admin_headers,
+        )
+        bob_open = client.post(
+            f"/web/agentkit-cli/sessions/{session_id}/open",
+            headers=bob_admin_headers,
+        )
+        alice_open = client.post(
+            f"/web/agentkit-cli/sessions/{session_id}/open",
+            headers=alice_headers,
+        )
+        terminal = client.post(
+            f"/web/agentkit-cli/sessions/{session_id}/terminal",
+            headers=alice_headers,
+        )
+
+    assert created.status_code == 200
+    assert created.json()["displayName"] == "akcli-alice"
+    assert created.json()["toolName"] == "agentkit-cli"
+    assert created.json()["persistent"] is False
+    assert gateway.tool_ids.count("tool-dev") >= 1
+    assert gateway.agent_kinds == ["agentkit-cli"]
+    assert [item["sessionId"] for item in alice_sessions.json()["sessions"]] == [
+        session_id
+    ]
+    assert bob_sessions.json() == {"sessions": []}
+    assert bob_open.status_code == 404
+    assert alice_open.status_code == 200
+    assert terminal.status_code == 200
+    assert "shellSessionId" not in terminal.json()
+    terminal_query = parse_qs(urlsplit(terminal.json()["url"]).query)
+    assert terminal_query["command"] == ["clear; agentkit --help; agentkit --version"]
+    assert terminal_query["font_size"] == ["12"]
+    assert terminal.json()["url"].startswith(
+        f"/web/sandbox/proxy/{session_id}/terminal/terminal?"
+    )
+
+
+def test_agentkit_cli_reports_unconfigured_dev_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SANDBOX_DEV", raising=False)
+    gateway = _FakeGateway()
+    with TestClient(_agent_app(gateway, agentkit_cli_tool_id=None)) as client:
+        capabilities = client.get(
+            "/web/agentkit-cli/capabilities",
+            headers={"X-Test-User": "alice"},
+        )
+        sessions = client.get(
+            "/web/agentkit-cli/sessions",
+            headers={"X-Test-User": "alice"},
+        )
+
+    message = "管理员未配置 AgentKit Dev Sandbox，请配置后再使用"
+    assert capabilities.status_code == 200
+    assert capabilities.json()["enabled"] is False
+    assert capabilities.json()["reason"] == message
+    assert sessions.status_code == 503
+    assert sessions.json()["detail"]["message"] == message
 
 
 @pytest.mark.parametrize("kind", ["openclaw", "hermes"])

--- a/tests/cli/test_frontend_sandbox_options.py
+++ b/tests/cli/test_frontend_sandbox_options.py
@@ -22,8 +22,8 @@ import pytest
 from click import ClickException, Command
 from click.testing import CliRunner
 
-from veadk.cli.cli_frontend import frontend, studio
 from veadk.cli.cli import _bootstrap_serve_provider
+from veadk.cli.cli_frontend import frontend, studio
 
 
 def test_serve_provider_is_bootstrapped_before_command_modules_load(
@@ -132,6 +132,15 @@ def test_local_studio_mounts_snapshot_tools_into_sandbox_services() -> None:
         "        tool_id=sandbox_chat_codex_tool_id,\n"
         "        snapshot_tool_id=sandbox_chat_codex_snapshot_tool_id,\n"
         "    )"
+    ) in source
+    assert (
+        '        "agentkit-cli": SandboxAgentSessionService(\n'
+        "            sandbox_gateway,\n"
+        '            kind="agentkit-cli",\n'
+        "            tool_id=intelligent_development_tool_id,\n"
+        "            filter_agent_kind=True,\n"
+        '            display_name_prefix="akcli-",\n'
+        "            allow_admin_cross_owner=False,\n"
     ) in source
     assert (
         "SandboxAgentSessionService(\n"

--- a/tests/cli/test_frontend_sandbox_proxy.py
+++ b/tests/cli/test_frontend_sandbox_proxy.py
@@ -33,9 +33,22 @@ from veadk.cli.frontend_sandbox_proxy import (
     mount_sandbox_proxy_routes,
     proxy_cookie_name,
     proxy_prefix,
+    terminal_initial_command_url,
     terminal_launch_url,
     upload_sandbox_file,
 )
+
+
+def test_terminal_initial_command_url_uses_compact_terminal_style() -> None:
+    url = terminal_initial_command_url(
+        "cloud-session",
+        "clear; agentkit --help; agentkit --version",
+    )
+
+    assert url == (
+        "/web/sandbox/proxy/cloud-session/terminal/terminal"
+        "?command=clear%3B+agentkit+--help%3B+agentkit+--version&font_size=12"
+    )
 
 
 @pytest.mark.asyncio

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -2757,6 +2757,16 @@ def _run_frontend_server(
         snapshot_tool_id=sandbox_chat_codex_snapshot_tool_id,
     )
     sandbox_agent_services = {
+        "agentkit-cli": SandboxAgentSessionService(
+            sandbox_gateway,
+            kind="agentkit-cli",
+            tool_id=intelligent_development_tool_id,
+            filter_agent_kind=True,
+            display_name_prefix="akcli-",
+            allow_admin_cross_owner=False,
+            terminal_initial_command="clear; agentkit --help; agentkit --version",
+            unconfigured_message=("管理员未配置 AgentKit Dev Sandbox，请配置后再使用"),
+        ),
         "deepseek-harness": SandboxAgentSessionService(
             sandbox_gateway,
             kind="deepseek-harness",

--- a/veadk/cli/frontend_sandbox.py
+++ b/veadk/cli/frontend_sandbox.py
@@ -74,6 +74,7 @@ from veadk.cli.frontend_sandbox_proxy import (
     mount_sandbox_proxy_routes,
     proxy_cookie_name,
     proxy_prefix,
+    terminal_initial_command_url,
     terminal_launch_url,
     upload_sandbox_file,
 )
@@ -97,6 +98,7 @@ _CODEX_PROJECT_HANDOFF_PAIRING_MIN_TTL_SECONDS = 60
 _CODEX_PROJECT_HANDOFF_PAIRING_ALPHABET = "23456789ABCDEFGHJKMNPQRSTUVWXYZ"
 _CODEX_PROJECT_HANDOFF_PAIRING_LENGTH = 8
 _SANDBOX_AGENT_TOOL_ENVS = {
+    "agentkit-cli": ("SANDBOX_DEV",),
     "deepseek-harness": (_SANDBOX_CHAT_TOOL_ENV,),
     "openclaw": ("SANDBOX_CHAT_OPENCLAW", "SANDBOX_OPENCLAW_TOOL"),
     "hermes": ("SANDBOX_CHAT_HERMES", "SANDBOX_HERMES_TOOL"),
@@ -2495,6 +2497,10 @@ class SandboxAgentSessionService:
         snapshot_tool_id: str | None = None,
         surface_path: str | None = None,
         filter_agent_kind: bool = False,
+        display_name_prefix: str = "",
+        allow_admin_cross_owner: bool = True,
+        terminal_initial_command: str = "",
+        unconfigured_message: str = "",
     ) -> None:
         if kind not in _SANDBOX_AGENT_TOOL_ENVS:
             raise ValueError(f"Unsupported Studio sandbox agent kind: {kind}")
@@ -2503,6 +2509,10 @@ class SandboxAgentSessionService:
         surface = (surface_path or f"/{kind}/").strip()
         self.surface_path = f"/{surface.strip('/')}/"
         self._filter_agent_kind = filter_agent_kind
+        self._display_name_prefix = display_name_prefix.strip()
+        self.allow_admin_cross_owner = allow_admin_cross_owner
+        self._terminal_initial_command = terminal_initial_command.strip()
+        self._unconfigured_message = unconfigured_message.strip()
         self._configured_tool_id = (tool_id or "").strip()
         self._configured_snapshot_tool_id = (snapshot_tool_id or "").strip()
         self._workspaces: dict[
@@ -2521,15 +2531,17 @@ class SandboxAgentSessionService:
                 ),
                 "",
             )
-        persistent = (
-            self._configured_snapshot_tool_id
-            or (os.getenv(_SANDBOX_AGENT_SNAPSHOT_TOOL_ENVS[self.kind]) or "").strip()
+        snapshot_env = _SANDBOX_AGENT_SNAPSHOT_TOOL_ENVS.get(self.kind, "")
+        persistent = self._configured_snapshot_tool_id or (
+            (os.getenv(snapshot_env) or "").strip() if snapshot_env else ""
         )
         return SandboxToolPair(transient=transient, persistent=persistent)
 
     def _tool_id(self, *, persistent: bool = False, required: bool = True) -> str:
         tool_id = self._tools().select(persistent)
         if required and not tool_id:
+            if self._unconfigured_message:
+                raise SandboxConfigurationError(self._unconfigured_message)
             detail = "快照版 " if persistent else ""
             raise SandboxConfigurationError(f"管理员未配置{detail}Sandbox Tool。")
         return tool_id
@@ -2539,7 +2551,7 @@ class SandboxAgentSessionService:
         enabled = bool(tools.configured)
         return {
             "enabled": enabled,
-            "reason": "" if enabled else "管理员未配置",
+            "reason": "" if enabled else (self._unconfigured_message or "管理员未配置"),
             "persistentEnabled": bool(tools.persistent),
             "persistentReason": "" if tools.persistent else "管理员未配置快照版 Tool",
         }
@@ -2677,7 +2689,15 @@ class SandboxAgentSessionService:
     ) -> SandboxCloudSession:
         if not isinstance(display_name, str):
             raise SandboxValidationError("智能体名称必须是文本。")
-        display_name = display_name.strip()
+        if self._display_name_prefix:
+            identity = creator_name.strip() or owner_id
+            identity_limit = max(
+                0,
+                STUDIO_SANDBOX_DISPLAY_NAME_MAX_LENGTH - len(self._display_name_prefix),
+            )
+            display_name = f"{self._display_name_prefix}{identity[:identity_limit]}"
+        else:
+            display_name = display_name.strip()
         if len(display_name) > STUDIO_SANDBOX_DISPLAY_NAME_MAX_LENGTH:
             raise SandboxValidationError(
                 f"智能体名称不能超过 {STUDIO_SANDBOX_DISPLAY_NAME_MAX_LENGTH} 个字符。"
@@ -2759,11 +2779,18 @@ class SandboxAgentSessionService:
         """Create a shell for an opened branded Session."""
         cloud, token, _expires_at = self._workspace(session_id, owner_id)
         try:
-            url, shell_session_id = await terminal_launch_url(
-                cloud.endpoint,
-                session_id,
-                direct=True,
-            )
+            if self._terminal_initial_command:
+                url = terminal_initial_command_url(
+                    session_id,
+                    self._terminal_initial_command,
+                )
+                shell_session_id = ""
+            else:
+                url, shell_session_id = await terminal_launch_url(
+                    cloud.endpoint,
+                    session_id,
+                    direct=True,
+                )
         except (RuntimeError, TypeError, ValueError) as error:
             raise SandboxInvocationError(_safe_error_message(error)) from error
         return url, shell_session_id, token
@@ -2855,8 +2882,12 @@ def mount_sandbox_agent_routes(
             raise HTTPException(status_code=404, detail="未知的沙箱智能体类型。")
         return service
 
-    def _is_admin(request: Request) -> bool:
-        return bool(admin_resolver and admin_resolver(request))
+    def _is_admin(service: SandboxAgentSessionService, request: Request) -> bool:
+        return bool(
+            service.allow_admin_cross_owner
+            and admin_resolver
+            and admin_resolver(request)
+        )
 
     def _http_error(error: SandboxError) -> HTTPException:
         status_code = 500
@@ -2916,9 +2947,10 @@ def mount_sandbox_agent_routes(
     ) -> dict[str, object]:
         try:
             owner_id = owner_resolver(request)
-            sessions, snapshots = await _service(kind).list_resources(
+            service = _service(kind)
+            sessions, snapshots = await service.list_resources(
                 owner_id,
-                is_admin=_is_admin(request),
+                is_admin=_is_admin(service, request),
                 auto_resume_snapshots=_request_auto_resume_snapshots(
                     request,
                     default=True,
@@ -2974,10 +3006,11 @@ def mount_sandbox_agent_routes(
     ) -> dict[str, object]:
         owner_id = owner_resolver(request)
         try:
-            session = await _service(kind).resume_snapshot(
+            service = _service(kind)
+            session = await service.resume_snapshot(
                 snapshot_id,
                 owner_id,
-                is_admin=_is_admin(request),
+                is_admin=_is_admin(service, request),
             )
         except SandboxError as error:
             raise _http_error(error) from error
@@ -2990,10 +3023,11 @@ def mount_sandbox_agent_routes(
         request: Request,
     ) -> dict[str, bool]:
         try:
-            await _service(kind).delete_snapshot(
+            service = _service(kind)
+            await service.delete_snapshot(
                 snapshot_id,
                 owner_resolver(request),
-                is_admin=_is_admin(request),
+                is_admin=_is_admin(service, request),
             )
         except SandboxError as error:
             raise _http_error(error) from error
@@ -3011,7 +3045,7 @@ def mount_sandbox_agent_routes(
             session, token = await service.open(
                 session_id,
                 owner_id,
-                is_admin=_is_admin(request),
+                is_admin=_is_admin(service, request),
             )
         except SandboxError as error:
             raise _http_error(error) from error
@@ -3028,10 +3062,11 @@ def mount_sandbox_agent_routes(
         request: Request,
     ) -> dict[str, bool]:
         try:
-            await _service(kind).delete(
+            service = _service(kind)
+            await service.delete(
                 session_id,
                 owner_resolver(request),
-                is_admin=_is_admin(request),
+                is_admin=_is_admin(service, request),
             )
         except SandboxError as error:
             raise _http_error(error) from error
@@ -3050,7 +3085,10 @@ def mount_sandbox_agent_routes(
             )
         except SandboxError as error:
             raise _http_error(error) from error
-        response = JSONResponse({"url": url, "shellSessionId": shell_session_id})
+        payload = {"url": url}
+        if shell_session_id:
+            payload["shellSessionId"] = shell_session_id
+        response = JSONResponse(payload)
         response.headers["Cache-Control"] = "no-store"
         forwarded_protocol = (
             request.headers.get("x-forwarded-proto", "").split(",", 1)[0].strip()

--- a/veadk/cli/frontend_sandbox_proxy.py
+++ b/veadk/cli/frontend_sandbox_proxy.py
@@ -24,7 +24,7 @@ import posixpath
 from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass
 from typing import Any, Literal
-from urllib.parse import quote, urlsplit
+from urllib.parse import quote, urlencode, urlsplit
 
 import httpx
 from fastapi import Request, WebSocket, WebSocketDisconnect
@@ -71,6 +71,20 @@ def browser_launch_url(
             raise RuntimeError("Sandbox Browser 返回了无效地址。")
         return sandbox_service_url(endpoint, "/browser-ui")
     return f"{proxy_prefix(session_id, 'browser')}/browser-ui"
+
+
+def terminal_initial_command_url(session_id: str, command: str) -> str:
+    """Return a proxied Terminal URL that creates a shell and runs one command."""
+    initial_command = command.strip()
+    if not initial_command:
+        raise ValueError("Sandbox Terminal 初始化命令不能为空。")
+    query = urlencode(
+        {
+            "command": initial_command,
+            "font_size": "12",
+        }
+    )
+    return f"{proxy_prefix(session_id, 'terminal')}/terminal?{query}"
 
 
 async def terminal_launch_url(
@@ -234,14 +248,14 @@ def mount_sandbox_proxy_routes(
         if target is None:
             return
         shell_session_id = websocket.query_params.get("session_id", "").strip()
-        if not shell_session_id or len(shell_session_id) > 1_000:
+        if len(shell_session_id) > 1_000:
             await websocket.close(code=1008, reason="invalid shell session")
             return
         upstream = sandbox_service_url(
             target.endpoint,
             "/v1/shell/ws",
             websocket=True,
-            query={"session_id": shell_session_id},
+            query={"session_id": shell_session_id} if shell_session_id else None,
         )
         await _relay_websocket(websocket, upstream)
 
@@ -357,7 +371,18 @@ async def _proxy_http_response(
     if surface == "browser" and asset_path == "v1/browser/info":
         return await _browser_info_response(request, upstream, client, prefix)
     if content_type.lower().startswith("text/html"):
-        return await _html_response(upstream, client, common_headers, prefix)
+        font_size = (
+            12
+            if surface == "terminal" and request.query_params.get("font_size") == "12"
+            else None
+        )
+        return await _html_response(
+            upstream,
+            client,
+            common_headers,
+            prefix,
+            terminal_font_size=font_size,
+        )
 
     async def _body() -> AsyncIterator[bytes]:
         size = 0
@@ -431,6 +456,8 @@ async def _html_response(
     client: httpx.AsyncClient,
     headers: dict[str, str],
     prefix: str,
+    *,
+    terminal_font_size: int | None = None,
 ) -> Response:
     try:
         content = await upstream.aread()
@@ -445,6 +472,12 @@ async def _html_response(
         ):
             text = text.replace(f'"{root}', f'"{prefix}{root}')
             text = text.replace(f"'{root}", f"'{prefix}{root}")
+        if terminal_font_size is not None:
+            text = text.replace(
+                "fontSize: 14,",
+                f"fontSize: {terminal_font_size},",
+                1,
+            )
         return Response(
             text,
             status_code=upstream.status_code,
@@ -588,6 +621,7 @@ __all__ = [
     "mount_sandbox_proxy_routes",
     "proxy_cookie_name",
     "proxy_prefix",
+    "terminal_initial_command_url",
     "terminal_launch_url",
     "upload_sandbox_file",
 ]


### PR DESCRIPTION
## Summary

- add an AgentKit CLI entry to the Studio sidebar and open an interactive terminal dialog
- provision or reuse non-persistent, tenant-isolated Dev Sandbox sessions named akcli-[username]
- show initialization, configuration errors, original server details, and environment expiry countdown
- run agentkit --help followed by agentkit --version when the terminal opens
- proxy terminal HTTP and WebSocket traffic through Studio and keep the terminal mounted across dialog reopen

## Validation

- uv run pre-commit run --all-files
- uv run pytest tests/cli/test_frontend_sandbox.py::test_agentkit_cli_uses_dev_tool_and_isolates_admin_by_owner tests/cli/test_frontend_sandbox.py::test_agentkit_cli_reports_unconfigured_dev_sandbox tests/cli/test_frontend_sandbox_proxy.py tests/cli/test_frontend_sandbox_options.py -q
- npm test (939 passed)
- npm run build
- visual QA at 1440x900 and 390x844