### PR TITLE
feat: support configured sync tool thread pools

### DIFF
--- a/tests/agent/test_agent_contract.py
+++ b/tests/agent/test_agent_contract.py
@@ -38,6 +38,7 @@ _EXPECTED_DEFAULTS = {
     "enable_skills_checklist": False,
     "enable_tunnel": False,
     "runtime": "adk",
+    "tool_thread_pool_config": None,
 }
 
 _EXPECTED_PRESENT = {

--- a/tests/test_adk_sync_tool_thread_pool_patch.py
+++ b/tests/test_adk_sync_tool_thread_pool_patch.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from google.adk.agents import LlmAgent, RunConfig
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.agents.run_config import ToolThreadPoolConfig
+from google.adk.flows.llm_flows import functions
+from google.adk.sessions.in_memory_session_service import InMemorySessionService
+from google.adk.sessions.session import Session
+from google.adk.tools.function_tool import FunctionTool
+from google.adk.tools.tool_context import ToolContext
+from google.genai import types
+
+from veadk import Agent
+from veadk.utils.patches import patch_adk_sync_tool_thread_pool
+
+
+def _ctx(agent: LlmAgent, run_config: RunConfig) -> InvocationContext:
+    return InvocationContext(
+        session_service=InMemorySessionService(),
+        invocation_id="inv-1",
+        agent=agent,
+        session=Session(
+            id="session-1",
+            appName="app",
+            userId="user",
+            state={},
+            events=[],
+        ),
+        run_config=run_config,
+    )
+
+
+async def _run_two_sync_tool_calls(
+    run_config: RunConfig,
+    *,
+    tool_name: str = "blocking_tool",
+    agent_tool_thread_pool_config: ToolThreadPoolConfig | None = None,
+) -> tuple[float, float, dict[str, int | None]]:
+    starts: dict[str, float] = {}
+    parallel_call_counts: dict[str, int | None] = {}
+
+    def blocking_tool(label: str, delay: float, tool_context: ToolContext) -> dict:
+        starts[label] = time.perf_counter()
+        parallel_call_counts[label] = getattr(
+            tool_context, "_veadk_parallel_tool_call_count", None
+        )
+        time.sleep(delay)
+        return {"label": label}
+
+    def run_code(label: str, delay: float, tool_context: ToolContext) -> dict:
+        return blocking_tool(label, delay, tool_context)
+
+    tool = FunctionTool(run_code if tool_name == "run_code" else blocking_tool)
+    if agent_tool_thread_pool_config is None:
+        agent = LlmAgent(
+            name="agent",
+            model="gemini-2.5-flash",
+            tools=[tool],
+        )
+    else:
+        agent = Agent(
+            name="agent",
+            model_name="test-model",
+            model_provider="openai",
+            model_api_key="test-key",
+            model_api_base="http://example.com",
+            tools=[tool],
+            tool_thread_pool_config=agent_tool_thread_pool_config,
+        )
+    ctx = _ctx(agent, run_config)
+
+    started_at = time.perf_counter()
+    response_event = await functions.handle_function_call_list_async(
+        ctx,
+        [
+            types.FunctionCall(
+                id="call-a",
+                name=tool_name,
+                args={"label": "a", "delay": 0.2},
+            ),
+            types.FunctionCall(
+                id="call-b",
+                name=tool_name,
+                args={"label": "b", "delay": 0.2},
+            ),
+        ],
+        {tool_name: tool},
+    )
+    elapsed = time.perf_counter() - started_at
+
+    assert response_event is not None
+    assert len(response_event.get_function_responses()) == 2
+    assert set(starts) == {"a", "b"}
+
+    start_gap = abs(starts["b"] - starts["a"])
+    return start_gap, elapsed, parallel_call_counts
+
+
+@pytest.mark.asyncio
+async def test_sync_tool_calls_stay_serial_without_thread_pool_config(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("VEADK_TOOL_THREAD_POOL_MAX_WORKERS", "2")
+    patch_adk_sync_tool_thread_pool()
+
+    start_gap, elapsed, _ = await _run_two_sync_tool_calls(RunConfig(max_llm_calls=5))
+
+    assert start_gap >= 0.18
+    assert elapsed >= 0.38
+
+
+@pytest.mark.asyncio
+async def test_sync_tool_calls_use_agent_thread_pool_when_configured() -> None:
+    patch_adk_sync_tool_thread_pool()
+
+    start_gap, elapsed, _ = await _run_two_sync_tool_calls(
+        RunConfig(max_llm_calls=5),
+        agent_tool_thread_pool_config=ToolThreadPoolConfig(max_workers=2),
+    )
+
+    assert start_gap < 0.1
+    assert elapsed < 0.35
+
+
+@pytest.mark.asyncio
+async def test_sync_tool_calls_use_thread_pool_when_configured() -> None:
+    patch_adk_sync_tool_thread_pool()
+
+    start_gap, elapsed, _ = await _run_two_sync_tool_calls(
+        RunConfig(
+            max_llm_calls=5,
+            tool_thread_pool_config=ToolThreadPoolConfig(max_workers=2),
+        )
+    )
+
+    assert start_gap < 0.1
+    assert elapsed < 0.35
+
+
+@pytest.mark.asyncio
+async def test_run_code_calls_stay_serial_without_thread_pool_config(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("VEADK_RUN_CODE_THREAD_POOL_MAX_WORKERS", "4")
+    patch_adk_sync_tool_thread_pool()
+
+    start_gap, elapsed, parallel_call_counts = await _run_two_sync_tool_calls(
+        RunConfig(max_llm_calls=5),
+        tool_name="run_code",
+    )
+
+    assert start_gap >= 0.18
+    assert elapsed >= 0.38
+    assert parallel_call_counts == {"a": None, "b": None}
+
+
+@pytest.mark.asyncio
+async def test_run_code_uses_agent_thread_pool_when_configured() -> None:
+    patch_adk_sync_tool_thread_pool()
+
+    start_gap, elapsed, parallel_call_counts = await _run_two_sync_tool_calls(
+        RunConfig(max_llm_calls=5),
+        tool_name="run_code",
+        agent_tool_thread_pool_config=ToolThreadPoolConfig(max_workers=2),
+    )
+
+    assert start_gap < 0.1
+    assert elapsed < 0.35
+    assert parallel_call_counts == {"a": 2, "b": 2}

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -17,6 +17,7 @@ from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
 from google.adk.agents.llm_agent import LlmAgent
+from google.adk.agents.run_config import ToolThreadPoolConfig
 from google.adk.models.lite_llm import LiteLlm
 from google.adk.tools import load_memory
 
@@ -230,6 +231,15 @@ def test_agent_empty_model_extra_config():
         agent.model_extra_config["extra_body"]
         == DEFAULT_MODEL_EXTRA_CONFIG["extra_body"]
     )
+
+
+@patch.dict("os.environ", {"MODEL_AGENT_API_KEY": "mock_api_key"})
+def test_agent_accepts_tool_thread_pool_config():
+    config = ToolThreadPoolConfig(max_workers=3)
+
+    agent = Agent(tool_thread_pool_config=config)
+
+    assert agent.tool_thread_pool_config == config
 
 
 @patch.dict("os.environ", {"MODEL_AGENT_API_KEY": "mock_api_key"})

--- a/tests/tools/builtin_tools/test_run_code.py
+++ b/tests/tools/builtin_tools/test_run_code.py
@@ -22,15 +22,19 @@ from veadk.tools.builtin_tools.execute_skills import execute_skills
 from veadk.tools.builtin_tools import run_code as run_code_module
 
 
-def _tool_context():
-    return SimpleNamespace(
+def _tool_context(function_call_id=None, parallel_tool_call_count=None):
+    context = SimpleNamespace(
         state={},
+        function_call_id=function_call_id,
         _invocation_context=SimpleNamespace(
             session=SimpleNamespace(id="session-id"),
             agent=SimpleNamespace(name="agent-name"),
             user_id="user-id",
         ),
     )
+    if parallel_tool_call_count is not None:
+        context._veadk_parallel_tool_call_count = parallel_tool_call_count
+    return context
 
 
 @pytest.mark.parametrize(
@@ -102,6 +106,88 @@ def test_run_code_uses_default_timeout_for_python():
 
     assert result == "ok"
     assert invoke.call_args.kwargs["timeout"] == 300
+
+
+def test_run_code_keeps_session_id_without_parallel_marker():
+    with (
+        patch.object(run_code_module, "resolve_agentkit_tool_id", return_value="tool"),
+        patch.object(
+            run_code_module,
+            "get_agentkit_endpoint_config",
+            return_value=("service", "region", "host", "https"),
+        ),
+        patch.object(
+            run_code_module,
+            "invoke_agentkit_run_code",
+            return_value={"Result": {"Result": "ok"}},
+        ) as invoke,
+    ):
+        result = run_code_module.run_code(
+            "print('hello')",
+            "python3",
+            _tool_context(function_call_id="call-a"),
+        )
+
+    assert result == "ok"
+    assert invoke.call_args.kwargs["tool_user_session_id"] == (
+        "agent-name_user-id_session-id"
+    )
+
+
+def test_run_code_isolates_parallel_session_id_by_call_id(monkeypatch):
+    monkeypatch.delenv("VEADK_RUN_CODE_ISOLATE_PARALLEL_CALLS", raising=False)
+
+    with (
+        patch.object(run_code_module, "resolve_agentkit_tool_id", return_value="tool"),
+        patch.object(
+            run_code_module,
+            "get_agentkit_endpoint_config",
+            return_value=("service", "region", "host", "https"),
+        ),
+        patch.object(
+            run_code_module,
+            "invoke_agentkit_run_code",
+            return_value={"Result": {"Result": "ok"}},
+        ) as invoke,
+    ):
+        result = run_code_module.run_code(
+            "print('hello')",
+            "python3",
+            _tool_context(function_call_id="call-a", parallel_tool_call_count=2),
+        )
+
+    assert result == "ok"
+    assert invoke.call_args.kwargs["tool_user_session_id"] == (
+        "agent-name_user-id_session-id_call-a"
+    )
+
+
+def test_run_code_parallel_session_isolation_can_be_disabled(monkeypatch):
+    monkeypatch.setenv("VEADK_RUN_CODE_ISOLATE_PARALLEL_CALLS", "0")
+
+    with (
+        patch.object(run_code_module, "resolve_agentkit_tool_id", return_value="tool"),
+        patch.object(
+            run_code_module,
+            "get_agentkit_endpoint_config",
+            return_value=("service", "region", "host", "https"),
+        ),
+        patch.object(
+            run_code_module,
+            "invoke_agentkit_run_code",
+            return_value={"Result": {"Result": "ok"}},
+        ) as invoke,
+    ):
+        result = run_code_module.run_code(
+            "print('hello')",
+            "python3",
+            _tool_context(function_call_id="call-a", parallel_tool_call_count=2),
+        )
+
+    assert result == "ok"
+    assert invoke.call_args.kwargs["tool_user_session_id"] == (
+        "agent-name_user-id_session-id"
+    )
 
 
 def test_run_code_forwards_custom_timeouts_for_bash():

--- a/veadk/agent.py
+++ b/veadk/agent.py
@@ -33,6 +33,7 @@ from google.adk.agents import LlmAgent
 from google.adk.agents.base_agent import BaseAgent
 from google.adk.agents.context_cache_config import ContextCacheConfig
 from google.adk.agents.llm_agent import InstructionProvider, ToolUnion
+from google.adk.agents.run_config import ToolThreadPoolConfig
 from google.adk.examples.base_example_provider import BaseExampleProvider
 from google.adk.models.lite_llm import LiteLlm
 from pydantic import ConfigDict, Field
@@ -56,6 +57,7 @@ from veadk.tracing.base_tracer import BaseTracer
 from veadk.utils.adk_compat import is_adk_gte
 from veadk.utils.logger import get_logger
 from veadk.utils.patches import (
+    patch_adk_sync_tool_thread_pool,
     patch_asyncio,
     patch_mcp_session_retry,
     patch_tracer,
@@ -69,6 +71,7 @@ if TYPE_CHECKING:
 patch_tracer()
 patch_asyncio()
 patch_mcp_session_retry()
+patch_adk_sync_tool_thread_pool()
 logger = get_logger(__name__)
 
 
@@ -89,6 +92,8 @@ class Agent(LlmAgent):
         model_api_base (str): The base URL of the model API.
         model_api_key (str): The API key for accessing the model.
         model_extra_config (dict): Extra configurations to include in model requests.
+        tool_thread_pool_config (Optional[ToolThreadPoolConfig]): Default thread
+            pool config for synchronous tool execution.
         tools (list[ToolUnion]): Tools available to the agent.
         sub_agents (list[BaseAgent]): Sub-agents managed by this agent.
         knowledgebase (Optional[KnowledgeBase]): Knowledge base attached to the agent.
@@ -127,6 +132,7 @@ class Agent(LlmAgent):
     MODEL_AGENT_API_KEY_NAME). A key value always wins over a key name, so this
     is ignored when `model_api_key` or the MODEL_AGENT_API_KEY env is set."""
     model_extra_config: dict = Field(default_factory=dict)
+    tool_thread_pool_config: Optional[ToolThreadPoolConfig] = None
 
     tools: list[ToolUnion] = []
 

--- a/veadk/tools/builtin_tools/run_code.py
+++ b/veadk/tools/builtin_tools/run_code.py
@@ -27,6 +27,7 @@ from veadk.utils.logger import get_logger
 logger = get_logger(__name__)
 
 _MAX_TIMEOUT = 300
+_ISOLATE_PARALLEL_CALLS_ENV = "VEADK_RUN_CODE_ISOLATE_PARALLEL_CALLS"
 
 
 def _validate_timeout(name: str, value: int) -> None:
@@ -34,6 +35,31 @@ def _validate_timeout(name: str, value: int) -> None:
         raise ValueError(
             f"{name} must be an integer between 1 and {_MAX_TIMEOUT} seconds"
         )
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _tool_user_session_id(tool_context: ToolContext) -> str:
+    invocation_context = tool_context._invocation_context
+    session_id = invocation_context.session.id
+    agent_name = invocation_context.agent.name
+    user_id = invocation_context.user_id
+    base_session_id = agent_name + "_" + user_id + "_" + session_id
+
+    if (
+        _env_bool(_ISOLATE_PARALLEL_CALLS_ENV, True)
+        and getattr(tool_context, "_veadk_parallel_tool_call_count", 1) > 1
+    ):
+        function_call_id = getattr(tool_context, "function_call_id", None)
+        if function_call_id:
+            return base_session_id + "_" + function_call_id
+
+    return base_session_id
 
 
 def run_code(
@@ -72,9 +98,7 @@ def run_code(
     logger.debug(f"tools endpoint: {host}")
 
     session_id = tool_context._invocation_context.session.id
-    agent_name = tool_context._invocation_context.agent.name
-    user_id = tool_context._invocation_context.user_id
-    tool_user_session_id = agent_name + "_" + user_id + "_" + session_id
+    tool_user_session_id = _tool_user_session_id(tool_context)
     logger.debug(f"tool_user_session_id: {tool_user_session_id}")
 
     logger.debug(

--- a/veadk/utils/patches.py
+++ b/veadk/utils/patches.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import contextvars
 from contextlib import asynccontextmanager
 import functools
 import sys
@@ -29,6 +30,46 @@ from veadk.version import VERSION
 logger = get_logger(__name__)
 
 _SUPPRESS_LANGUAGE_MODEL_INSTRUMENTATION = "suppress_language_model_instrumentation"
+_PARALLEL_RUN_CODE_CALL_COUNT = contextvars.ContextVar(
+    "veadk_parallel_run_code_call_count", default=1
+)
+
+
+def _adk_tool_name(tool) -> str:
+    return (
+        getattr(tool, "name", None)
+        or getattr(tool, "__name__", None)
+        or tool.__class__.__name__
+    )
+
+
+def _resolve_tool_thread_pool_max_workers(tool, tool_context) -> int | None:
+    invocation_context = getattr(tool_context, "_invocation_context", None)
+    run_config = getattr(invocation_context, "run_config", None)
+    thread_pool_config = getattr(run_config, "tool_thread_pool_config", None)
+    if thread_pool_config is not None:
+        return thread_pool_config.max_workers
+
+    agent = getattr(invocation_context, "agent", None)
+    thread_pool_config = getattr(agent, "tool_thread_pool_config", None)
+    if thread_pool_config is not None:
+        return thread_pool_config.max_workers
+
+    return None
+
+
+def _set_parallel_run_code_context(tool, tool_context, max_workers: int | None) -> None:
+    parallel_run_code_call_count = _PARALLEL_RUN_CODE_CALL_COUNT.get()
+    if (
+        max_workers is not None
+        and _adk_tool_name(tool) == "run_code"
+        and parallel_run_code_call_count > 1
+    ):
+        setattr(
+            tool_context,
+            "_veadk_parallel_tool_call_count",
+            parallel_run_code_call_count,
+        )
 
 
 def patch_asyncio():
@@ -168,6 +209,89 @@ def patch_tracer() -> None:
                         ),
                     )
                     logger.debug(f"Patch {mod_name} {var_name} with VeADK tracer.")
+
+
+def patch_adk_sync_tool_thread_pool() -> None:
+    """Enable ADK's tool thread pool for non-live ``run_async`` tool calls.
+
+    Google ADK exposes ``RunConfig.tool_thread_pool_config`` and already has a
+    thread-pool helper for sync tools, but some supported versions only consult
+    that config in the live-tool path. VeADK agents use the standard async flow,
+    so sync tools such as builtin ``run_code`` would otherwise block the event
+    loop and serialize same-turn tool calls.
+    """
+    try:
+        from google.adk.flows.llm_flows import functions as adk_functions
+
+        if getattr(adk_functions, "_veadk_sync_tool_thread_pool_patched", False):
+            return
+
+        original_call_tool_async = getattr(adk_functions, "__call_tool_async")
+        original_handle_function_call_list_async = getattr(
+            adk_functions, "handle_function_call_list_async"
+        )
+        call_tool_in_thread_pool = getattr(
+            adk_functions, "_call_tool_in_thread_pool", None
+        )
+        if not callable(call_tool_in_thread_pool):
+            logger.debug("Skip ADK sync tool thread-pool patch: helper is unavailable.")
+            return
+
+        @functools.wraps(original_call_tool_async)
+        async def veadk_call_tool_async(tool, args, tool_context):
+            max_workers = _resolve_tool_thread_pool_max_workers(tool, tool_context)
+            _set_parallel_run_code_context(tool, tool_context, max_workers)
+
+            if max_workers is not None:
+                return await call_tool_in_thread_pool(
+                    tool,
+                    args=args,
+                    tool_context=tool_context,
+                    max_workers=max_workers,
+                )
+
+            return await original_call_tool_async(
+                tool=tool,
+                args=args,
+                tool_context=tool_context,
+            )
+
+        @functools.wraps(original_handle_function_call_list_async)
+        async def veadk_handle_function_call_list_async(
+            invocation_context,
+            function_calls,
+            tools_dict,
+            filters=None,
+            tool_confirmation_dict=None,
+        ):
+            run_code_call_count = len(
+                [
+                    function_call
+                    for function_call in function_calls
+                    if function_call.name == "run_code"
+                    and (not filters or function_call.id in filters)
+                ]
+            )
+            token = _PARALLEL_RUN_CODE_CALL_COUNT.set(run_code_call_count)
+            try:
+                return await original_handle_function_call_list_async(
+                    invocation_context,
+                    function_calls,
+                    tools_dict,
+                    filters=filters,
+                    tool_confirmation_dict=tool_confirmation_dict,
+                )
+            finally:
+                _PARALLEL_RUN_CODE_CALL_COUNT.reset(token)
+
+        adk_functions.__call_tool_async = veadk_call_tool_async
+        adk_functions.handle_function_call_list_async = (
+            veadk_handle_function_call_list_async
+        )
+        adk_functions._veadk_sync_tool_thread_pool_patched = True
+        logger.debug("Patch ADK non-live sync tool calls to honor thread pool config.")
+    except Exception as e:  # pragma: no cover - defensive across adk versions
+        logger.warning(f"Skip ADK sync tool thread-pool patch: {e}")
 
 
 def _sanitize_adk_graph_value(value, field_name: str | None = None):


### PR DESCRIPTION
## Summary

  - Add `Agent.tool_thread_pool_config` to configure default thread-pool execution for synchronous tools.
  - Patch ADK non-live tool execution so `RunConfig.tool_thread_pool_config` and `Agent.tool_thread_pool_config` are honored.
  - Isolate concurrent `run_code` AgentKit sessions by appending `function_call_id` only when multiple `run_code` calls run
  concurrently.
  - Add tests for sync tool threading, Agent-level config, RunConfig priority, and `run_code` session isolation.

  ## Behavior

  Thread-pool config priority:

  1. `RunConfig.tool_thread_pool_config`
  2. `Agent.tool_thread_pool_config`
  3. no thread pool

  Example:

  ```python
  from google.adk.agents.run_config import ToolThreadPoolConfig
  from veadk import Agent

  agent = Agent(
      tools=[run_code],
      tool_thread_pool_config=ToolThreadPoolConfig(max_workers=4),
  )

  ## Compatibility

  - Existing agents without tool_thread_pool_config keep the previous synchronous execution behavior.
  - run_code does not enable local thread-pool concurrency unless the user configures it.
  - Concurrent run_code calls use isolated AgentKit UserSessionIds to avoid session creation collisions.