### PR TITLE
fix(studio): keep one minimum instance during deploy and update

### DIFF
--- a/tests/cli/test_frontend_deploy_iam.py
+++ b/tests/cli/test_frontend_deploy_iam.py
@@ -288,6 +288,7 @@ def test_frontend_policy_allows_release_download() -> None:
     assert "iam:UpdatePolicy" not in actions
     assert "vefaas:CodeUploadCallback" in actions
     assert "vefaas:UpdateFunction" in actions
+    assert "vefaas:UpdateFunctionResource" in actions
     assert "vefaas:ReleaseApplication" in actions
     assert "tag:TagResources" in actions
     assert "tag:UntagResources" in actions

--- a/tests/cli/test_studio_deploy_permissions.py
+++ b/tests/cli/test_studio_deploy_permissions.py
@@ -38,7 +38,7 @@ def test_default_studio_deploy_requires_all_reachable_actions() -> None:
     specs = _default_specs()
     actions = [spec.action for spec in specs]
 
-    assert len(actions) == 44
+    assert len(actions) == 45
     assert len(actions) == len(set(actions))
     assert "id:CreateUserPool" in actions
     assert "iam:UpdatePolicy" in actions
@@ -47,6 +47,7 @@ def test_default_studio_deploy_requires_all_reachable_actions() -> None:
     assert "apig:CreateGateway" in actions
     assert "apig:UpdateRoute" in actions
     assert "vefaas:CreateApplication" in actions
+    assert "vefaas:UpdateFunctionResource" in actions
     assert "vefaas:CreateTimer" in actions
     assert "vefaas:ListTriggers" in actions
     assert "vefaas:UpdateTimer" in actions

--- a/tests/cli/test_studio_self_update.py
+++ b/tests/cli/test_studio_self_update.py
@@ -516,7 +516,7 @@ def test_submit_thin_release_falls_back_to_legacy_full_bundle_end_to_end(
         def __init__(self, **_kwargs: str) -> None:
             self.client = object()
 
-        def submit_application_code_bundle_update(self, **kwargs: Any) -> None:
+        def submit_application_code_bundle_update(self, **kwargs: Any) -> bool:
             package = Path(kwargs["path"])
             captured["full_selected"] = (package / "full-marker").read_text()
 

--- a/tests/cli/test_studio_update.py
+++ b/tests/cli/test_studio_update.py
@@ -1435,6 +1435,7 @@ def test_update_application_code_bundle_merges_only_explicit_environment(
     tmp_path: Path,
 ) -> None:
     updated_requests: list[Any] = []
+    resource_requests: list[Any] = []
     service = object.__new__(VeFaaS)
     service.session_token = ""
     cast(Any, service).client = SimpleNamespace(
@@ -1445,6 +1446,7 @@ def test_update_application_code_bundle_merges_only_explicit_environment(
             ]
         ),
         update_function=updated_requests.append,
+        update_function_resource=resource_requests.append,
     )
     monkeypatch.setattr(service, "_upload_and_mount_code", lambda *_: None)
     monkeypatch.setattr(service, "_release_application", lambda _: "https://same")
@@ -1466,7 +1468,96 @@ def test_update_application_code_bundle_merges_only_explicit_environment(
         "EXISTING": "kept",
         "VEADK_SITE_TITLE": "新标题",
     }
+    resource_request = resource_requests[0]
+    assert resource_request.function_id == "function-id"
+    assert resource_request.min_instance == 1
+    assert resource_request.max_instance is None
+    assert resource_request.reserved_frozen_instance is None
     ensure_route.assert_called_once_with("app-id", disable_cors=True)
+
+
+def test_submit_application_code_bundle_sets_only_minimum_instance(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    updated_requests: list[Any] = []
+    resource_requests: list[Any] = []
+    releases: list[str] = []
+    service = object.__new__(VeFaaS)
+    cast(Any, service).client = SimpleNamespace(
+        update_function=updated_requests.append,
+        update_function_resource=resource_requests.append,
+    )
+    monkeypatch.setattr(service, "_upload_and_mount_code", lambda *_: None)
+    monkeypatch.setattr(service, "_start_application_release", releases.append)
+
+    service.submit_application_code_bundle_update(
+        application_id="app-id",
+        function_id="function-id",
+        path=str(tmp_path),
+    )
+
+    assert updated_requests[0].id == "function-id"
+    resource_request = resource_requests[0]
+    assert resource_request.function_id == "function-id"
+    assert resource_request.min_instance == 1
+    assert resource_request.max_instance is None
+    assert resource_request.reserved_frozen_instance is None
+    assert releases == ["app-id"]
+
+
+def test_submit_application_code_bundle_stops_without_resource_permission(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    releases: list[str] = []
+    service = object.__new__(VeFaaS)
+
+    def _permission_denied(_: Any) -> None:
+        raise RuntimeError("AccessDenied: vefaas:UpdateFunctionResource")
+
+    cast(Any, service).client = SimpleNamespace(
+        update_function=lambda _: None,
+        update_function_resource=_permission_denied,
+    )
+    monkeypatch.setattr(service, "_upload_and_mount_code", lambda *_: None)
+    monkeypatch.setattr(service, "_start_application_release", releases.append)
+
+    with pytest.raises(RuntimeError, match="UpdateFunctionResource"):
+        service.submit_application_code_bundle_update(
+            application_id="app-id",
+            function_id="function-id",
+            path=str(tmp_path),
+        )
+
+    assert releases == []
+
+
+def test_submit_application_code_bundle_stops_on_other_resource_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    releases: list[str] = []
+    service = object.__new__(VeFaaS)
+
+    def _invalid_operation(_: Any) -> None:
+        raise RuntimeError("InvalidOperation")
+
+    cast(Any, service).client = SimpleNamespace(
+        update_function=lambda _: None,
+        update_function_resource=_invalid_operation,
+    )
+    monkeypatch.setattr(service, "_upload_and_mount_code", lambda *_: None)
+    monkeypatch.setattr(service, "_start_application_release", releases.append)
+
+    with pytest.raises(RuntimeError, match="InvalidOperation"):
+        service.submit_application_code_bundle_update(
+            application_id="app-id",
+            function_id="function-id",
+            path=str(tmp_path),
+        )
+
+    assert releases == []
 
 
 def test_application_operations_use_deployment_region(
@@ -1749,6 +1840,7 @@ def test_update_application_code_bundle_preserves_unspecified_sandbox_tool(
             ]
         ),
         update_function=updated_requests.append,
+        update_function_resource=lambda _: None,
     )
     monkeypatch.setattr(service, "_upload_and_mount_code", lambda *_: None)
     monkeypatch.setattr(service, "_release_application", lambda _: "https://same")
@@ -1777,6 +1869,7 @@ def test_update_application_code_bundle_does_not_read_or_replace_environment(
     cast(Any, service).client = SimpleNamespace(
         get_function=lambda _: pytest.fail("environment should not be read"),
         update_function=updated_requests.append,
+        update_function_resource=lambda _: None,
     )
     monkeypatch.setattr(service, "_upload_and_mount_code", lambda *_: None)
     monkeypatch.setattr(service, "_release_application", lambda _: "https://same")

--- a/tests/cli/test_studio_update_permissions.py
+++ b/tests/cli/test_studio_update_permissions.py
@@ -182,6 +182,40 @@ def test_default_frontend_policy_satisfies_every_ota_permission() -> None:
     assert all(evaluated.values())
 
 
+def test_precheck_adds_function_resource_permission_to_authorization() -> None:
+    current = deepcopy(FRONTEND_DEPLOY_POLICY)
+    actions = current["Statement"][0]["Action"]
+    current["Statement"][0]["Action"] = [
+        action for action in actions if action != "vefaas:UpdateFunctionResource"
+    ]
+    principal = PrincipalPolicySet(
+        kind="role",
+        name="CustomerRole",
+        policies=(
+            AttachedPolicyDocument(
+                name="CustomerPolicy",
+                policy_type="Custom",
+                document=current,
+            ),
+        ),
+    )
+
+    report = StudioUpdatePermissionService(
+        provider="volcengine",
+        access_key="ak",
+        secret_key="sk",
+        inspector=_Inspector(principal),
+    ).check()
+
+    assert report.missing_actions == ("vefaas:UpdateFunctionResource",)
+    query = parse_qs(urlparse(report.authorization_url).query)
+    prefilled = json.loads(query["query"][0])
+    merged = json.loads(prefilled["NewPolicyDocument"])
+    assert evaluate_actions(["vefaas:UpdateFunctionResource"], [merged])[
+        "vefaas:UpdateFunctionResource"
+    ]
+
+
 def test_merge_policy_actions_preserves_unrelated_statements() -> None:
     original = {
         "Statement": [

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -14,6 +14,7 @@
 
 import os
 import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
@@ -67,10 +68,28 @@ def test_vefaas_create_function_uses_configured_project() -> None:
     assert request.project_name == "studio-project"
 
 
+@pytest.mark.parametrize("provider", ["volcengine", "byteplus"])
+def test_vefaas_sets_only_minimum_instance(provider: str) -> None:
+    requests = []
+    service = object.__new__(VeFaaS)
+    service.provider = provider
+    service.client = SimpleNamespace(update_function_resource=requests.append)
+
+    service._set_function_min_instance("function-id")
+
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.function_id == "function-id"
+    assert request.min_instance == 1
+    assert request.max_instance is None
+    assert request.reserved_frozen_instance is None
+
+
 def test_vefaas_deploy_cleans_created_resources_on_release_failure() -> None:
     service = object.__new__(VeFaaS)
     service.find_app_id_by_name = Mock(return_value=None)
     service._create_function = Mock(return_value=("studio-app-fn", "function-id"))
+    service._set_function_min_instance = Mock()
     service._create_application = Mock(return_value="application-id")
     service._release_application = Mock(side_effect=RuntimeError("release failed"))
     service.delete = Mock()
@@ -87,12 +106,14 @@ def test_vefaas_deploy_cleans_created_resources_on_release_failure() -> None:
 
     service.delete.assert_called_once_with("application-id")
     service.delete_function.assert_called_once_with("function-id")
+    service._set_function_min_instance.assert_not_called()
 
 
 def test_vefaas_deploy_can_keep_failed_resources_for_inspection() -> None:
     service = object.__new__(VeFaaS)
     service.find_app_id_by_name = Mock(return_value=None)
     service._create_function = Mock(return_value=("studio-app-fn", "function-id"))
+    service._set_function_min_instance = Mock()
     service._create_application = Mock(return_value="application-id")
     service._release_application = Mock(side_effect=RuntimeError("release failed"))
     service.delete = Mock()
@@ -110,6 +131,60 @@ def test_vefaas_deploy_can_keep_failed_resources_for_inspection() -> None:
 
     service.delete.assert_not_called()
     service.delete_function.assert_not_called()
+    service._set_function_min_instance.assert_not_called()
+
+
+def test_vefaas_update_code_uses_resource_updating_bundle_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "agent"
+    project.mkdir()
+    service = object.__new__(VeFaaS)
+    service.find_app_id_by_name = Mock(return_value="application-id")
+    service._get_application_status = Mock(
+        return_value=(
+            "deploy_success",
+            {
+                "Result": {
+                    "CloudResource": (
+                        '{"framework":{"function":{"Name":"studio-app-fn",'
+                        '"Id":"function-id"}}}'
+                    )
+                }
+            },
+        )
+    )
+    service._replace_application_code_bundle = Mock()
+    service._release_application = Mock(return_value="https://studio.example")
+    service._set_function_min_instance = Mock()
+    service.ensure_application_route_methods = Mock()
+
+    def _cookiecutter(*, output_dir: str, extra_context: dict, **_: object) -> None:
+        package = Path(output_dir) / str(extra_context["local_dir_name"])
+        (package / "src").mkdir(parents=True)
+
+    monkeypatch.setattr(
+        "veadk.integrations.ve_faas.ve_faas.formatted_timestamp", lambda: "stamp"
+    )
+    monkeypatch.setattr(
+        "veadk.integrations.ve_faas.ve_faas.tempfile.gettempdir",
+        lambda: str(tmp_path),
+    )
+    monkeypatch.setattr(
+        "veadk.integrations.ve_faas.ve_faas.cookiecutter", _cookiecutter
+    )
+
+    result = service._update_function_code("studio-app", str(project))
+
+    assert result == ("https://studio.example", "application-id", "function-id")
+    service._replace_application_code_bundle.assert_called_once_with(
+        function_id="function-id",
+        path=str(tmp_path / "agent_update_stamp" / "src"),
+        environment_overrides=None,
+        request_timeout=1800,
+    )
+    service._set_function_min_instance.assert_called_once_with("function-id")
 
 
 def test_vefaas_deploy_updates_existing_application_in_place() -> None:
@@ -297,6 +372,7 @@ def test_vefaas_deploy_can_disable_gateway_cors() -> None:
     service._create_function = Mock(return_value=("studio-app-fn", "function-id"))
     service._create_application = Mock(return_value="application-id")
     service._release_application = Mock(return_value="https://studio.example.com")
+    service._set_function_min_instance = Mock()
     service.ensure_application_route_methods = Mock()
 
     service.deploy(
@@ -312,6 +388,7 @@ def test_vefaas_deploy_can_disable_gateway_cors() -> None:
         "application-id",
         disable_cors=True,
     )
+    service._set_function_min_instance.assert_called_once_with("function-id")
 
 
 def test_vefaas_code_upload_callback_uses_configured_region() -> None:

--- a/veadk/cli/frontend_deploy_policy.py
+++ b/veadk/cli/frontend_deploy_policy.py
@@ -207,6 +207,7 @@ FRONTEND_DEPLOY_POLICY: dict = {
                 "vefaas:SetSandboxTimeout",
                 "vefaas:UpdateTimer",
                 "vefaas:UpdateFunction",
+                "vefaas:UpdateFunctionResource",
                 "vikingdb:GetKnowledgeBaseServiceInfo",
                 "vikingdb:GetMemorydbInstanceDetail",
                 "vikingdb:ListCollections",

--- a/veadk/cli/studio_deploy_permissions.py
+++ b/veadk/cli/studio_deploy_permissions.py
@@ -229,6 +229,11 @@ _VEFAAS_PERMISSIONS = (
         "Update Studio function environment variables",
     ),
     _permission(
+        "vefaas:UpdateFunctionResource",
+        "设置 Studio 函数最小实例数",
+        "Set the Studio function minimum instance count",
+    ),
+    _permission(
         "vefaas:Release", "重新发布 Studio 函数", "Release the updated Studio function"
     ),
     _permission(

--- a/veadk/cli/studio_update_permissions.py
+++ b/veadk/cli/studio_update_permissions.py
@@ -81,6 +81,11 @@ STUDIO_UPDATE_PERMISSION_SPECS: tuple[PermissionSpec, ...] = (
         "Update Studio and scheduler Functions",
     ),
     _permission(
+        "vefaas:UpdateFunctionResource",
+        "设置 Studio 函数最小实例数",
+        "Set the Studio function minimum instance count",
+    ),
+    _permission(
         "vefaas:ReleaseApplication",
         "发布 Studio 应用新 Revision",
         "Release the new Studio revision",

--- a/veadk/integrations/ve_faas/ve_faas.py
+++ b/veadk/integrations/ve_faas/ve_faas.py
@@ -517,9 +517,10 @@ class VeFaaS:
     ) -> str:
         """Replace an application's function bundle and release it.
 
-        Existing function settings are left untouched. When environment overrides
-        are provided, they are merged with the complete current environment before
-        updating the function.
+        Existing function settings are left untouched except that the minimum
+        instance count is set to one. When environment overrides are provided,
+        they are merged with the complete current environment before updating the
+        function.
 
         Args:
             application_id: Existing VeFaaS Application ID.
@@ -537,6 +538,7 @@ class VeFaaS:
             environment_overrides=environment_overrides,
         )
         url = self._release_application(application_id)
+        self._set_function_min_instance(function_id)
         if disable_gateway_cors:
             self.ensure_application_route_methods(
                 application_id,
@@ -557,13 +559,15 @@ class VeFaaS:
         Unlike :meth:`update_application_code_bundle`, this method does not wait for
         the new revision. It is intended for a function updating itself, because
         the current process may stop as soon as the control plane activates the
-        replacement revision.
+        replacement revision. The minimum instance count must be updated before
+        the release starts so a successful update always leaves one warm instance.
         """
         self._replace_application_code_bundle(
             function_id=function_id,
             path=path,
             environment_overrides=environment_overrides,
         )
+        self._set_function_min_instance(function_id)
         self._start_application_release(application_id)
 
     def _replace_application_code_bundle(
@@ -572,9 +576,12 @@ class VeFaaS:
         function_id: str,
         path: str,
         environment_overrides: dict[str, str] | None,
+        request_timeout: int | None = None,
     ) -> None:
         """Upload a bundle and update the Function without releasing it."""
         request_options: dict[str, Any] = {"id": function_id}
+        if request_timeout is not None:
+            request_options["request_timeout"] = request_timeout
         if environment_overrides:
             function = cast(
                 Any,
@@ -594,6 +601,15 @@ class VeFaaS:
         self._upload_and_mount_code(function_id, path)
         self.client.update_function(
             volcenginesdkvefaas.UpdateFunctionRequest(**request_options)
+        )
+
+    def _set_function_min_instance(self, function_id: str) -> None:
+        """Set only a Function's minimum instance count to one."""
+        self.client.update_function_resource(
+            volcenginesdkvefaas.UpdateFunctionResourceRequest(
+                function_id=function_id,
+                min_instance=1,
+            )
         )
 
     def _update_function_code(
@@ -670,17 +686,17 @@ class VeFaaS:
             else:
                 logger.warning("No requirements.txt found, using template default")
 
-            self._upload_and_mount_code(function_id, str(tmp_path / "src"))
-            self.client.update_function(
-                volcenginesdkvefaas.UpdateFunctionRequest(
-                    id=function_id,
-                    request_timeout=1800,  # Keep same timeout as deploy
-                )
+            self._replace_application_code_bundle(
+                function_id=function_id,
+                path=str(tmp_path / "src"),
+                environment_overrides=None,
+                request_timeout=1800,  # Keep same timeout as deploy
             )
             logger.info(
                 f"VeFaaS function {function_name} with ID {function_id} updated."
             )
             url = self._release_application(app_id)
+            self._set_function_min_instance(function_id)
             self.ensure_application_route_methods(app_id)
             logger.info(
                 f"VeFaaS application {application_name} with ID {app_id} released."
@@ -1014,6 +1030,7 @@ class VeFaaS:
             logger.info(f"VeFaaS application {name} with ID {app_id} created.")
             logger.info(f"Start to release VeFaaS application {app_id}.")
             url = self._release_application(app_id)
+            self._set_function_min_instance(function_id)
             self.ensure_application_route_methods(
                 app_id,
                 disable_cors=disable_gateway_cors,


### PR DESCRIPTION
## Summary\n\n- set the Studio VeFaaS minimum instance count to 1 during deploy and updates\n- apply the setting before a frontend self-update publishes its new revision, and stop the update if it cannot be applied\n- preserve the existing maximum instance count by omitting it from the resource update\n- add the required VeFaaS IAM permission for deployed Studio roles and the existing one-click authorization flow\n\n## Verification\n\n- ruff check...............................................................Passed
ruff format..............................................................Passed
Detect hardcoded secrets.................................................Passed\n- ============================= test session starts ==============================
platform darwin -- Python 3.12.11, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/bytedance/Projects/veadk-python-worktrees/studio-min-instance
configfile: pytest.ini
testpaths: tests
plugins: cov-7.1.0, xdist-3.8.0, asyncio-1.4.0, anyio-4.15.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 3697 items / 2 skipped

tests/a2a/test_registry_client.py .........................              [  0%]
tests/agent/test_agent_contract.py .....                                 [  0%]
tests/agent/test_model_api_key_resolution.py ...                         [  0%]
tests/agent/test_workflow_agent_contract.py .......                      [  1%]
tests/agent/test_workflow_execution.py ...s...........                   [  1%]
tests/auth/test_credential_service.py ..........                         [  1%]
tests/auth/test_oauth2_auth.py ......................................... [  2%]
.............                                                            [  3%]
tests/auth/veauth/test_apmplus_veauth.py ...                             [  3%]
tests/auth/veauth/test_ark_veauth.py .........                           [  3%]
tests/auth/veauth/test_speech_veauth.py ...                              [  3%]
tests/benchmarks/test_scheduler_500_due.py .                             [  3%]
tests/cli/test_agentkit_runtime_iam.py ...                               [  3%]
tests/cli/test_agentkit_sandbox_region.py .......                        [  3%]
tests/cli/test_cli_agentkit_harness_invoke.py .......                    [  4%]
tests/cli/test_cli_clean.py ...                                          [  4%]
tests/cli/test_cli_create.py ......                                      [  4%]
tests/cli/test_cli_deploy.py .                                           [  4%]
tests/cli/test_cli_harness.py ...                                        [  4%]
tests/cli/test_cli_harness_open_source_defaults.py ...                   [  4%]
tests/cli/test_cli_harness_registry.py ....                              [  4%]
tests/cli/test_codex_app_server.py ..................................... [  5%]
.......                                                                  [  5%]
tests/cli/test_frontend_agent_proxy.py ................                  [  6%]
tests/cli/test_frontend_apmplus_trace.py ...........                     [  6%]
tests/cli/test_frontend_branding.py ...........                          [  6%]
tests/cli/test_frontend_coding_agents.py ..............                  [  7%]
tests/cli/test_frontend_deploy_errors.py ................                [  7%]
tests/cli/test_frontend_deploy_iam.py ............                       [  8%]
tests/cli/test_frontend_deploy_iam_vestack.py ..                         [  8%]
tests/cli/test_frontend_evaluation_feedback.py ..............            [  8%]
tests/cli/test_frontend_invocation.py .........                          [  8%]
tests/cli/test_frontend_issue_feedback.py ............                   [  9%]
tests/cli/test_frontend_runtime_proxy.py ............................... [  9%]
....................................                                     [ 10%]
tests/cli/test_frontend_sandbox.py ..................................... [ 11%]
..................................................................       [ 13%]
tests/cli/test_frontend_sandbox_options.py ...........                   [ 13%]
tests/cli/test_frontend_sandbox_proxy.py ........                        [ 14%]
tests/cli/test_frontend_skill_creator.py .....................           [ 14%]
tests/cli/test_frontend_skill_spaces.py ...................              [ 15%]
tests/cli/test_frontend_trace.py ......                                  [ 15%]
tests/cli/test_frontend_video_env.py ..                                  [ 15%]
tests/cli/test_generated_agent_backend_codegen.py ...................... [ 16%]
.......................................................................  [ 17%]
tests/cli/test_generated_agent_backend_codegen_extended.py ............. [ 18%]
..........................................                               [ 19%]
tests/cli/test_generated_agent_component_matrix.py ..................... [ 19%]
...........................................                              [ 21%]
tests/cli/test_generated_agent_harness_sidecar.py .......                [ 21%]
tests/cli/test_generated_agent_mcp.py ...                                [ 21%]
tests/cli/test_generated_agent_planner.py ........sss                    [ 21%]
tests/cli/test_generated_agent_request_models.py .                       [ 21%]
tests/cli/test_github_cicd.py .............................              [ 22%]
tests/cli/test_legacy_runtime_recovery.py .............................. [ 23%]
..............                                                           [ 23%]
tests/cli/test_managed_sidecar_source.py ..........                      [ 23%]
tests/cli/test_runtime_update_recovery.py ............                   [ 24%]
tests/cli/test_studio_account_id.py ....                                 [ 24%]
tests/cli/test_studio_artifacts.py ......                                [ 24%]
tests/cli/test_studio_companion.py .........................             [ 25%]
tests/cli/test_studio_deploy_permissions.py ..............               [ 25%]
tests/cli/test_studio_deploy_serverless_iam.py ........                  [ 25%]
tests/cli/test_studio_deploy_target.py ................................. [ 26%]
..................                                                       [ 27%]
tests/cli/test_studio_environment_deploy_flags.py ..........             [ 27%]
tests/cli/test_studio_offline_runtime.py .............                   [ 27%]
tests/cli/test_studio_rbac.py .......................................... [ 28%]
........................................................................ [ 30%]
...                                                                      [ 31%]
tests/cli/test_studio_release.py .................................       [ 31%]
tests/cli/test_studio_sandbox_tools.py ................................. [ 32%]
..                                                                       [ 32%]
tests/cli/test_studio_sandbox_updates.py ...........                     [ 33%]
tests/cli/test_studio_self_update.py ................................... [ 34%]
........                                                                 [ 34%]
tests/cli/test_studio_sidecar_prerequisites.py ..........                [ 34%]
tests/cli/test_studio_telemetry.py .                                     [ 34%]
tests/cli/test_studio_update.py ...................................      [ 35%]
tests/cli/test_studio_update_permissions.py ........                     [ 35%]
tests/cli/test_studio_vpc_network.py ....                                [ 35%]
tests/cli/test_vestack_studio_deploy.py ............                     [ 36%]
tests/cli/test_vestack_studio_image.py ...                               [ 36%]
tests/cloud/test_harness_app_contract.py ............................... [ 37%]
...................................                                      [ 38%]
tests/cloud/test_harness_app_http.py ............                        [ 38%]
tests/cloud/test_harness_enhance_env.py ..                               [ 38%]
tests/cloud/test_harness_plugins.py ....                                 [ 38%]
tests/cloud/test_harness_skill_download.py ....                          [ 38%]
tests/config/test_model_config.py .....                                  [ 38%]
tests/config/test_tracing_config.py ...                                  [ 38%]
tests/extensions/harness/sidecar_runtime/test_component_catalog.py ..... [ 39%]
......                                                                   [ 39%]
tests/extensions/harness/sidecar_runtime/test_deploy.py .......          [ 39%]
tests/extensions/harness/sidecar_runtime/test_failover_proxy.py .        [ 39%]
tests/extensions/harness/sidecar_runtime/test_mcp_client.py ..           [ 39%]
tests/extensions/harness/sidecar_runtime/test_mcp_loopback_proxy.py ..   [ 39%]
tests/extensions/harness/sidecar_runtime/test_mcp_upstream_proxy.py ..   [ 39%]
tests/extensions/harness/sidecar_runtime/test_sidecar.py ..............  [ 39%]
tests/extensions/harness/sidecar_runtime/test_sidecar_config.py ........ [ 40%]
................................                                         [ 41%]
tests/extensions/harness/test_backward_compat.py ..                      [ 41%]
tests/extensions/harness/test_content_adapter.py ..                      [ 41%]
tests/extensions/harness/test_context_engine.py .....                    [ 41%]
tests/extensions/harness/test_env.py ...                                 [ 41%]
tests/extensions/harness/test_extension.py ......                        [ 41%]
tests/extensions/harness/test_headroom_provider.py .....                 [ 41%]
tests/extensions/harness/test_package_metadata.py .                      [ 41%]
tests/extensions/harness/test_result_verifier.py ...........             [ 41%]
tests/extensions/harness/test_runner_plugins.py .........                [ 42%]
tests/extensions/harness/test_sidecar_public_api.py .................    [ 42%]
tests/extensions/harness/test_sidecar_wheel.py ...                       [ 42%]
tests/extensions/harness/test_studio_sidecar.py ..........               [ 43%]
tests/extensions/harness/test_tool_compressor.py .....                   [ 43%]
tests/frontend/server/agent_usage/test_agent_usage_repository.py ....    [ 43%]
tests/frontend/server/agent_usage/test_agent_usage_service_routes.py ... [ 43%]
.......                                                                  [ 43%]
tests/frontend/server/artifacts/test_artifact_library.py ....            [ 43%]
tests/frontend/server/cronjobs/test_cronjobs.py ........                 [ 43%]
tests/frontend/server/environments/test_environment_share_codes.py ..... [ 44%]
.......                                                                  [ 44%]
tests/frontend/server/environments/test_environment_source_contracts.py . [ 44%]
.....                                                                    [ 44%]
tests/frontend/server/environments/test_environment_sources_backend.py . [ 44%]
..............                                                           [ 44%]
tests/frontend/server/environments/test_environments.py ................ [ 45%]
......................................................                   [ 46%]
tests/frontend/server/environments/test_session_mounts.py .............. [ 47%]
                                                                         [ 47%]
tests/frontend/server/environments/test_tool_provisioning.py ........... [ 47%]
...                                                                      [ 47%]
tests/frontend/server/evaluation_automation/test_datasets.py .           [ 47%]
tests/frontend/server/evaluation_automation/test_models.py ..            [ 47%]
tests/frontend/server/evaluation_automation/test_repository.py .....     [ 47%]
tests/frontend/server/evaluation_automation/test_routes.py ..            [ 47%]
tests/frontend/server/evaluation_automation/test_scheduler.py ..         [ 47%]
tests/frontend/server/evaluation_automation/test_service.py ....         [ 47%]
tests/frontend/server/evaluation_automation/test_sse.py .......          [ 48%]
tests/frontend/server/model_catalog/test_model_catalog.py .............. [ 48%]
......                                                                   [ 48%]
tests/frontend/server/skills/test_skill_publish_storage.py ......        [ 48%]
tests/frontend/server/storage/test_provisioning.py .........             [ 48%]
tests/frontend/server/storage/test_studio_storage.py .....               [ 49%]
tests/frontend/server/storage/test_tos.py .....                          [ 49%]
tests/frontend/server/studio_routes/test_studio_route_connector.py ..    [ 49%]
tests/frontend/server/studio_routes/test_studio_route_registry.py ..     [ 49%]
tests/frontend/server/studio_routes/test_studio_skill_catalog.py ....    [ 49%]
tests/frontend/server/studio_tools/test_branch_compare.py .........      [ 49%]
tests/frontend/server/studio_tools/test_codex_sandbox.py .............   [ 50%]
tests/frontend/server/studio_tools/test_connector.py .........           [ 50%]
tests/frontend/server/studio_tools/test_extensions.py ....               [ 50%]
tests/frontend/server/studio_tools/test_local.py ...                     [ 50%]
tests/frontend/server/studio_tools/test_registry.py .........            [ 50%]
tests/frontend/server/studio_tools/test_sandbox_shell.py ............... [ 51%]
.......                                                                  [ 51%]
tests/frontend/server/studio_tools/test_veadk_builtin_tools.py ...       [ 51%]
tests/frontend/server/test_agentkit_clients.py .                         [ 51%]
tests/frontend/server/test_deployment_resources.py ..................... [ 52%]
......                                                                   [ 52%]
tests/frontend/server/test_feishu_bot_setup.py ...........               [ 52%]
tests/frontend/server/test_intelligent_development_projects.py ......... [ 52%]
......                                                                   [ 52%]
tests/frontend/server/test_intelligent_development_routes.py ........... [ 53%]
.................................................                        [ 54%]
tests/frontend/server/test_intelligent_development_source.py ........... [ 54%]
..........................................................               [ 56%]
tests/frontend/server/test_intelligent_development_task.py ............. [ 56%]
.............................                                            [ 57%]
tests/frontend/server/test_migration_source_projects.py .                [ 57%]
tests/frontend/server/test_runtime_logs.py ............                  [ 57%]
tests/frontend/server/test_sandbox_remote.py ........................    [ 58%]
tests/frontend/server/test_studio_update_resources.py ........           [ 58%]
tests/frontend/server/video/test_video_routes.py ..............          [ 59%]
tests/frontend/server/video/test_video_storage.py ...                    [ 59%]
tests/frontend/server/website_integration/test_tos_service.py ....       [ 59%]
tests/frontend/server/website_integration/test_website_integration.py .. [ 59%]
............                                                             [ 59%]
tests/frontend/server/workspaces/test_workspaces.py ..                   [ 59%]
tests/frontend/service/studio_scheduler/test_diagnostics.py .            [ 59%]
tests/frontend/service/studio_scheduler/test_dispatcher.py ...........   [ 60%]
tests/frontend/service/studio_scheduler/test_end_to_end.py .             [ 60%]
tests/frontend/service/studio_scheduler/test_http_app.py ...             [ 60%]
tests/frontend/service/studio_scheduler/test_local_entrypoint.py ..      [ 60%]
tests/frontend/service/studio_scheduler/test_local_runner.py .           [ 60%]
tests/frontend/service/studio_scheduler/test_runtime_provider.py ......  [ 60%]
tests/frontend/service/studio_scheduler/test_schedule.py ....            [ 60%]
tests/frontend/service/studio_scheduler/test_scheduler_deploy.py .....   [ 60%]
tests/frontend/service/studio_scheduler/test_tos_repository.py ......    [ 60%]
tests/frontend/test_deployment_source.py ............................... [ 61%]
........                                                                 [ 61%]
tests/frontend/test_knowledge_service.py ............................... [ 62%]
.................................                                        [ 63%]
tests/frontend/test_knowledge_uploads.py ............................... [ 64%]
......................................                                   [ 65%]
tests/frontend/test_knowledge_web_import.py ............................ [ 66%]
.......                                                                  [ 66%]
tests/frontend/test_migration_contracts.py .........                     [ 66%]
tests/frontend/test_migration_gateway_edges.py .............             [ 67%]
tests/frontend/test_migration_routes.py .......                          [ 67%]
tests/frontend/test_migration_server.py ................................ [ 68%]
........................................................................ [ 70%]
....................                                                     [ 70%]
tests/frontend/test_migration_service_edges.py ......................... [ 71%]
..                                                                       [ 71%]
tests/frontend/test_skill_repair.py ...                                  [ 71%]
tests/frontend/test_skills_server.py ................................... [ 72%]
..                                                                       [ 72%]
tests/integrations/agentkit/evaluation/test_client.py ..........         [ 72%]
tests/integrations/agentkit/evaluation/test_feedback.py ...              [ 72%]
tests/integrations/agentkit/test_app.py ....................             [ 73%]
tests/integrations/agentkit/test_studio_channel.py ................      [ 73%]
tests/integrations/agentkit/test_studio_routes.py ..........             [ 73%]
tests/integrations/test_ve_apig_vestack.py .........                     [ 74%]
tests/integrations/test_ve_faas_image.py .                               [ 74%]
tests/memory/long_term_memory_backends/test_tos_context_bucket_backend.py . [ 74%]
..............                                                           [ 74%]
tests/memory/test_postgres_schema.py ..........                          [ 74%]
tests/models/test_ark_llm_context_management.py .                        [ 74%]
tests/models/test_ark_llm_fallbacks.py ....                              [ 75%]
tests/models/test_ark_llm_input_conversion.py ....                       [ 75%]
tests/multimodal/test_api.py ...                                         [ 75%]
tests/multimodal/test_plugin.py ..........                               [ 75%]
tests/multimodal/test_storage.py ........                                [ 75%]
tests/multimodal/test_transport.py ....                                  [ 75%]
tests/plugins/test_codex_sandbox_upload.py ............................. [ 76%]
....                                                                     [ 76%]
tests/realtime/test_doubao_realtime_client.py ......                     [ 76%]
tests/realtime/test_doubao_realtime_voice_llm.py .......                 [ 77%]
tests/realtime/test_doubao_realtime_voice_llm_connection.py ....         [ 77%]
tests/realtime/test_live.py ...                                          [ 77%]
tests/realtime/test_protocol.py ........                                 [ 77%]
tests/runner/test_runner_contract.py .......                             [ 77%]
tests/runtime/codex/test_codex_runtime.py .......................        [ 78%]
tests/runtime/codex/test_codex_runtime_smoke.py s                        [ 78%]
tests/runtime/codex/test_codex_shim_rounds.py ........................   [ 78%]
tests/runtime/codex/test_codex_tracing.py .                              [ 78%]
tests/runtime/codex/test_codex_turn_contract.py .........                [ 79%]
tests/runtime/differential/test_parity_harness.py ...................... [ 79%]
..                                                                       [ 79%]
tests/runtime/differential/test_runtime_parity.py ...........xx......... [ 80%]
...                                                                      [ 80%]
tests/runtime/piagent/test_piagent_runtime.py .......................... [ 81%]
.............................                                            [ 82%]
tests/runtime/piagent/test_piagent_runtime_smoke.py s                    [ 82%]
tests/runtime/piagent/test_piagent_turn_contract.py ..........           [ 82%]
tests/runtime/test_agent_transfer.py ...                                 [ 82%]
tests/runtime/test_dispatch_runtime_provider.py ....                     [ 82%]
tests/runtime/test_model_callbacks.py ......                             [ 82%]
tests/runtime/test_output_state.py ...........                           [ 82%]
tests/runtime/test_self_host_sandbox_agent.py ...                        [ 83%]
tests/runtime/test_self_host_sandbox_client.py ....                      [ 83%]
tests/skills/test_adk_skill_materializer.py ............                 [ 83%]
tests/skills/test_adk_skill_registry.py .....                            [ 83%]
tests/skills/test_agent_adk_skill_toolset.py ...                         [ 83%]
tests/test_adk_compat.py ...........                                     [ 84%]
tests/test_adk_compat_regression.py ..............................s..... [ 84%]
..........                                                               [ 85%]
tests/test_adk_sync_tool_thread_pool_patch.py .....                      [ 85%]
tests/test_agent.py ...............                                      [ 85%]
tests/test_agent_metadata.py ...                                         [ 85%]
tests/test_cloud.py .............................                        [ 86%]
tests/test_evaluator.py ..                                               [ 86%]
tests/test_feishu_channel_extension.py ........                          [ 86%]
tests/test_knowledgebase.py .                                            [ 86%]
tests/test_llm_attributes_extractors.py ..........                       [ 87%]
tests/test_long_term_memory.py ...............                           [ 87%]
tests/test_milvus_knowledge_backend.py ...............                   [ 88%]
tests/test_multiple_agents.py .                                          [ 88%]
tests/test_openviking_knowledgebase.py .............................     [ 88%]
tests/test_openviking_long_term_memory.py .............................. [ 89%]
..                                                                       [ 89%]
tests/test_pdf_to_images.py ...                                          [ 89%]
tests/test_portal_metrics.py .......                                     [ 89%]
tests/test_runner.py .                                                   [ 90%]
tests/test_runtime_data_collecting.py .                                  [ 90%]
tests/test_short_term_memory.py .....                                    [ 90%]
tests/test_studio_release_lock_contract.py .                             [ 90%]
tests/test_studio_release_server.py .................................... [ 91%]
................................                                         [ 92%]
tests/test_tracing.py ...................                                [ 92%]
tests/test_tracing_content.py .............                              [ 92%]
tests/test_ve_a2a_middlewares.py ..........                              [ 93%]
tests/test_ve_identity_auth_config.py .................                  [ 93%]
tests/test_ve_identity_function_tool.py ..........                       [ 93%]
tests/test_ve_identity_mcp_tool.py ......                                [ 94%]
tests/test_ve_identity_mcp_toolset.py ...........                        [ 94%]
tests/test_ve_tos.py ................                                    [ 94%]
tests/test_vikingdb_knowledge_backend.py ..........                      [ 95%]
tests/test_vikingdb_memory_backend.py ..........                         [ 95%]
tests/tools/builtin_tools/create_agent/test_create_agent_toolset.py .... [ 95%]
..........................                                               [ 96%]
tests/tools/builtin_tools/create_agent/test_resource_sources.py ........ [ 96%]
......                                                                   [ 96%]
tests/tools/builtin_tools/test_agentkit.py ..............                [ 96%]
tests/tools/builtin_tools/test_invoke_poll_skill.py ......               [ 97%]
tests/tools/builtin_tools/test_load_knowledgebase.py ....                [ 97%]
tests/tools/builtin_tools/test_remote_skills.py ......                   [ 97%]
tests/tools/builtin_tools/test_run_code.py .................             [ 97%]
tests/tools/builtin_tools/test_run_sandbox_agent.py .................... [ 98%]
                                                                         [ 98%]
tests/tools/builtin_tools/test_tts.py .....                              [ 98%]
tests/tools/builtin_tools/test_web_fetch_contract.py ....                [ 98%]
tests/tools/mcp_tool/test_trusted_mcp_components.py .....                [ 98%]
tests/tools/test_builtin_registry_contract.py .................          [ 99%]
tests/tools/test_ppt_generate.py ...                                     [ 99%]
tests/tools/test_web_search_byteplus.py ..                               [ 99%]
tests/tunnel/test_tunnel_contract.py ..............                      [ 99%]
tests/utils/test_mcp_session_retry.py .........                          [ 99%]
tests/utils/test_volcengine_sign.py ..                                   [100%]

=============================== warnings summary ===============================
veadk/auth/middleware/oauth2_auth.py:96
  /Users/bytedance/Projects/veadk-python-worktrees/studio-min-instance/veadk/auth/middleware/oauth2_auth.py:96: AuthlibDeprecationWarning: authlib.jose module is deprecated, please use joserfc instead.
  It will be compatible before version 2.0.0.
    from authlib.jose import JsonWebKey, jwt

tests/cli/test_frontend_trace.py::test_build_graph_serializes_veadk_agent_model
  /Users/bytedance/Projects/veadk-python-worktrees/studio-min-instance/.venv/lib/python3.12/site-packages/google/adk/cli/fast_api.py:104: PendingDeprecationWarning: Please use `import python_multipart` instead.
    import multipart

tests/cli/test_studio_rbac.py::test_system_info_lists_configured_sandbox_tool_ids
  /Users/bytedance/Projects/veadk-python-worktrees/studio-min-instance/.venv/lib/python3.12/site-packages/tos/utils.py:1034: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
    t.setDaemon(True)

tests/cli/test_studio_rbac.py::test_system_info_lists_configured_sandbox_tool_ids
tests/cli/test_studio_rbac.py::test_system_info_lists_configured_sandbox_tool_ids
tests/cli/test_studio_rbac.py::test_system_info_lists_configured_sandbox_tool_ids
tests/cli/test_studio_rbac.py::test_system_info_prefetches_codex_model_env_state_on_startup
tests/cli/test_studio_rbac.py::test_system_info_prefetches_codex_model_env_state_on_startup
tests/cli/test_studio_rbac.py::test_system_info_prefetches_codex_model_env_state_on_startup
tests/cli/test_studio_rbac.py::test_system_info_prefetch_hides_get_tool_failures_but_reports_error_code
tests/cli/test_studio_rbac.py::test_system_info_prefetch_hides_get_tool_failures_but_reports_error_code
tests/cli/test_studio_rbac.py::test_system_info_prefetch_hides_get_tool_failures_but_reports_error_code
  /Users/bytedance/Projects/veadk-python-worktrees/studio-min-instance/.venv/lib/python3.12/site-packages/tos/auth.py:293: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    return datetime.datetime.utcnow().strftime(DATE_FORMAT)

tests/cli/test_studio_rbac.py: 16 warnings
tests/cli/test_studio_self_update.py: 1 warning
tests/utils/test_volcengine_sign.py: 2 warnings
  /Users/bytedance/Projects/veadk-python-worktrees/studio-min-instance/veadk/utils/volcengine_sign.py:372: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now = datetime.datetime.utcnow()

tests/cloud/test_harness_app_http.py::test_harness_app_exposes_agent_info
  /Users/bytedance/Projects/veadk-python-worktrees/studio-min-instance/.venv/lib/python3.12/site-packages/google/adk/runners.py:294: DeprecationWarning: The `plugins` argument is deprecated. Please use the `app` argument to provide plugins instead.
    warnings.warn(

tests/cloud/test_harness_app_http.py::test_harness_app_exposes_agent_info
  /Users/bytedance/Projects/veadk-python-worktrees/studio-min-instance/veadk/cloud/harness_app/app.py:247: DeprecationWarning: AdkWebServer is deprecated and has been refactored into ApiServer and DevServer. Use DevServer instead.
    self._server = AdkWebServer(

tests/extensions/harness/sidecar_runtime/test_mcp_client.py::test_managed_client_normalizes_runtime_gateway_session_header
  /Users/bytedance/Projects/veadk-python-worktrees/studio-min-instance/tests/extensions/harness/sidecar_runtime/test_mcp_client.py:147: DeprecationWarning: MCPToolset class is deprecated, use `McpToolset` instead.
    toolset = MCPToolset(

tests/extensions/harness/sidecar_runtime/test_mcp_client.py::test_managed_client_normalizes_runtime_gateway_session_header
tests/extensions/harness/sidecar_runtime/test_mcp_client.py::test_managed_client_ignores_proxy_environment_for_loopback
tests/extensions/harness/sidecar_runtime/test_mcp_loopback_proxy.py::test_loopback_relay_preserves_alternate_session_without_env_proxy[/mcp]
tests/extensions/harness/sidecar_runtime/test_mcp_loopback_proxy.py::test_loopback_relay_preserves_alternate_session_without_env_proxy[/vmetrics]
  /Users/bytedance/.local/share/uv/python/cpython-3.12-macos-aarch64-none/lib/python3.12/contextlib.py:105: DeprecationWarning: Use `streamable_http_client` instead.
    self.gen = func(*args, **kwds)

tests/extensions/harness/sidecar_runtime/test_mcp_client.py::test_managed_client_normalizes_runtime_gateway_session_header
tests/extensions/harness/sidecar_runtime/test_mcp_client.py::test_managed_client_ignores_proxy_environment_for_loopback
tests/extensions/harness/sidecar_runtime/test_mcp_loopback_proxy.py::test_loopback_relay_preserves_alternate_session_without_env_proxy[/mcp]
tests/extensions/harness/sidecar_runtime/test_mcp_loopback_proxy.py::test_loopback_relay_preserves_alternate_session_without_env_proxy[/vmetrics]
tests/runtime/codex/test_codex_runtime.py::test_tool_executor_supports_stdio_mcp_toolset
tests/runtime/piagent/test_piagent_runtime.py::test_build_executable_tools_calls_real_stdio_mcp_toolset
  /Users/bytedance/Projects/veadk-python-worktrees/studio-min-instance/.venv/lib/python3.12/site-packages/google/adk/tools/mcp_tool/mcp_toolset.py:356: DeprecationWarning: MCPTool class is deprecated, use `McpTool` instead.
    mcp_tool = MCPTool(

tests/extensions/harness/sidecar_runtime/test_mcp_client.py::test_managed_client_ignores_proxy_environment_for_loopback
  /Users/bytedance/Projects/veadk-python-worktrees/studio-min-instance/tests/extensions/harness/sidecar_runtime/test_mcp_client.py:194: DeprecationWarning: MCPToolset class is deprecated, use `McpToolset` instead.
    toolset = MCPToolset(

tests/extensions/harness/sidecar_runtime/test_mcp_loopback_proxy.py::test_loopback_relay_preserves_alternate_session_without_env_proxy[/mcp]
tests/extensions/harness/sidecar_runtime/test_mcp_loopback_proxy.py::test_loopback_relay_preserves_alternate_session_without_env_proxy[/vmetrics]
  /Users/bytedance/Projects/veadk-python-worktrees/studio-min-instance/tests/extensions/harness/sidecar_runtime/test_mcp_loopback_proxy.py:123: DeprecationWarning: MCPToolset class is deprecated, use `McpToolset` instead.
    toolset = MCPToolset(

tests/plugins/test_codex_sandbox_upload.py::test_build_and_restore_preserves_worktree_and_github_auth
  /Users/bytedance/Projects/veadk-python-worktrees/studio-min-instance/tests/plugins/test_codex_sandbox_upload.py:106: DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata. Use the filter argument to control this behavior.
    archive.extractall(stage)

tests/plugins/test_codex_sandbox_upload.py::test_restore_hides_generated_section_for_tracked_handoff
  /Users/bytedance/Projects/veadk-python-worktrees/studio-min-instance/tests/plugins/test_codex_sandbox_upload.py:187: DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata. Use the filter argument to control this behavior.
    archive.extractall(stage)

tests/runtime/codex/test_codex_runtime.py::test_authenticated_tool_stores_credential_and_resumes
  /Users/bytedance/Projects/veadk-python-worktrees/studio-min-instance/.venv/lib/python3.12/site-packages/google/adk/auth/auth_tool.py:94: DeprecationWarning: This method is deprecated. Use credential_key instead.
    self.credential_key = self.get_credential_key()

tests/runtime/codex/test_codex_runtime.py::test_tool_executor_supports_stdio_mcp_toolset
  /Users/bytedance/Projects/veadk-python-worktrees/studio-min-instance/tests/runtime/codex/test_codex_runtime.py:855: DeprecationWarning: MCPToolset class is deprecated, use `McpToolset` instead.
    toolset = MCPToolset(

tests/runtime/piagent/test_piagent_runtime.py::test_build_executable_tools_calls_real_stdio_mcp_toolset
  /Users/bytedance/Projects/veadk-python-worktrees/studio-min-instance/tests/runtime/piagent/test_piagent_runtime.py:1412: DeprecationWarning: MCPToolset class is deprecated, use `McpToolset` instead.
    toolset = MCPToolset(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===== 3688 passed, 9 skipped, 2 xfailed, 52 warnings in 420.58s (0:07:00) ====== (3687 passed, 9 skipped, 2 xfailed)\n- Volcengine CLI deploy/update verified: min 0 -> 1, max remains 10, endpoint HTTP 200\n- Volcengine Studio frontend online update verified end to end:\n  - removed  from the Function role policy and reset min to 0\n  - update was blocked before cloud resource changes and displayed the missing permission\n  - the prefilled one-click IAM page preserved the existing policy and included the new permission\n  -  returned HTTP 200\n  - retry passed permission precheck and the new Revision took over\n  - final resource state: min 1, max 10; Studio endpoint HTTP 200\n- BytePlus resource update verified: min 0 -> 1, max remains 10