### PR TITLE
fix(studio): provision persistent sandbox alongside other tools

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1011,8 +1011,13 @@ agent terminology rather than exposing these control-plane resource types.
 `/opt/gem/run.sh`，不再注入编辑器补丁。火山引擎默认中文，BytePlus 默认英文，
 模型配置沿用相应云环境的 Studio 配置。
 
+部署时 Studio Sandbox 与其他 Sandbox Tool 并行创建，并自动获取模型凭据，
+注入 `MODEL_AGENT_NAME`、`MODEL_AGENT_BASE_URL` 和 `MODEL_AGENT_API_KEY`。
+可通过 `--studio-sandbox-tool-id t-xxx` 或环境变量 `STUDIO_WORKSPACE_TOOL_ID`
+指定已配置好的持久化 Tool，此时直接复用，不重新创建或修改配置。
 部署通过 `STUDIO_WORKSPACE_TOOL_ID` 绑定工作区，系统信息显示对应 Tool ID。
-`veadk studio update` 和前端更新都会自动补齐缺失的持久化工作区 Tool，并保存绑定。
+`veadk studio update` 和前端更新都会自动补齐缺失的持久化工作区 Tool，
+配置上述模型凭据并保存绑定，火山引擎和 BytePlus 均适用。
 已有 Tool ID 时保留绑定，避免切换个人项目存储；创建失败时更新报错，不忽略失败。
 从尚不支持补建的旧版本更新时，新版本首次启动会在后台补建并保存函数环境中的 Tool ID。
 补建期间代码项目暂不可用，失败会记录日志，可检查权限后重试更新。

--- a/tests/cli/test_frontend_branding.py
+++ b/tests/cli/test_frontend_branding.py
@@ -108,11 +108,13 @@ def test_resolve_site_logo_downloads_network_image(
     ("title_args", "expected_site_title"),
     [([], None), (["--site-title", "火山助手"], "火山助手")],
 )
+@pytest.mark.parametrize("workspace_id", [None, "existing-studio-tool"])
 def test_studio_deploy_bundles_logo_and_optional_title(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     title_args: list[str],
     expected_site_title: str | None,
+    workspace_id: str | None,
 ) -> None:
     logo_path = tmp_path / "logo.png"
     logo_path.write_bytes(_PNG)
@@ -180,9 +182,28 @@ def test_studio_deploy_bundles_logo_and_optional_title(
         "veadk.cli.frontend_skill_creator.ensure_skill_creator_model_credential",
         lambda **_: None,
     )
+    from threading import Event
+
+    workspace_started = Event()
+    other_tool_started = Event()
+
+    def create_code_tool(**kwargs):
+        other_tool_started.set()
+        if workspace_id is None:
+            assert workspace_started.wait(5), "Studio Sandbox must start concurrently"
+        return f"auto-{kwargs['name']}"
+
+    monkeypatch.setattr(
+        "veadk.cli.studio_sandbox_tools.ensure_studio_code_env_tool",
+        create_code_tool,
+    )
     workspace_calls = []
 
     def provision_workspace(**kwargs):
+        workspace_started.set()
+        assert other_tool_started.wait(5), (
+            "Other tools must not wait for Studio Sandbox"
+        )
         workspace_calls.append(kwargs)
         return "studio-workspace-tool"
 
@@ -219,13 +240,20 @@ def test_studio_deploy_bundles_logo_and_optional_title(
         "--site-logo",
         str(logo_path),
     ]
+    if workspace_id:
+        args.extend(["--studio-sandbox-tool-id", workspace_id])
     result = CliRunner().invoke(studio, args + title_args)
 
     assert result.exit_code == 0, result.output
-    assert len(workspace_calls) == 1
-    assert workspace_calls[0]["provider"] == "volcengine"
-    assert workspace_calls[0]["access_key"] == "ak"
-    assert environments["STUDIO_WORKSPACE_TOOL_ID"] == "studio-workspace-tool"
+    if workspace_id:
+        assert workspace_calls == []
+        assert environments["STUDIO_WORKSPACE_TOOL_ID"] == workspace_id
+    else:
+        assert len(workspace_calls) == 1
+        assert workspace_calls[0]["provider"] == "volcengine"
+        assert workspace_calls[0]["access_key"] == "ak"
+        assert environments["STUDIO_WORKSPACE_TOOL_ID"] == "studio-workspace-tool"
+        assert "Studio Sandbox Tool and model credentials are ready" in result.output
     assert captured["logo"] == _PNG
     assert '--site-logo "$ROOT_DIR/site-logo.png"' in str(captured["run_script"])
     if expected_site_title is None:

--- a/tests/frontend/server/test_studio_update_resources.py
+++ b/tests/frontend/server/test_studio_update_resources.py
@@ -130,10 +130,27 @@ def test_reconcile_studio_update_resources_reuses_existing_resources(
 def test_reconcile_studio_update_resources_provisions_missing_resources(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    workspace_models = []
+
+    def workspace_tool(client, image, provider, model_environment):
+        assert provider == "byteplus"
+        workspace_models.append(model_environment)
+        return "workspace-tool"
+
+    def model_token(**kwargs):
+        assert kwargs == {
+            "cloud_provider": "byteplus",
+            "region": "ap-southeast-1",
+            "access_key": "ak",
+            "secret_key": "sk",
+            "session_token": "token",
+        }
+        return "test-workspace-model-token"
+
     monkeypatch.setattr(
-        "frontend.server.workspace_tool.provision_workspace_tool",
-        lambda **kwargs: "workspace-tool",
+        "frontend.server.workspace_tool.ensure_workspace_tool", workspace_tool
     )
+    monkeypatch.setattr("veadk.auth.veauth.ark_veauth.get_ark_token", model_token)
     storage_calls: list[dict[str, Any]] = []
     tool_calls: list[dict[str, Any]] = []
 
@@ -171,6 +188,10 @@ def test_reconcile_studio_update_resources_provisions_missing_resources(
         session_token="token",
     )
 
+    assert len(workspace_models) == 1
+    assert workspace_models[0]["MODEL_AGENT_API_KEY"] == "test-workspace-model-token"
+    assert workspace_models[0]["MODEL_AGENT_NAME"]
+    assert workspace_models[0]["MODEL_AGENT_BASE_URL"].startswith("https://")
     assert overrides == {
         "STUDIO_WORKSPACE_TOOL_ID": "workspace-tool",
         "VEADK_STUDIO_KNOWLEDGE_SIGNING_KEY": "generated-key",

--- a/tests/frontend/server/test_workspace_tool.py
+++ b/tests/frontend/server/test_workspace_tool.py
@@ -194,3 +194,58 @@ def test_old_release_startup_persists_binding_without_replacing_function_env(
     )
     client.update_function.assert_not_called()
     client.release.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "provider,region",
+    [
+        ("volcengine", "cn-beijing"),
+        ("volcengine", "cn-shanghai"),
+        ("byteplus", "ap-southeast-1"),
+    ],
+)
+def test_missing_workspace_update_injects_model_credentials(
+    monkeypatch, provider, region
+):
+    from types import SimpleNamespace
+
+    from frontend.server import workspace_tool
+
+    captured = {}
+    credentials = {
+        "access_key": "test-ak",
+        "secret_key": "test-sk",
+        "session_token": "test-session",
+        "region": region,
+    }
+
+    class Client:
+        def __init__(self, **kwargs):
+            assert kwargs == credentials
+
+        def list_tools(self, request):
+            return SimpleNamespace(tools=[])
+
+        def create_tool(self, request):
+            captured["request"] = request
+            return SimpleNamespace(tool_id="t-configured")
+
+        def get_tool(self, request):
+            return SimpleNamespace(status="Ready")
+
+    def get_token(**kwargs):
+        assert kwargs == {**credentials, "cloud_provider": provider}
+        return "test-model-token"
+
+    monkeypatch.setattr("agentkit.sdk.tools.client.AgentkitToolsClient", Client)
+    monkeypatch.setattr("veadk.auth.veauth.ark_veauth.get_ark_token", get_token)
+    result = workspace_tool.workspace_update_environment(
+        {}, provider=provider, **credentials
+    )
+    assert result == {"STUDIO_WORKSPACE_TOOL_ID": "t-configured"}
+    request = captured["request"]
+    env = {item.key: item.value for item in request.envs}
+    assert env["MODEL_AGENT_API_KEY"] == "test-model-token"
+    assert env["MODEL_AGENT_NAME"]
+    assert env["MODEL_AGENT_BASE_URL"].startswith("https://")
+    assert request.enable_snapshot is True

--- a/veadk/cli/cli_frontend.py
+++ b/veadk/cli/cli_frontend.py
@@ -14568,6 +14568,13 @@ def _resolve_studio_cloud_credentials(
     help="Comma-separated Studio developer usernames or OAuth emails.",
 )
 @click.option(
+    "--studio-sandbox-tool-id",
+    default=None,
+    envvar="STUDIO_WORKSPACE_TOOL_ID",
+    help="Existing persistent Studio Sandbox Tool ID. Omit to create and "
+    "configure one alongside the other sandbox tools.",
+)
+@click.option(
     "--sandbox-dev-tool-id",
     "sandbox_dev_tool_id",
     default=None,
@@ -14687,6 +14694,7 @@ def frontend_deploy(
     site_title: str | None,
     studio_admins: str | None,
     studio_developers: str | None,
+    studio_sandbox_tool_id: str | None,
     sandbox_dev_tool_id: str | None,
     sandbox_chat_codex_tool_id: str | None,
     sandbox_chat_openclaw_tool_id: str | None,
@@ -15001,8 +15009,18 @@ def frontend_deploy(
     auto_storage = not str(
         veadk_environments.get("VEADK_STUDIO_TOS_BUCKET") or ""
     ).strip()
-    # Studio always provisions its persistent workspace Tool.
-    auto_sandbox_tools = True
+    auto_sandbox_tools = not all(
+        (
+            studio_sandbox_tool_id,
+            sandbox_dev_tool_id,
+            sandbox_chat_codex_tool_id,
+            sandbox_chat_codex_snapshot_tool_id,
+            sandbox_chat_openclaw_tool_id,
+            sandbox_chat_openclaw_snapshot_tool_id,
+            sandbox_chat_hermes_tool_id,
+            sandbox_chat_hermes_snapshot_tool_id,
+        )
+    )
     from veadk.cli.studio_deploy_permissions import (
         IAM_CONFIG_URLS,
         required_permission_specs,
@@ -15243,8 +15261,27 @@ def frontend_deploy(
         click.echo(f"Creating AgentKit {label} Tool '{tool_names[0]}'…")
         missing_sandbox_tools[kind] = tool_names
 
-    if missing_sandbox_tools:
-        with ThreadPoolExecutor(max_workers=len(missing_sandbox_tools)) as executor:
+    from frontend.server.workspace_tool import provision_workspace_tool
+
+    workspace_tool_id = (studio_sandbox_tool_id or "").strip()
+    if workspace_tool_id:
+        click.echo(f"Using configured Studio Sandbox Tool '{workspace_tool_id}'.")
+
+    if missing_sandbox_tools or not workspace_tool_id:
+        with ThreadPoolExecutor(max_workers=len(missing_sandbox_tools) + 1) as executor:
+            workspace_future = None
+            if not workspace_tool_id:
+                click.echo(
+                    "Preparing persistent Studio Sandbox Tool and model credentials…"
+                )
+                workspace_future = executor.submit(
+                    provision_workspace_tool,
+                    provider=provider_id,
+                    region=region,
+                    access_key=ak,
+                    secret_key=sk,
+                    session_token=session_token or "",
+                )
             tool_futures = {}
             for kind, tool_names in missing_sandbox_tools.items():
                 if tool_futures:
@@ -15303,6 +15340,24 @@ def frontend_deploy(
                         f"Underlying error:\n{detail}"
                     ) from error
                 click.echo(f"AgentKit {label} Tool is ready.")
+
+            if workspace_future is not None:
+                try:
+                    workspace_tool_id = workspace_future.result()
+                    if not workspace_tool_id:
+                        raise RuntimeError(
+                            "Studio Sandbox provisioning returned no Tool ID"
+                        )
+                except Exception as error:
+                    detail = _safe_exception_detail(
+                        error, secrets=(ak, sk, session_token)
+                    )
+                    raise click.ClickException(
+                        f"Failed to provision Studio Sandbox Tool and model credentials: {detail}"
+                    ) from error
+                click.echo(
+                    f"Studio Sandbox Tool and model credentials are ready: {workspace_tool_id}"
+                )
 
     from veadk.cli.frontend_skill_creator import (
         ensure_skill_creator_model_credential,
@@ -15378,24 +15433,6 @@ def frontend_deploy(
     hermes_tool_id = resolved_sandbox_tool_ids.get("hermes", "")
     hermes_snapshot_tool_id = resolved_sandbox_tool_ids.get("hermes_snapshot", "")
     dev_tool_id = resolved_sandbox_tool_ids.get("dev", "")
-
-    from frontend.server.workspace_tool import provision_workspace_tool
-
-    click.echo("Preparing persistent Studio Sandbox Tool…")
-    try:
-        workspace_tool_id = provision_workspace_tool(
-            provider=provider_id,
-            region=region,
-            access_key=ak,
-            secret_key=sk,
-            session_token=session_token or "",
-        )
-    except Exception as error:
-        detail = _safe_exception_detail(error, secrets=(ak, sk, session_token))
-        raise click.ClickException(
-            f"Failed to provision Studio Sandbox Tool: {detail}"
-        ) from error
-    click.echo(f"Studio Sandbox Tool is ready: {workspace_tool_id}")
 
     knowledge_signing_key = resolve_studio_knowledge_signing_key(
         {


### PR DESCRIPTION
Studio deployment previously waited for every chat and development Tool and model credential before starting the persistent Studio Sandbox. Start its provisioning in the same worker pool so it runs alongside the other Tool creations, and report when its model configuration is ready.

Add `--studio-sandbox-tool-id` (also `STUDIO_WORKSPACE_TOOL_ID`) to reuse an already configured persistent Tool without recreating or modifying it. Omission retains automatic provisioning with model credentials. CLI and frontend updates retain the existing missing-binding reconciliation and preserve existing bindings.

Validation:
- 132 targeted deployment, update, and workspace tests passed on current main
- Event-based regression verifies Studio Sandbox and other Tools actually start concurrently
- Existing-ID deploy cases verify provisioning is skipped
- Beijing, Shanghai, and BytePlus missing-workspace tests verify model credentials reach the Tool creation request
- Frontend update reconciliation verifies model credential configuration before returning the new binding; all 8 update resource tests pass
- Pre-commit formatting, lint, and secret scanning passed
- Pyright reports 34 existing diagnostics, identical to unchanged main after normalizing paths and line offsets

No live cloud deployment was performed for this follow-up
