### PR TITLE
ci(studio): speed up release verification and sidecar checks

### DIFF
--- a/.github/workflows/harness-sidecar-release-gate.yaml
+++ b/.github/workflows/harness-sidecar-release-gate.yaml
@@ -47,7 +47,7 @@ permissions:
   contents: read
 
 jobs:
-  gate:
+  python:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -56,43 +56,74 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
+
+      - name: Install Python test dependencies
+        run: python -m pip install -e '.[dev]'
+
+      - name: Run Python Sidecar checks in parallel
+        shell: bash
+        run: |
+          set -euo pipefail
+          checks=(coverage lifecycle credentials)
+          pids=()
+          (
+            python -m pytest -q \
+              tests/extensions/harness/test_studio_sidecar.py \
+              tests/extensions/harness/test_sidecar_public_api.py \
+              tests/extensions/harness/test_extension.py \
+              tests/cli/test_generated_agent_harness_sidecar.py \
+              tests/cli/test_managed_sidecar_source.py \
+              tests/integrations/agentkit/test_app.py \
+              tests/cli/test_studio_rbac.py::test_sidecar_deployment_uses_agentkit_cli_structured_release \
+              tests/cli/test_generated_agent_backend_codegen_extended.py::test_generated_agent_sidecar_debug_uses_runtime_apig_and_active_plan \
+              --cov=. --cov-branch --cov-report= --cov-fail-under=0
+            python -m coverage report \
+              --include='*/veadk/extensions/harness/sidecar.py' \
+              --fail-under=91 --show-missing
+          ) > "$RUNNER_TEMP/sidecar-coverage.log" 2>&1 &
+          pids+=("$!")
+          (
+            python -m pytest -q \
+              tests/cli/test_legacy_runtime_recovery.py -k 'six_case_ or changed_unnamed_mcp_url'
+          ) > "$RUNNER_TEMP/sidecar-lifecycle.log" 2>&1 &
+          pids+=("$!")
+          (
+            python -m pytest -q \
+              tests/cli/test_generated_agent_mcp.py \
+              tests/cli/test_generated_agent_backend_codegen_extended.py::test_generated_debug_applies_published_mcp_credential_contract_before_discovery \
+              tests/cli/test_studio_rbac.py::test_new_deployment_only_updates_non_default_instance_range \
+              tests/cli/test_studio_rbac.py::test_sidecar_deployment_uses_agentkit_cli_structured_release \
+              tests/cli/test_studio_rbac.py::test_application_owned_mcp_update_routes_cover_reuse_and_additions \
+              tests/cli/test_studio_rbac.py::test_sidecar_update_resolves_or_explicitly_reuses_stored_mcp_credentials
+          ) > "$RUNNER_TEMP/sidecar-credentials.log" 2>&1 &
+          pids+=("$!")
+
+          status=0
+          for index in "${!pids[@]}"; do
+            if ! wait "${pids[$index]}"; then
+              status=1
+            fi
+            echo "::group::Python Sidecar ${checks[$index]}"
+            cat "$RUNNER_TEMP/sidecar-${checks[$index]}.log"
+            echo "::endgroup::"
+          done
+          exit "$status"
+
+  frontend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
           node-version: 22.17.0
           cache: npm
           cache-dependency-path: frontend/package-lock.json
-
-      - name: Install Python test dependencies
-        run: python -m pip install -e '.[dev]'
-
-      - name: Enforce public Python Sidecar coverage above 90 percent
-        run: |
-          python -m pytest -q \
-            tests/extensions/harness/test_studio_sidecar.py \
-            tests/extensions/harness/test_sidecar_public_api.py \
-            tests/extensions/harness/test_extension.py \
-            tests/cli/test_generated_agent_harness_sidecar.py \
-            tests/cli/test_managed_sidecar_source.py \
-            tests/integrations/agentkit/test_app.py \
-            tests/cli/test_studio_rbac.py::test_sidecar_deployment_uses_agentkit_cli_structured_release \
-            tests/cli/test_generated_agent_backend_codegen_extended.py::test_generated_agent_sidecar_debug_uses_runtime_apig_and_active_plan \
-            --cov=. --cov-branch --cov-report= --cov-fail-under=0
-          python -m coverage report \
-            --include='*/veadk/extensions/harness/sidecar.py' \
-            --fail-under=91 --show-missing
-
-      - name: Verify Studio six-case lifecycle and credential regressions
-        run: |
-          python -m pytest -q \
-            tests/cli/test_legacy_runtime_recovery.py -k 'six_case_ or changed_unnamed_mcp_url'
-          python -m pytest -q \
-            tests/cli/test_generated_agent_mcp.py \
-            tests/cli/test_generated_agent_backend_codegen_extended.py::test_generated_debug_applies_published_mcp_credential_contract_before_discovery \
-            tests/cli/test_studio_rbac.py::test_new_deployment_only_updates_non_default_instance_range \
-            tests/cli/test_studio_rbac.py::test_sidecar_deployment_uses_agentkit_cli_structured_release \
-            tests/cli/test_studio_rbac.py::test_application_owned_mcp_update_routes_cover_reuse_and_additions \
-            tests/cli/test_studio_rbac.py::test_sidecar_update_resolves_or_explicitly_reuses_stored_mcp_credentials
 
       - name: Install frontend dependencies
         working-directory: frontend
@@ -105,3 +136,17 @@ jobs:
       - name: Verify frontend Sidecar integration
         working-directory: frontend
         run: npm test
+
+  gate:
+    if: always()
+    needs: [python, frontend]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every Sidecar check to pass
+        env:
+          PYTHON_RESULT: ${{ needs.python.result }}
+          FRONTEND_RESULT: ${{ needs.frontend.result }}
+        run: |
+          test "$PYTHON_RESULT" = success
+          test "$FRONTEND_RESULT" = success

--- a/.github/workflows/publish-studio-release.yaml
+++ b/.github/workflows/publish-studio-release.yaml
@@ -56,6 +56,11 @@ jobs:
       (github.event_name == 'pull_request' || github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      PIP_INDEX_URL: https://pypi.org/simple
+      UV_DEFAULT_INDEX: https://pypi.org/simple
+      npm_config_registry: https://registry.npmjs.org
+      npm_config_replace_registry_host: always
 
     steps:
       - name: Check out release source
@@ -67,6 +72,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
+            frontend/service/studio_release_server/offline_runtime.py
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -77,37 +87,108 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          prune-cache: false
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Cache pinned Studio build inputs
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/studio-release-inputs
+          key: studio-release-inputs-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('veadk/cli/studio_dependencies.py', 'veadk/cli/agentkit_cli.py') }}
 
       - name: Validate frozen Studio runtime lock
         run: uv lock --check
 
       - name: Build and validate Studio bundle
-        env:
-          PIP_INDEX_URL: https://mirrors.aliyun.com/pypi/simple/
-          UV_DEFAULT_INDEX: https://mirrors.aliyun.com/pypi/simple/
-          npm_config_registry: https://registry.npmmirror.com
-          npm_config_replace_registry_host: always
         run: |
           set -euo pipefail
           output_dir="$RUNNER_TEMP/studio-release-output"
           version="$(TZ=Asia/Shanghai date +%Y%m%d%H%M%S)"
           export output_dir version
           uv run --frozen --group dev python - <<'PY'
+          import hashlib
           import json
           import os
+          import time
+          import urllib.request
+          from concurrent.futures import ThreadPoolExecutor
           from pathlib import Path
 
+          from veadk.cli.agentkit_cli import download_agentkit_cli_archive
+          from veadk.cli.studio_dependencies import (
+              STUDIO_AGENTKIT_CLI_ARTIFACT,
+              STUDIO_DEPENDENCY_SOURCES,
+          )
+          from veadk.cli.studio_package import build_frontend_assets
           from veadk.cli.studio_release import build_studio_release
+
+
+          def prepare_dependency(dependency, destination):
+              target = destination / dependency.filename
+              if target.is_file():
+                  if hashlib.sha256(target.read_bytes()).hexdigest() == dependency.sha256:
+                      print(f"Using cached {dependency.filename}", flush=True)
+                      return
+                  target.unlink()
+              started = time.monotonic()
+              if dependency == STUDIO_AGENTKIT_CLI_ARTIFACT:
+                  download_agentkit_cli_archive(target, dependency)
+              else:
+                  with urllib.request.urlopen(dependency.url, timeout=120) as response:
+                      content = response.read(128 * 1024 * 1024 + 1)
+                  if len(content) > 128 * 1024 * 1024:
+                      raise ValueError(f"{dependency.filename} exceeds 128 MiB")
+                  if hashlib.sha256(content).hexdigest() != dependency.sha256:
+                      raise ValueError(f"{dependency.filename} checksum mismatch")
+                  target.write_bytes(content)
+              print(
+                  f"Prepared {dependency.filename} in {time.monotonic() - started:.1f}s",
+                  flush=True,
+              )
+
 
           source_root = Path(os.environ["GITHUB_WORKSPACE"])
           output_dir = Path(os.environ["output_dir"])
+          frontend_assets = Path(os.environ["RUNNER_TEMP"]) / "studio-release-frontend"
+          dependency_inputs = Path(os.environ["RUNNER_TEMP"]) / "studio-release-inputs"
+          dependency_inputs.mkdir(parents=True, exist_ok=True)
+          changelog = ("Pull request release validation",)
+          started = time.monotonic()
+          with ThreadPoolExecutor(max_workers=5) as executor:
+              preparation = [
+                  executor.submit(
+                      build_frontend_assets,
+                      source_root,
+                      frontend_assets,
+                      changelog=changelog,
+                  )
+              ]
+              for dependency in (*STUDIO_DEPENDENCY_SOURCES, STUDIO_AGENTKIT_CLI_ARTIFACT):
+                  preparation.append(
+                      executor.submit(
+                          prepare_dependency,
+                          dependency,
+                          dependency_inputs,
+                      )
+                  )
+              for future in preparation:
+                  future.result()
+          print(f"Build inputs ready in {time.monotonic() - started:.1f}s", flush=True)
+          started = time.monotonic()
           bundle, manifest = build_studio_release(
               source_root=source_root,
               output_dir=output_dir,
               version=os.environ["version"],
               git_sha=os.environ["GITHUB_SHA"],
-              changelog=("Pull request release validation",),
+              changelog=changelog,
+              frontend_assets=frontend_assets,
+              dependency_wheels=dependency_inputs,
           )
+          print(f"Bundle built in {time.monotonic() - started:.1f}s", flush=True)
           print(
               json.dumps(
                   {
@@ -130,8 +211,6 @@ jobs:
         env:
           BYTEPLUS_ACCESS_KEY: smoke
           BYTEPLUS_SECRET_KEY: smoke
-          PIP_INDEX_URL: https://mirrors.aliyun.com/pypi/simple/
-          UV_DEFAULT_INDEX: https://mirrors.aliyun.com/pypi/simple/
           VOLCENGINE_ACCESS_KEY: smoke
           VOLCENGINE_SECRET_KEY: smoke
         run: |

--- a/.github/workflows/publish-studio-release.yaml
+++ b/.github/workflows/publish-studio-release.yaml
@@ -47,14 +47,13 @@ jobs:
   harness-sidecar-release-gate:
     if: >-
       github.repository == 'volcengine/veadk-python' &&
-      (github.event_name == 'pull_request' || github.ref == 'refs/heads/main')
+      github.event_name == 'pull_request'
     uses: ./.github/workflows/harness-sidecar-release-gate.yaml
 
   verify:
     if: >-
       github.repository == 'volcengine/veadk-python' &&
       (github.event_name == 'pull_request' || github.ref == 'refs/heads/main')
-    needs: harness-sidecar-release-gate
     runs-on: ubuntu-latest
     timeout-minutes: 45
 

--- a/tests/test_studio_release_workflow.py
+++ b/tests/test_studio_release_workflow.py
@@ -14,9 +14,14 @@
 
 """Regression tests for the Studio release workflow."""
 
+import hashlib
+import io
 from pathlib import Path
+from threading import Barrier
+from types import SimpleNamespace
 from typing import Any
 
+import pytest
 import yaml
 
 
@@ -40,3 +45,123 @@ def test_thin_bundle_input_is_scoped_to_supported_provider() -> None:
     assert providers["volcengine"]["thin_bundles"] == "${{ inputs.thin_bundles }}"
     assert providers["byteplus"]["thin_bundles"] is False
     assert publish["env"]["RELEASE_THIN_BUNDLES"] == "${{ matrix.thin_bundles }}"
+
+
+def _verification_script() -> str:
+    workflow_path = (
+        Path(__file__).parents[1]
+        / ".github"
+        / "workflows"
+        / "publish-studio-release.yaml"
+    )
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    step = next(
+        step
+        for step in workflow["jobs"]["verify"]["steps"]
+        if step.get("name") == "Build and validate Studio bundle"
+    )
+    return step["run"].split("<<'PY'\n", 1)[1].split("\nPY\n", 1)[0]
+
+
+def test_verification_reuses_checked_inputs_and_rebuilds_current_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from veadk.cli import (
+        agentkit_cli,
+        studio_dependencies,
+        studio_package,
+        studio_release,
+    )
+
+    sources = [
+        SimpleNamespace(
+            filename=f"dependency-{index}.tar.gz",
+            url=f"https://files.pythonhosted.org/packages/dependency-{index}.tar.gz",
+            sha256=hashlib.sha256(f"source-{index}".encode()).hexdigest(),
+        )
+        for index in range(2)
+    ]
+    artifact = SimpleNamespace(
+        filename="agentkit-linux-x64.tar.gz",
+        sha256=hashlib.sha256(b"cli").hexdigest(),
+    )
+    monkeypatch.setattr(studio_dependencies, "STUDIO_DEPENDENCY_SOURCES", sources)
+    monkeypatch.setattr(studio_dependencies, "STUDIO_AGENTKIT_CLI_ARTIFACT", artifact)
+    for name, value in {
+        "GITHUB_WORKSPACE": str(tmp_path / "source"),
+        "RUNNER_TEMP": str(tmp_path),
+        "output_dir": str(tmp_path / "output"),
+        "version": "20260910120000",
+        "GITHUB_SHA": "a" * 40,
+    }.items():
+        monkeypatch.setenv(name, value)
+
+    downloads: list[str] = []
+    builds: list[str] = []
+    frontend_builds: list[Path] = []
+    barrier: Barrier | None = Barrier(4)
+
+    def synchronize() -> None:
+        if barrier is not None:
+            barrier.wait(timeout=5)
+
+    def download(url: str, *, timeout: int) -> io.BytesIO:
+        downloads.append(url)
+        synchronize()
+        index = next(index for index, source in enumerate(sources) if source.url == url)
+        return io.BytesIO(f"source-{index}".encode())
+
+    def download_cli(target: Path, selected: Any) -> None:
+        assert selected is artifact
+        downloads.append(selected.filename)
+        synchronize()
+        target.write_bytes(b"cli")
+
+    def build_frontend(source: Path, destination: Path, *, changelog: Any) -> None:
+        frontend_builds.append(source)
+        synchronize()
+        destination.mkdir(exist_ok=True)
+        (destination / "index.html").write_text("current frontend")
+
+    def build_bundle(**kwargs: Any) -> tuple[Path, Any]:
+        assert (kwargs["frontend_assets"] / "index.html").is_file()
+        for dependency in (*sources, artifact):
+            content = (kwargs["dependency_wheels"] / dependency.filename).read_bytes()
+            assert hashlib.sha256(content).hexdigest() == dependency.sha256
+        builds.append(kwargs["git_sha"])
+        return tmp_path / "bundle.zip", SimpleNamespace(
+            version=kwargs["version"],
+            git_sha=kwargs["git_sha"],
+            sha256="b" * 64,
+            size=10,
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", download)
+    monkeypatch.setattr(agentkit_cli, "download_agentkit_cli_archive", download_cli)
+    monkeypatch.setattr(studio_package, "build_frontend_assets", build_frontend)
+    monkeypatch.setattr(studio_release, "build_studio_release", build_bundle)
+    script = _verification_script()
+    exec(script, {})
+    assert len(downloads) == 3
+
+    barrier = None
+    monkeypatch.setenv("GITHUB_SHA", "c" * 40)
+    exec(script, {})
+    assert len(downloads) == 3
+    assert builds == ["a" * 40, "c" * 40]
+    assert len(frontend_builds) == 2
+
+    cached_source = tmp_path / "studio-release-inputs" / sources[0].filename
+    cached_source.write_bytes(b"corrupt cache")
+    exec(script, {})
+    assert len(downloads) == 4
+    assert downloads[-1] == sources[0].url
+
+    cached_source.unlink()
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda *a, **kw: io.BytesIO(b"corrupt")
+    )
+    with pytest.raises(ValueError, match="checksum mismatch"):
+        exec(script, {})
+    assert len(builds) == 3
+    assert not cached_source.exists()


### PR DESCRIPTION
Manual Studio releases start verification without rerunning the Sidecar gate already exercised on push and pull requests. The Sidecar workflow runs frontend and Python checks concurrently; Python coverage, lifecycle, and credential checks share one cached dependency installation and run in parallel. The existing gate only succeeds after all checks pass.

Release verification uses official PyPI and npm sources on GitHub runners, caches pip/uv downloads and checksum-pinned build inputs, and prepares dependencies alongside the frontend build. Cached inputs are verified before reuse; current frontend and project code are rebuilt on every run. Bundle validation and both provider smoke checks remain in place. Neither Release Server is changed.

Validation:
- Pre-commit, workflow shell syntax checks, and Pyright passed
- 132 selected Sidecar Python tests passed; Python Sidecar coverage is 96%
- 22 frontend coverage tests and 1,053 frontend tests passed
- 54 release workflow, bundle, and offline runtime tests passed
- Verified parallel startup, failure propagation, and gate aggregation for failed, cancelled, and skipped checks
- Verified cached input reuse across source changes, corrupt-cache recovery, and rejection of invalid downloads before packaging
