### PR TITLE
fix(studio): use StudioEnv for BytePlus workspace provisioning

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1138,7 +1138,12 @@ agent terminology rather than exposing these control-plane resource types.
 ### Studio Sandbox 工作区
 
 `veadk studio deploy` 默认创建或复用启用持久化快照的 Studio Sandbox Tool，
-新建规格为 8 核 CPU、16 GB 内存，更新时自动补建也使用相同规格，
+新建规格为 8 核 CPU、16 GB 内存，更新时自动补建也使用相同规格。
+
+部署、命令行更新和云上 OTA 共用 Studio Sandbox 创建流程：BytePlus 使用内置
+`StudioEnv`，火山引擎继续使用 `Private`。创建时获取模型凭据并配置模型名称、
+地址、API Key、鉴权和快照；已有工作区绑定保持不变。
+
 按云环境和地域选择 `studio-sandbox-1.0.1` 镜像：
 
 | 云环境 | 地域 | 镜像 |

--- a/frontend/server/workspace_tool.py
+++ b/frontend/server/workspace_tool.py
@@ -86,7 +86,7 @@ def workspace_tool_request(
     )
     return types.CreateToolRequest(
         Name=name,
-        ToolType="Private",
+        ToolType="StudioEnv" if provider == "byteplus" else "Private",
         EnableSnapshot=True,
         ProjectName="default",
         Description="AgentKit Studio Sandbox",
@@ -129,7 +129,7 @@ def ensure_workspace_tool(
         raise RuntimeError("Multiple workspace tools match the image")
     if matches:
         tool_id = matches[0].tool_id
-        if matches[0].tool_type != "Private" or matches[0].image_url != image:
+        if matches[0].tool_type != request.tool_type or matches[0].image_url != image:
             raise RuntimeError(
                 "Existing workspace tool does not match the requested image"
             )
@@ -178,6 +178,7 @@ def provision_workspace_tool(
     image: str = "",
 ) -> str:
     """Provision the image and model environment during Studio deployment."""
+    from agentkit.platform.context import default_cloud_provider
     from agentkit.sdk.tools.client import AgentkitToolsClient
     from veadk.auth.veauth.ark_veauth import get_ark_token
     from veadk.cli.studio_sandbox_tools import (
@@ -186,12 +187,14 @@ def provision_workspace_tool(
     )
 
     image = image.strip() or resolve_workspace_image(provider, region)
-    client = AgentkitToolsClient(
-        access_key=access_key,
-        secret_key=secret_key,
-        session_token=session_token,
-        region=region,
-    )
+    # Deployment provisions resources in worker threads without inherited context.
+    with default_cloud_provider(provider):
+        client = AgentkitToolsClient(
+            access_key=access_key,
+            secret_key=secret_key,
+            session_token=session_token,
+            region=region,
+        )
     key = get_ark_token(
         cloud_provider=provider,
         region=region,

--- a/tests/frontend/server/test_studio_update_resources.py
+++ b/tests/frontend/server/test_studio_update_resources.py
@@ -195,7 +195,13 @@ def test_reconcile_studio_update_resources_provisions_missing_resources(
     workspace_models = []
 
     def workspace_tool(client, image, provider, model_environment):
+        from frontend.server.workspace_tool import workspace_tool_request
+
         assert provider == "byteplus"
+        request = workspace_tool_request(image, provider, model_environment)
+        assert request.tool_type == "StudioEnv"
+        assert request.enable_snapshot is True
+        assert request.authorizer_configuration.key_auth.api_key_location == "Header"
         workspace_models.append(model_environment)
         return "workspace-tool"
 

--- a/tests/frontend/server/test_workspace_tool.py
+++ b/tests/frontend/server/test_workspace_tool.py
@@ -34,7 +34,7 @@ def test_cloud_tool_preserves_native_entrypoint_and_model_configuration(
     assert "STUDIO_EDITOR_BOOTSTRAP" not in env
     assert request.image_url == image
     assert request.command == "/opt/gem/run.sh"
-    assert request.tool_type == "Private"
+    assert request.tool_type == ("StudioEnv" if provider == "byteplus" else "Private")
     assert request.enable_snapshot is True
     assert request.cpu_milli == 8000
     assert request.memory_mb == 16384
@@ -221,6 +221,11 @@ def test_missing_workspace_update_injects_model_credentials(
 
     class Client:
         def __init__(self, **kwargs):
+            from agentkit.platform.context import get_default_cloud_provider
+
+            active_provider = get_default_cloud_provider()
+            assert active_provider is not None
+            assert active_provider.value == provider
             assert kwargs == credentials
 
         def list_tools(self, request):
@@ -245,7 +250,43 @@ def test_missing_workspace_update_injects_model_credentials(
     assert result == {"STUDIO_WORKSPACE_TOOL_ID": "t-configured"}
     request = captured["request"]
     env = {item.key: item.value for item in request.envs}
+    assert request.tool_type == ("StudioEnv" if provider == "byteplus" else "Private")
     assert env["MODEL_AGENT_API_KEY"] == "test-model-token"
     assert env["MODEL_AGENT_NAME"]
     assert env["MODEL_AGENT_BASE_URL"].startswith("https://")
     assert request.enable_snapshot is True
+
+
+@pytest.mark.parametrize("provider", ["byteplus", "volcengine"])
+def test_reuses_matching_workspace_tool(monkeypatch, provider):
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+    from frontend.server import workspace_tool
+
+    model = {
+        "MODEL_AGENT_NAME": "test-model",
+        "MODEL_AGENT_BASE_URL": "https://example.test/v3",
+        "MODEL_AGENT_API_KEY": "test-key",
+    }
+    image = "registry.example/studio:v1"
+    request = workspace_tool.workspace_tool_request(image, provider, model)
+    tool = SimpleNamespace(
+        tool_id="t-existing",
+        name=request.name,
+        tool_type="StudioEnv" if provider == "byteplus" else "Private",
+        image_url=image,
+        enable_snapshot=True,
+        command=request.command,
+        model_agent_name=request.model_agent_name,
+        envs=request.envs,
+        status="Ready",
+    )
+    client = Mock()
+    client.list_tools.return_value = SimpleNamespace(tools=[tool])
+    client.get_tool.return_value = tool
+    assert (
+        workspace_tool.ensure_workspace_tool(client, image, provider, model)
+        == "t-existing"
+    )
+    client.create_tool.assert_not_called()
+    client.update_tool.assert_not_called()


### PR DESCRIPTION
BytePlus rejected Studio workspace creation with `InvalidParameter.ImageUrl` when the request used `ToolType=Private`. Use the built-in `StudioEnv` type for BytePlus in the shared provisioning path used by deploy, CLI update, and online OTA resource reconciliation. Volcengine continues to use `Private`.

Match existing tools against the provider-specific type and explicitly select the SDK cloud provider when constructing the client, including in deployment worker threads. Preserve model credential retrieval, model environment variables, API-key authorization, snapshot configuration, and existing workspace bindings.

Validation:
- 107 targeted tests passed for workspace provisioning, update resource reconciliation, CLI update, and self-update after synchronizing with main
- Pre-commit passed: Ruff check, Ruff format, and secret scanning
- BytePlus live provisioning reached Ready with StudioEnv, model configuration, and snapshots enabled; a repeated update reused the same tool
- Source deployment before the main synchronization successfully published the main Studio application and displayed the login page; scheduler publication was blocked by exhausted VeFaaS memory capacity. Authenticated workspace interaction and an actual OTA upgrade were not completed
- Pyright reports three existing errors in the workspace upgrade repair helper, reproduced on the unchanged baseline
