### PR TITLE
fix(studio): scope thin releases by provider

### DIFF
--- a/.github/workflows/publish-studio-release.yaml
+++ b/.github/workflows/publish-studio-release.yaml
@@ -22,7 +22,7 @@ on:
         required: true
         type: string
       thin_bundles:
-        description: Publish provider-local thin bundles (requires server opt-in)
+        description: Publish Volcengine thin bundles (BytePlus remains full-only)
         required: true
         default: false
         type: boolean
@@ -246,9 +246,11 @@ jobs:
       matrix:
         include:
           - provider: volcengine
+            thin_bundles: ${{ inputs.thin_bundles }}
             url_secret: STUDIO_RELEASE_SERVER_URL
             key_secret: STUDIO_RELEASE_SERVER_API_KEY
           - provider: byteplus
+            thin_bundles: false
             url_secret: BYTEPLUS_STUDIO_RELEASE_SERVER_URL
             key_secret: BYTEPLUS_STUDIO_RELEASE_SERVER_API_KEY
     runs-on: ubuntu-latest
@@ -259,7 +261,7 @@ jobs:
       RELEASE_SERVER_URL: ${{ secrets[matrix.url_secret] }}
       RELEASE_SERVER_API_KEY: ${{ secrets[matrix.key_secret] }}
       RELEASE_VERSION: ${{ needs.release-context.outputs.version }}
-      RELEASE_THIN_BUNDLES: ${{ inputs.thin_bundles }}
+      RELEASE_THIN_BUNDLES: ${{ matrix.thin_bundles }}
 
     steps:
       - name: Validate release server configuration

--- a/tests/test_studio_release_workflow.py
+++ b/tests/test_studio_release_workflow.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for the Studio release workflow."""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def _publish_job() -> dict[str, Any]:
+    workflow_path = (
+        Path(__file__).parents[1]
+        / ".github"
+        / "workflows"
+        / "publish-studio-release.yaml"
+    )
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    return workflow["jobs"]["publish"]
+
+
+def test_thin_bundle_input_is_scoped_to_supported_provider() -> None:
+    publish = _publish_job()
+    providers = {
+        entry["provider"]: entry for entry in publish["strategy"]["matrix"]["include"]
+    }
+
+    assert providers["volcengine"]["thin_bundles"] == "${{ inputs.thin_bundles }}"
+    assert providers["byteplus"]["thin_bundles"] is False
+    assert publish["env"]["RELEASE_THIN_BUNDLES"] == "${{ matrix.thin_bundles }}"


### PR DESCRIPTION
## Summary

- keep the existing `thin_bundles` workflow input for compatibility
- apply that input only to the Volcengine publisher and keep BytePlus full-only
- add a structural YAML regression test for the provider matrix and environment binding

## Context

Publish Studio Release run #826 enabled thin bundles globally. The BytePlus Release Server intentionally has thin releases disabled, so its accepted release job failed before bundle publication while the Volcengine job succeeded.

## Testing

- `pytest -q tests/test_studio_release_workflow.py`
- `ruff check tests/test_studio_release_workflow.py`
- `ruff format --check tests/test_studio_release_workflow.py`
- `pre-commit run --files .github/workflows/publish-studio-release.yaml tests/test_studio_release_workflow.py`
- `git diff --check`
